### PR TITLE
Update various tools to latest versions

### DIFF
--- a/berkeleydb.mk
+++ b/berkeleydb.mk
@@ -41,7 +41,7 @@ berkeleydb-package: berkeleydb-stage
 	rm -rf $(BUILD_DIST)/berkeleydb/usr/docs
 	
 	# berkeleydb.mk Sign
-	+$(call SIGN,berkeleydb,general.xml)
+	$(call SIGN,berkeleydb,general.xml)
 	
 	# berkeleydb.mk Make .debs
 	$(call PACK,berkeleydb,DEB_BDB_V)

--- a/berkeleydb.mk
+++ b/berkeleydb.mk
@@ -11,7 +11,7 @@ DEB_BDB_V   ?= $(BDB_VERSION)
 berkeleydb-setup: setup
 	$(call EXTRACT_TAR,db-$(BDB_VERSION).tar.gz,db-$(BDB_VERSION),berkeleydb)
 	$(SED) -i 's/install_docs//g' $(BUILD_WORK)/berkeleydb/dist/Makefile.in
-	$(SED) -i 's/install_docs//g' $(BUILD_WORK)/berkeleydb/dist/Makefile.in
+	$(SED) -i 's/uninstall_docs//g' $(BUILD_WORK)/berkeleydb/dist/Makefile.in
 ifneq ($(wildcard $(BUILD_WORK)/berkeleydb/.build_complete),)
 berkeleydb:
 	@echo "Using previously built berkeleydb."
@@ -23,7 +23,6 @@ berkeleydb: berkeleydb-setup gettext openssl
 		--prefix=/usr \
 		--enable-static=no \
 		--enable-shared=yes \
-		--docdir=$(BUILD_WORK)/berkeleydb/docs \
 		--with-mutex=Darwin/_spin_lock_try
 	+$(MAKE) -C $(BUILD_WORK)/berkeleydb/build_unix
 	+$(MAKE) -C $(BUILD_WORK)/berkeleydb/build_unix install \
@@ -42,7 +41,7 @@ berkeleydb-package: berkeleydb-stage
 	rm -rf $(BUILD_DIST)/berkeleydb/usr/docs
 	
 	# berkeleydb.mk Sign
-	$(call SIGN,berkeleydb,general.xml)
+	+$(call SIGN,berkeleydb,general.xml)
 	
 	# berkeleydb.mk Make .debs
 	$(call PACK,berkeleydb,DEB_BDB_V)

--- a/berkeleydb.mk
+++ b/berkeleydb.mk
@@ -10,7 +10,8 @@ DEB_BDB_V   ?= $(BDB_VERSION)
 
 berkeleydb-setup: setup
 	$(call EXTRACT_TAR,db-$(BDB_VERSION).tar.gz,db-$(BDB_VERSION),berkeleydb)
-
+	$(SED) -i 's/install_docs//g' $(BUILD_WORK)/berkeleydb/dist/Makefile.in
+	$(SED) -i 's/install_docs//g' $(BUILD_WORK)/berkeleydb/dist/Makefile.in
 ifneq ($(wildcard $(BUILD_WORK)/berkeleydb/.build_complete),)
 berkeleydb:
 	@echo "Using previously built berkeleydb."
@@ -22,6 +23,7 @@ berkeleydb: berkeleydb-setup gettext openssl
 		--prefix=/usr \
 		--enable-static=no \
 		--enable-shared=yes \
+		--docdir=$(BUILD_WORK)/berkeleydb/docs \
 		--with-mutex=Darwin/_spin_lock_try
 	+$(MAKE) -C $(BUILD_WORK)/berkeleydb/build_unix
 	+$(MAKE) -C $(BUILD_WORK)/berkeleydb/build_unix install \

--- a/berkeleydb.mk
+++ b/berkeleydb.mk
@@ -5,7 +5,7 @@ endif
 SUBPROJECTS += berkeleydb
 # Berkeleydb requires registration on Oracle's website, so this is a mirror.
 DOWNLOAD    += https://fossies.org/linux/misc/db-$(BDB_VERSION).tar.gz
