### PR TITLE
Add libusb 1.0.23

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -543,9 +543,11 @@ setup:
 	@# Copy headers from MacOSX.sdk
 	$(CP) -af $(MACOSX_SYSROOT)/usr/include/{arpa,net,xpc} $(BUILD_BASE)/usr/include
 	$(CP) -af $(MACOSX_SYSROOT)/usr/include/sys/{tty*,proc*,kern*,random,vnode}.h $(BUILD_BASE)/usr/include/sys
-	$(CP) -af $(MACOSX_SYSROOT)/System/Library/Frameworks/IOKit.framework/Headers/ps $(BUILD_BASE)/usr/include/IOKit
+	$(CP) -af $(MACOSX_SYSROOT)/System/Library/Frameworks/IOKit.framework/Headers/* $(BUILD_BASE)/usr/include/IOKit
 	$(CP) -af $(MACOSX_SYSROOT)/usr/include/{ar,launch,libproc,tzfile}.h $(BUILD_BASE)/usr/include
 	-$(CP) -af $(BUILD_INFO)/IOKit.framework.$(PLATFORM) $(BUILD_BASE)/System/Library/Frameworks/IOKit.framework
+	mkdir -p $(BUILD_BASE)/usr/include/libkern
+	$(CP) -af $(MACOSX_SYSROOT)/usr/include/libkern/OSTypes.h $(BUILD_BASE)/usr/include/libkern
 
 	@# Patch headers from iPhoneOS.sdk
 	$(SED) -E s/'__IOS_PROHIBITED|__TVOS_PROHIBITED|__WATCHOS_PROHIBITED'//g < $(SYSROOT)/usr/include/stdlib.h > $(BUILD_BASE)/usr/include/stdlib.h

--- a/build_info/libusb.control
+++ b/build_info/libusb.control
@@ -1,0 +1,8 @@
+Package: libusb
+Version: @DEB_LIBUSB_V@
+Architecture: @DEB_ARCH@
+Maintainer: @DEB_MAINTAINER@
+Depends:
+Section: Development
+Priority: optional
+Description: userspace USB programming library

--- a/libusb.mk
+++ b/libusb.mk
@@ -1,0 +1,45 @@
+ifneq ($(PROCURSUS),1)
+$(error Use the main Makefile)
+endif
+
+SUBPROJECTS      += libusb
+DOWNLOAD         += https://github.com/libusb/libusb/archive/v$(LIBUSB_VERSION).tar.gz
+LIBUSB_VERSION   := 1.0.23
+DEB_LIBUSB_V     ?= $(LIBUSB_VERSION)
+
+libusb-setup: setup
+	$(call EXTRACT_TAR,libusb-$(LIBUSB_VERSION).tar.gz,libusb-$(LIBUSB_VERSION),libusb)
+
+ifneq ($(wildcard $(BUILD_WORK)/libusb/.build_complete),)
+libusb:
+	@echo "Using previously built libusb."
+else
+libusb: libusb-setup
+	cd $(BUILD_WORK)/libusb && ./autogen.sh \
+		--host=$(GNU_HOST_TRIPLE) \
+		--disable-dependency-tracking \
+		--prefix=/usr
+	+$(MAKE) -C $(BUILD_WORK)/libusb
+	+$(MAKE) -C $(BUILD_WORK)/libusb install \
+		DESTDIR="$(BUILD_STAGE)/libusb"
+	touch $(BUILD_WORK)/libusb/.build_complete
+endif
+
+libusb-package: libusb-stage
+	# libusb.mk Package Structure
+	rm -rf $(BUILD_DIST)/libusb
+	mkdir -p $(BUILD_DIST)/libusb
+	
+	# libusb.mk Prep libusb
+	cp -a $(BUILD_STAGE)/libusb/usr $(BUILD_DIST)/libusb
+	
+	# libusb.mk Sign
+	$(call SIGN,libusb,general.xml)
+	
+	# libusb.mk Make .debs
+	$(call PACK,libusb,DEB_LIBUSB_V)
+	
+	# libusb.mk Build cleanup
+	rm -rf $(BUILD_DIST)/libusb
+
+.PHONY: libusb libusb-package


### PR DESCRIPTION
Adds libusb 1.0.23 & copies over all IOKit headers from macOS SDK (and also copies over libkern/OSTypes.h)