### PR TITLE
Fix clean target erroring when darwintools isn't built

### DIFF
--- a/darwintools/Makefile
+++ b/darwintools/Makefile
@@ -18,4 +18,4 @@ firmware: main.m Firmware.m DeviceInfo.m
 	$(LDID) -S firmware
 
 clean:
-	rm sw_vers firmware
+	rm -f sw_vers firmware


### PR DESCRIPTION
**Fixes this error:**
```
$ make clean
Makefile:66: Building for iOS
Makefile:122: Building on MacOS
rm -rf /Users/absidue/dev/github/Procursus/build_work/iphoneos-arm64/1600 /Users/absidue/dev/github/Procursus/build_base/iphoneos-arm64/1600 /Users/absidue/dev/github/Procursus/build_stage/iphoneos-arm64/1600
git submodule foreach --recursive git clean -xfd
Entering 'uikittools'
git submodule foreach --recursive git reset --hard
Entering 'uikittools'
HEAD is now at 373c012 No longer support calling uicache without -a
rm -f darwintools/.build_complete
make -C darwintools clean
rm sw_vers firmware
rm: sw_vers: No such file or directory
rm: firmware: No such file or directory
make[1]: *** [Makefile:21: clean] Error 1
make: [Makefile:583: clean] Error 2 (ignored)
```