### PR TITLE
Add bsdiff 4.3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "uikittools"]
 	path = uikittools
 	url = https://github.com/Diatrus/uikittools-ng
+[submodule "bsdiff"]
+	path = bsdiff
+	url = https://github.com/mendsley/bsdiff

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "uikittools"]
 	path = uikittools
 	url = https://github.com/Diatrus/uikittools-ng
-[submodule "bsdiff"]
-	path = bsdiff
-	url = https://github.com/mendsley/bsdiff

--- a/bsdiff.mk
+++ b/bsdiff.mk
@@ -1,0 +1,45 @@
+ifneq ($(PROCURSUS),1)
+$(error Use the main Makefile)
+endif
+
+SUBPROJECTS    += bsdiff
+BSDIFF_VERSION := 4.2
+DEB_BSDIFF_V   ?= $(BSDIFF_VERSION)
+
+bsdiff-setup: setup
+	rm -rf $(BUILD_WORK)/bsdiff
+	mkdir -p $(BUILD_WORK)/bsdiff
+	cp -af bsdiff/* $(BUILD_WORK)/bsdiff
+
+ifneq ($(wildcard $(BUILD_WORK)/bsdiff/.build_complete),)
+bsdiff:
+	@echo "Using previously built bsdiff."
+else
+bsdiff: bsdiff-setup bzip2
+	cd $(BUILD_WORK)/bsdiff && ./autogen.sh && ./configure -C \
+	--prefix=/usr \
+	--host=$(GNU_HOST_TRIPLE)
+	+$(MAKE) -C $(BUILD_WORK)/bsdiff
+	+$(MAKE) -C $(BUILD_WORK)/bsdiff install \
+		DESTDIR=$(BUILD_STAGE)/bsdiff
+	touch $(BUILD_WORK)/bsdiff/.build_complete
+endif
+
+bsdiff-package: bsdiff-stage
+	# bsdiff.mk Package Structure
+	rm -rf $(BUILD_DIST)/bsdiff
+	mkdir -p $(BUILD_DIST)/bsdiff
+	
+	# bsdiff.mk Prep bsdiff
+	cp -a $(BUILD_STAGE)/bsdiff/usr $(BUILD_DIST)/bsdiff
+	
+	# bsdiff.mk Sign
+	$(call SIGN,bsdiff,general.xml)
+	
+	# bsdiff.mk Make .debs
+	$(call PACK,bsdiff,DEB_BSDIFF_V)
+	
+	# bsdiff.mk Build cleanup
+	rm -rf $(BUILD_DIST)/bsdiff
+
+.PHONY: bsdiff bsdiff-package

--- a/bsdiff.mk
+++ b/bsdiff.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS    += bsdiff
-BSDIFF_VERSION := 4.2
+BSDIFF_VERSION := 4.3
 DEB_BSDIFF_V   ?= $(BSDIFF_VERSION)
 
 bsdiff-setup: setup

--- a/bsdiff.mk
+++ b/bsdiff.mk
@@ -3,13 +3,12 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS    += bsdiff
-BSDIFF_VERSION := 4.3
+BSDIFF_VERSION := 4.3.1
 DEB_BSDIFF_V   ?= $(BSDIFF_VERSION)
 
 bsdiff-setup: setup
-	rm -rf $(BUILD_WORK)/bsdiff
-	mkdir -p $(BUILD_WORK)/bsdiff
-	cp -af bsdiff/* $(BUILD_WORK)/bsdiff
+	wget -q -nc -P $(BUILD_SOURCE) https://github.com/marijuanARM/bsdiff/archive/v$(BSDIFF_VERSION).tar.gz
+	$(call EXTRACT_TAR,v$(BSDIFF_VERSION).tar.gz,bsdiff-$(BSDIFF_VERSION),bsdiff)
 
 ifneq ($(wildcard $(BUILD_WORK)/bsdiff/.build_complete),)
 bsdiff:

--- a/build_info/bsdiff.control
+++ b/build_info/bsdiff.control
@@ -1,0 +1,8 @@
+Package: bsdiff
+Version: @DEB_BSDIFF_V@
+Architecture: @DEB_ARCH@
+Maintainer: @DEB_MAINTAINER@
+Section: Utilities
+Priority: optional
+Description: Generate and apply patches to binary files
+Tag: purpose::console, role::hackerb


### PR DESCRIPTION
I would've added bsdiff 4.3 from [here](https://www.daemonology.net/bsdiff/bsdiff-4.3.tar.gz), but iirc it uses bsdmake (and 4.3 can't be downloaded from that link, which is weird)