-BDB_VERSION := 18.1.32
+BDB_VERSION := 18.1.40
 DEB_BDB_V   ?= $(BDB_VERSION)
 
 berkeleydb-setup: setup

--- a/build_info/img4lib.control
+++ b/build_info/img4lib.control
@@ -1,0 +1,8 @@
+Package: img4lib
+Version: @DEB_IMG4LIB_V@
+Architecture: @DEB_ARCH@
+Maintainer: @DEB_MAINTAINER@
+Depends: 
+Section: Utilities
+Priority: optional
+Description: Some WIP code to deal with img4 files in a decent manner.

--- a/build_info/sl.control
+++ b/build_info/sl.control
@@ -3,6 +3,7 @@ Version: @DEB_SL_V@
 Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
 Depends: ncurses
+Conflicts: com.ichitaso.sl
 Section: Utilities
 Priority: optional
 Description: cure your bad habit of mistyping

--- a/curl.mk
+++ b/curl.mk
@@ -4,7 +4,7 @@ endif
 
 SUBPROJECTS  += curl
 DOWNLOAD     += https://curl.haxx.se/download/curl-$(CURL_VERSION).tar.xz{,.asc}
-CURL_VERSION := 7.69.1
+CURL_VERSION := 7.70.0
 DEB_CURL_V   ?= $(CURL_VERSION)
 
 curl-setup: setup

--- a/debianutils.mk
+++ b/debianutils.mk
@@ -4,7 +4,7 @@ endif
 
 STRAPPROJECTS       += debianutils
 DOWNLOAD            += http://deb.debian.org/debian/pool/main/d/debianutils/debianutils_$(DEBIANUTILS_VERSION).tar.xz
-DEBIANUTILS_VERSION := 4.9.1
+DEBIANUTILS_VERSION := 4.11
 DEB_DEBIANUTILS_V   ?= $(DEBIANUTILS_VERSION)
 
 debianutils-setup: setup

--- a/diskdev-cmds.mk
+++ b/diskdev-cmds.mk
@@ -4,7 +4,7 @@ endif
 
 STRAPPROJECTS        += diskdev-cmds
 DOWNLOAD             += https://opensource.apple.com/tarballs/diskdev_cmds/diskdev_cmds-$(DISKDEV-CMDS_VERSION).tar.gz
-DISKDEV-CMDS_VERSION := 641.0.1
+DISKDEV-CMDS_VERSION := 593.230.1
 DEB_DISKDEV-CMDS_V   ?= $(DISKDEV-CMDS_VERSION)
 
 diskdev-cmds-setup: setup

--- a/diskdev-cmds.mk
+++ b/diskdev-cmds.mk
@@ -4,7 +4,7 @@ endif
 
 STRAPPROJECTS        += diskdev-cmds
 DOWNLOAD             += https://opensource.apple.com/tarballs/diskdev_cmds/diskdev_cmds-$(DISKDEV-CMDS_VERSION).tar.gz
-DISKDEV-CMDS_VERSION := 593.230.1
+DISKDEV-CMDS_VERSION := 641.0.1
 DEB_DISKDEV-CMDS_V   ?= $(DISKDEV-CMDS_VERSION)
 
 diskdev-cmds-setup: setup

--- a/git.mk
+++ b/git.mk
@@ -4,7 +4,7 @@ endif
 
 SUBPROJECTS += git
 DOWNLOAD    += https://mirrors.edge.kernel.org/pub/software/scm/git/git-$(GIT_VERSION).tar.xz
-GIT_VERSION := 2.26.1
+GIT_VERSION := 2.27.0
 DEB_GIT_V   ?= $(GIT_VERSION)
 
 git-setup: setup

--- a/gnutls.mk
+++ b/gnutls.mk
@@ -4,7 +4,7 @@ endif
 
 SUBPROJECTS    += gnutls
 DOWNLOAD       += https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/gnutls-$(GNUTLS_VERSION).tar.xz
-GNUTLS_VERSION := 3.6.13
+GNUTLS_VERSION := 3.6.14
 DEB_GNUTLS_V   ?= $(GNUTLS_VERSION)
 
 gnutls-setup: setup

