### PR TITLE
Improve building on Darwin hosts.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,7 @@ else ifeq ($(UNAME),Darwin)
 $(warning Building on MacOS)
 SYSROOT         ?= $(shell xcrun --sdk $(PLATFORM) --show-sdk-path)
 MACOSX_SYSROOT  ?= $(shell xcrun --show-sdk-path)
+PATH            := /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin:$(PATH)
 CPP             := cc -E
 RANLIB          := ranlib
 STRIP           := strip


### PR DESCRIPTION
- Add Xcode default toolchain to $PATH when building on Darwin Hosts.