### PR TITLE
Update apt and dpkg

### DIFF
--- a/apt.mk
+++ b/apt.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 STRAPPROJECTS += apt
-APT_VERSION   := 2.1.6
+APT_VERSION   := 2.1.7
 DEB_APT_V     ?= $(APT_VERSION)
 
 ifeq ($(shell [ "$(CFVER_WHOLE)" -lt 1500 ] && echo 1),1)

--- a/dpkg.mk
+++ b/dpkg.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 STRAPPROJECTS  += dpkg
-DPKG_VERSION   := 1.20.3
+DPKG_VERSION   := 1.20.5
 DEB_DPKG_V     ?= $(DPKG_VERSION)-1
 
 dpkg-setup: setup


### PR DESCRIPTION
Due to the way Debian manages their servers updating dpkg to 1.20.5, or changing the download url is necessary.