--- a/img4lib.mk
+++ b/img4lib.mk
@@ -1,0 +1,42 @@
+ifneq ($(PROCURSUS),1)
+$(error Use the main Makefile)
+endif
+
+SUBPROJECTS        += img4lib
+DOWNLOAD           += https://github.com/xerub/img4lib/archive/$(IMG4LIB_VERSION).tar.gz
+IMG4LIB_VERSION := master
+DEB_IMG4LIB_V   ?= $(IMG4LIB_VERSION)
+
+img4lib-setup: setup
+	$(call EXTRACT_TAR,$(IMG4LIB_VERSION).tar.gz,img4lib-$(IMG4LIB_VERSION),img4lib)
+
+ifneq ($(wildcard $(BUILD_WORK)/img4lib/.build_complete),)
+img4lib:
+	@echo "Using previously built img4lib."
+else
+img4lib: img4lib-setup openssl
+	cd $(BUILD_WORK)/img4lib
+	+$(MAKE) -C $(BUILD_WORK)/img4lib
+	+$(MAKE) -C $(BUILD_WORK)/img4lib install \
+		DESTDIR="$(BUILD_STAGE)/img4lib"
+	touch $(BUILD_WORK)/img4lib/.build_complete
+endif
+
+img4lib-package: img4lib-stage
+	# img4lib.mk Package Structure
+	rm -rf $(BUILD_DIST)/img4lib
+	mkdir -p $(BUILD_DIST)/img4lib
+	
+	# img4lib.mk Prep img4lib
+	cp -a $(BUILD_STAGE)/img4lib/usr $(BUILD_DIST)/img4lib
+	
+	# img4lib.mk Sign
+	$(call SIGN,img4lib,general.xml)
+	
+	# img4lib.mk Make .debs
+	$(call PACK,img4lib,DEB_IMG4LIB_V)
+	
+	# img4lib.mk Build cleanup
+	rm -rf $(BUILD_DIST)/img4lib
+
+.PHONY: img4lib img4lib-package

--- a/iokittools.mk
+++ b/iokittools.mk
@@ -4,7 +4,7 @@ endif
 
 SUBPROJECTS        += iokittools
 DOWNLOAD           += https://opensource.apple.com/tarballs/IOKitTools/IOKitTools-$(IOKITTOOLS_VERSION).tar.gz
-IOKITTOOLS_VERSION := 91
+IOKITTOOLS_VERSION := 112
 DEB_IOKITTOOLS_V   ?= $(IOKITTOOLS_VERSION)
 
 iokittools-setup: setup

--- a/libgpg-error.mk
+++ b/libgpg-error.mk
@@ -4,7 +4,7 @@ endif
 
 STRAPPROJECTS        += libgpg-error
 DOWNLOAD             += https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-$(LIBGPG-ERROR_VERSION).tar.bz2{,.sig}
-LIBGPG-ERROR_VERSION := 1.37
+LIBGPG-ERROR_VERSION := 1.38
 DEB_LIBGPG-ERROR_V   ?= $(LIBGPG-ERROR_VERSION)
 
 ifneq (,$(findstring aarch64,$(GNU_HOST_TRIPLE)))

--- a/libplist.mk
+++ b/libplist.mk
@@ -4,7 +4,7 @@ endif
 
 SUBPROJECTS       += libplist
 DOWNLOAD          += https://github.com/libimobiledevice/libplist/archive/$(LIBPLIST_VERSION).tar.gz
-LIBPLIST_VERSION  := 2.1.0
+LIBPLIST_VERSION  := 2.2.0
 DEB_LIBPLIST_V    ?= $(LIBPLIST_VERSION)
 
 libplist-setup: setup

--- a/libzip.mk
+++ b/libzip.mk
@@ -4,7 +4,7 @@ endif
 
 SUBPROJECTS          += libzip
 DOWNLOAD             += https://libzip.org/download/libzip-$(LIBZIP_VERSION).tar.gz
-LIBZIP_VERSION       := 1.7.0
+LIBZIP_VERSION       := 1.7.1
 DEB_LIBZIP_V         ?= $(LIBZIP_VERSION)
 
 libzip-setup: setup

