### PR TITLE
fix groff detection when using brew

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -328,6 +328,9 @@ $(error Install flex)
 endif
 
 ifneq ($(call HAS_COMMAND,groff),1)
+ifneq (,$(wildcard $(shell brew --prefix)/opt/groff/bin))
+PATH := $(shell brew --prefix)/opt/groff/bin:$(PATH)
+endif
 ifneq ($(shell groff --version | grep -q 'version 1.2' && echo 1),1)
 $(error Install newer groff)
 endif

--- a/Makefile
+++ b/Makefile
@@ -327,13 +327,10 @@ ifneq ($(call HAS_COMMAND,lex),1)
 $(error Install flex)
 endif
 
-ifneq ($(call HAS_COMMAND,groff),1)
 ifneq (,$(wildcard $(shell brew --prefix)/opt/groff/bin))
 PATH := $(shell brew --prefix)/opt/groff/bin:$(PATH)
-endif
-ifneq ($(shell groff --version | grep -q 'version 1.2' && echo 1),1)
+else ifneq ($(shell groff --version | grep -q 'version 1.2' && echo 1),1)
 $(error Install newer groff)
-endif
 endif
 
 ifneq (,$(wildcard $(shell brew --prefix)/opt/gpatch/bin))


### PR DESCRIPTION
## Problem
On macOS it is using `/usr/bin/groff` instead of brew groff