### PR TITLE
Update berkleydb to 18.1.40

### DIFF
--- a/berkeleydb.mk
+++ b/berkeleydb.mk
@@ -4,7 +4,7 @@ endif
 
 SUBPROJECTS += berkeleydb
 # Berkeleydb requires registration on Oracle's website, so this is a mirror.
-BDB_VERSION := 18.1.32
+BDB_VERSION := 18.1.40
 DEB_BDB_V   ?= $(BDB_VERSION)
 
 berkeleydb-setup: setup


### PR DESCRIPTION
The version update has caused the old version to be removed from the mirror (or just moved) so updating the version is required to download the source code.