--- a/lsof.mk
+++ b/lsof.mk
@@ -4,7 +4,7 @@ endif
 
 SUBPROJECTS  += lsof
 DOWNLOAD     += https://opensource.apple.com/tarballs/lsof/lsof-$(LSOF_VERSION).tar.gz
-LSOF_VERSION := 62
+LSOF_VERSION := 67
 DEB_LSOF_V   ?= $(LSOF_VERSION)
 
 lsof-setup: setup

--- a/man-db.mk
+++ b/man-db.mk
@@ -4,7 +4,7 @@ endif
 
 SUBPROJECTS    += man-db
 DOWNLOAD       += https://download.savannah.gnu.org/releases/man-db/man-db-$(MAN-DB_VERSION).tar.xz{,.asc}
-MAN-DB_VERSION := 2.9.1
+MAN-DB_VERSION := 2.9.2
 DEB_MAN-DB_V   ?= $(MAN-DB_VERSION)
 
 man-db-setup: setup

--- a/nettle.mk
+++ b/nettle.mk
@@ -4,7 +4,7 @@ endif
 
 SUBPROJECTS    += nettle
 DOWNLOAD       += https://ftp.gnu.org/gnu/nettle/nettle-$(NETTLE_VERSION).tar.gz{,.sig}
-NETTLE_VERSION := 3.5.1
+NETTLE_VERSION := 3.6
 DEB_NETTLE_V   ?= $(NETTLE_VERSION)
 
 nettle-setup: setup

--- a/nghttp2.mk
+++ b/nghttp2.mk
@@ -4,7 +4,7 @@ endif
 
 SUBPROJECTS     += nghttp2
 DOWNLOAD        += https://github.com/nghttp2/nghttp2/releases/download/v$(NGHTTP2_VERSION)/nghttp2-$(NGHTTP2_VERSION).tar.xz
-NGHTTP2_VERSION := 1.40.0
+NGHTTP2_VERSION := 1.41.0
 DEB_NGHTTP2_V   ?= $(NGHTTP2_VERSION)
 
 nghttp2-setup: setup

--- a/p11-kit.mk
+++ b/p11-kit.mk
@@ -15,7 +15,7 @@ ifneq ($(wildcard $(BUILD_WORK)/p11-kit/.build_complete),)
 p11-kit:
 	@echo "Using previously built p11-kit."
 else
-p11-kit: p11-kit-setup gettext
+p11-kit: p11-kit-setup gettext libtasn1
 	cd $(BUILD_WORK)/p11-kit && ./configure -C \
 		--host=$(GNU_HOST_TRIPLE) \
 		--prefix=/usr \

--- a/p11-kit.mk
+++ b/p11-kit.mk
@@ -15,12 +15,13 @@ ifneq ($(wildcard $(BUILD_WORK)/p11-kit/.build_complete),)
 p11-kit:
 	@echo "Using previously built p11-kit."
 else
-p11-kit: p11-kit-setup gettext libtasn1
+p11-kit: p11-kit-setup gettext
 	cd $(BUILD_WORK)/p11-kit && ./configure -C \
 		--host=$(GNU_HOST_TRIPLE) \
 		--prefix=/usr \
 		--without-trust-paths \
-		--without-libffi
+		--without-libffi \
+		LIBTASN1_CFLAGS=-I$(BUILD_BASE)/usr/include
 	+$(MAKE) -C $(BUILD_WORK)/p11-kit
 	+$(MAKE) -C $(BUILD_WORK)/p11-kit install \
 		DESTDIR=$(BUILD_STAGE)/p11-kit

--- a/pcre2.mk
+++ b/pcre2.mk
@@ -4,7 +4,7 @@ endif
 
 SUBPROJECTS   += pcre2
 DOWNLOAD      += https://ftp.pcre.org/pub/pcre/pcre2-$(PCRE2_VERSION).tar.bz2{,.sig}
-PCRE2_VERSION := 10.34
+PCRE2_VERSION := 10.35
 DEB_PCRE2_V   ?= $(PCRE2_VERSION)
 
 pcre2-setup: setup

