### PR TITLE
Add tree

### DIFF
--- a/build_info/tree.control
+++ b/build_info/tree.control
@@ -1,0 +1,7 @@
+Package: tree
+Version: @DEB_TREE_V@
+Architecture: @DEB_ARCH@
+Maintainer: @DEB_MAINTAINER@
+Section: Utilities
+Priority: optional
+Description: A directory listing program displaying a depth indented list of files

--- a/build_patch/tree/ios.diff
+++ b/build_patch/tree/ios.diff
@@ -1,7 +1,7 @@
-diff -urN tree-1.8.0/Makefile tree/Makefile
---- tree-1.8.0/Makefile	2018-01-18 15:02:20.000000000 -0500
-+++ tree/Makefile	2020-07-30 01:23:21.880850344 -0400
-@@ -18,7 +18,7 @@
+diff -ur build_work/iphoneos-arm64/1500/tree/Makefile build_work/iphoneos-arm64/1600/tree/Makefile
+--- tree/Makefile	2018-01-18 15:02:20.000000000 -0500
++++ tree/Makefile	2020-08-05 10:20:12.000000000 -0400
+@@ -18,19 +18,19 @@
  
  prefix = /usr
  
@@ -10,7 +10,12 @@ diff -urN tree-1.8.0/Makefile tree/Makefile
  
  VERSION=1.8.0
  TREE_DEST=tree
-@@ -30,7 +30,7 @@
+ BINDIR=${prefix}/bin
+ MAN=tree.1
+-MANDIR=${prefix}/man/man1
++#MANDIR=${prefix}/man/man1
+ OBJS=tree.o unix.o html.o xml.o json.o hash.o color.o file.o
+ 
  # Uncomment options below for your particular OS:
  
  # Linux defaults:
@@ -19,11 +24,16 @@ diff -urN tree-1.8.0/Makefile tree/Makefile
  #CFLAGS=-O4 -Wall  -DLINUX -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64
  #LDFLAGS=-s
  
-@@ -66,7 +66,7 @@
- #CFLAGS=-O2 -Wall -fomit-frame-pointer -no-cpp-precomp
+@@ -63,10 +63,10 @@
+ # It is not allowed to install to /usr/bin on OS X any longer (SIP):
+ #prefix = /usr/local
+ #CC=cc
+-#CFLAGS=-O2 -Wall -fomit-frame-pointer -no-cpp-precomp
++CFLAGS+=-O2 -Wall -fomit-frame-pointer -no-cpp-precomp
  #LDFLAGS=
- #MANDIR=/usr/share/man/man1
+-#MANDIR=/usr/share/man/man1
 -#OBJS+=strverscmp.o
++MANDIR=${prefix}/share/man/man1
 +OBJS+=strverscmp.o
  
  # Uncomment for HP/UX:

--- a/build_patch/tree/ios.diff
+++ b/build_patch/tree/ios.diff
@@ -1,0 +1,30 @@
+diff -urN tree-1.8.0/Makefile tree/Makefile
+--- tree-1.8.0/Makefile	2018-01-18 15:02:20.000000000 -0500
++++ tree/Makefile	2020-07-30 01:23:21.880850344 -0400
+@@ -18,7 +18,7 @@
+ 
+ prefix = /usr
+ 
+-CC=gcc
++#CC=gcc
+ 
+ VERSION=1.8.0
+ TREE_DEST=tree
+@@ -30,7 +30,7 @@
+ # Uncomment options below for your particular OS:
+ 
+ # Linux defaults:
+-CFLAGS=-ggdb -pedantic -Wall -DLINUX -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64
++#CFLAGS=-ggdb -pedantic -Wall -DLINUX -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64
+ #CFLAGS=-O4 -Wall  -DLINUX -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64
+ #LDFLAGS=-s
+ 
+@@ -66,7 +66,7 @@
+ #CFLAGS=-O2 -Wall -fomit-frame-pointer -no-cpp-precomp
+ #LDFLAGS=
+ #MANDIR=/usr/share/man/man1
+-#OBJS+=strverscmp.o
++OBJS+=strverscmp.o
+ 
+ # Uncomment for HP/UX:
+ #CC=cc

--- a/tree.mk
+++ b/tree.mk
@@ -1,0 +1,42 @@
+ifneq ($(PROCURSUS),1)
+$(error Use the main Makefile)
+endif
+
+SUBPROJECTS  += tree
+TREE_VERSION := 1.8.0
+DEB_TREE_V   ?= $(TREE_VERSION)-1
+
+tree-setup: setup
+	wget -q -nc -P $(BUILD_SOURCE) http://mama.indstate.edu/users/ice/tree/src/tree-$(TREE_VERSION).tgz
+	$(call EXTRACT_TAR,tree-$(TREE_VERSION).tgz,tree-$(TREE_VERSION),tree)
+	$(call DO_PATCH,tree,tree,-p1)
+
+ifneq ($(wildcard $(BUILD_WORK)/tree/.build_complete),)
+tree:
+	@echo "Using previously built tree."
+else
+tree: tree-setup 
+	+$(MAKE) -C $(BUILD_WORK)/tree
+	+$(MAKE) -C $(BUILD_WORK)/tree install \
+		prefix=$(BUILD_STAGE)/tree/usr
+	touch $(BUILD_WORK)/tree/.build_complete
+endif
+
+tree-package: tree-stage
+	# tree.mk Package Structure
+	rm -rf $(BUILD_DIST)/tree
+	mkdir -p $(BUILD_DIST)/tree
+	
+	# tree.mk Prep tree
+	cp -a $(BUILD_STAGE)/tree $(BUILD_DIST)/
+	
+	# tree.mk Sign
+	$(call SIGN,tree,general.xml)
+	
+	# tree.mk Make .debs
+	$(call PACK,tree,DEB_TREE_V)
+	
+	# tree.mk Build cleanup
+	rm -rf $(BUILD_DIST)/tree
+
+.PHONY: tree tree-package


### PR DESCRIPTION
The way the Makefile was written it doesn't support `DESTDIR` so I have to use prefix which shouldn't have any problems. Patching the Makefile is the official method to compile.