--- a/perl.mk
+++ b/perl.mk
@@ -5,10 +5,10 @@ endif
 SUBPROJECTS  += perl
 DOWNLOAD     += https://www.cpan.org/src/5.0/perl-$(PERL_VERSION).tar.gz \
 		https://github.com/arsv/perl-cross/releases/download/$(PERL_CROSS_V)/perl-cross-$(PERL_CROSS_V).tar.gz
-PERL_MAJOR   := 5.30
-PERL_VERSION := $(PERL_MAJOR).2
+PERL_MAJOR   := 5.31
+PERL_VERSION := $(PERL_MAJOR).11
 PERL_API_V   := $(PERL_MAJOR).0
-PERL_CROSS_V := 1.3.2
+PERL_CROSS_V := 1.3.4
 DEB_PERL_V   ?= $(PERL_VERSION)
 
 perl-setup: setup

--- a/perl.mk
+++ b/perl.mk
@@ -5,8 +5,8 @@ endif
 SUBPROJECTS  += perl
 DOWNLOAD     += https://www.cpan.org/src/5.0/perl-$(PERL_VERSION).tar.gz \
 		https://github.com/arsv/perl-cross/releases/download/$(PERL_CROSS_V)/perl-cross-$(PERL_CROSS_V).tar.gz
-PERL_MAJOR   := 5.31
-PERL_VERSION := $(PERL_MAJOR).11
+PERL_MAJOR   := 5.32
+PERL_VERSION := $(PERL_MAJOR).0
 PERL_API_V   := $(PERL_MAJOR).0
 PERL_CROSS_V := 1.3.4
 DEB_PERL_V   ?= $(PERL_VERSION)

--- a/python3.mk
+++ b/python3.mk
@@ -4,8 +4,8 @@ endif
 
 SUBPROJECTS      += python3
 DOWNLOAD         += https://www.python.org/ftp/python/$(PYTHON3_VERSION)/Python-$(PYTHON3_VERSION).tar.xz{,.asc}
-PYTHON3_MAJOR_V  := 3.8.3
-PYTHON3_VERSION  := $(PYTHON3_MAJOR_V).2
+PYTHON3_MAJOR_V  := 3.8
+PYTHON3_VERSION  := $(PYTHON3_MAJOR_V).3
 DEB_PYTHON3_V    ?= $(PYTHON3_VERSION)
 
 ifeq ($(call HAS_COMMAND,python$(PYTHON3_MAJOR_V)),1)

--- a/python3.mk
+++ b/python3.mk
@@ -4,7 +4,7 @@ endif
 
 SUBPROJECTS      += python3
 DOWNLOAD         += https://www.python.org/ftp/python/$(PYTHON3_VERSION)/Python-$(PYTHON3_VERSION).tar.xz{,.asc}
-PYTHON3_MAJOR_V  := 3.8
+PYTHON3_MAJOR_V  := 3.8.3
 PYTHON3_VERSION  := $(PYTHON3_MAJOR_V).2
 DEB_PYTHON3_V    ?= $(PYTHON3_VERSION)
 

--- a/sudo.mk
+++ b/sudo.mk
@@ -4,7 +4,7 @@ endif
 
 STRAPPROJECTS += sudo
 DOWNLOAD      += https://www.sudo.ws/dist/sudo-$(SUDO_VERSION).tar.gz{,.sig}
-SUDO_VERSION  := 1.8.31p1
+SUDO_VERSION  := 1.9.0
 DEB_SUDO_V    ?= $(SUDO_VERSION)
 
 sudo-setup: setup

--- a/tmux.mk
+++ b/tmux.mk
@@ -4,7 +4,7 @@ endif
 
 SUBPROJECTS    += tmux
 DOWNLOAD       += https://github.com/tmux/tmux/releases/download/$(TMUX_VERSION)/tmux-$(TMUX_VERSION).tar.gz
-TMUX_VERSION   := 3.0a
+TMUX_VERSION   := 3.1b
 DEB_TMUX_V     ?= $(TMUX_VERSION)
 
 tmux-setup: setup

--- a/tsschecker.mk
+++ b/tsschecker.mk
@@ -1,0 +1,44 @@
+ifneq ($(PROCURSUS),1)
+$(error Use the main Makefile)
+endif
+
+SUBPROJECTS        += tsschecker
+DOWNLOAD           += https://github.com/tihmstar/tsschecker/archive/$(TSSCHECKER_VERSION).tar.gz
+TSSCHECKER_VERSION := 304
+DEB_TSSCHECKER_V   ?= $(TSSCHECKER_VERSION)
+
+tsschecker-setup: setup
+	$(call EXTRACT_TAR,$(TSSCHECKER_VERSION).tar.gz,tsschecker-$(TSSCHECKER_VERSION),tsschecker)
+
+ifneq ($(wildcard $(BUILD_WORK)/tsschecker/.build_complete),)
+tsschecker:
+	@echo "Using previously built tsschecker."
+else
+tsschecker: tsschecker-setup curl libplist openssl libfragmentzip libirecovery
+	cd $(BUILD_WORK)/tsschecker && ./autogen.sh \
+		--host=$(GNU_HOST_TRIPLE) \
+		--prefix=/usr 
+	+$(MAKE) -C $(BUILD_WORK)/tsschecker
+	+$(MAKE) -C $(BUILD_WORK)/tsschecker install \
+		DESTDIR="$(BUILD_STAGE)/tsschecker"
+	touch $(BUILD_WORK)/tsschecker/.build_complete
+endif
+
+tsschecker-package: tsschecker-stage
+	# tsschecker.mk Package Structure
+	rm -rf $(BUILD_DIST)/tsschecker
+	mkdir -p $(BUILD_DIST)/tsschecker
+	
+	# tsschecker.mk Prep tsschecker
+	cp -a $(BUILD_STAGE)/tsschecker/usr $(BUILD_DIST)/tsschecker
+	
+	# tsschecker.mk Sign
+	$(call SIGN,tsschecker,general.xml)
+	
+	# tsschecker.mk Make .debs
+	$(call PACK,tsschecker,DEB_TSSCHECKER_V)
+	
+	# tsschecker.mk Build cleanup
+	rm -rf $(BUILD_DIST)/tsschecker
+
+.PHONY: tsschecker tsschecker-package

--- a/vim.mk
+++ b/vim.mk
@@ -5,7 +5,7 @@ endif
 SUBPROJECTS += vim
 DOWNLOAD    += https://github.com/vim/vim/archive/v$(VIM_VERSION).tar.gz
 # Per homebrew, vim should only be updated every 50 releases on multiples of 50
-VIM_VERSION := 8.2.0700
+VIM_VERSION := 8.2.0950
 DEB_VIM_V   ?= $(VIM_VERSION)
 
 vim-setup: setup

--- a/zstd.mk
+++ b/zstd.mk
@@ -4,7 +4,7 @@ endif
 
 STRAPPROJECTS += zstd
 DOWNLOAD      += https://github.com/facebook/zstd/archive/v$(ZSTD_VERSION).tar.gz
-ZSTD_VERSION  := 1.4.4
+ZSTD_VERSION  := 1.4.5
 DEB_ZSTD_V    ?= $(ZSTD_VERSION)
 
 zstd-setup: setup


### PR DESCRIPTION
don't merge yet, still checking through all the packages. There are probably some packages (namely packages from opensource.apple.com) that aren't supposed to be updated, but those can be reviewed.
little list for organization to make sure these updates actually compile and work correctly (testing on iOS 12), once they're all checked this is ready to be merged
- [ ] curl (can't test currently, since building is broken)
- [x] python3
- [x] berkeleydb
- [x] debianutils
- [ ] diskdev-cmds (latest doesn't build for iOS 12)
- [ ] git (can't test currently due to curl dep)
- [ ] gnutls (can't test currently do to p11-kit dep, which fails to build (i'll take a look tomorrow))
- [ ] iokittools (latest iokittools looks like it needs more changes then just a version bump, will check out tomorrow)
- [x] libgpg-error
- [x] libzip
- [x] lsof
- [ ] man-db
- [x] nettle
- [x] nghttp2
- [x] pcre2
- [x] perl
- [x] sudo
- [ ] tmux
- [x] vim
- [ ] Zstandard
