### PR TITLE
Mosh: add gettext-localizations and libssl1.1 dependencies

### DIFF
--- a/build_info/mosh.control
+++ b/build_info/mosh.control
@@ -2,7 +2,7 @@ Package: mosh
 Version: @DEB_MOSH_V@
 Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
-Depends: libncursesw6, openssh-client, libprotobuf23, gettext-localizations, libssl1.1
+Depends: libncursesw6, openssh-client, libprotobuf23, gettext-localizations, libssl1.1, perl
 Section: Networking
 Priority: standard
 Description: Mobile shell, surviving disconnects with local echo and line editing

--- a/build_info/mosh.control
+++ b/build_info/mosh.control
@@ -2,7 +2,7 @@ Package: mosh
 Version: @DEB_MOSH_V@
 Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
-Depends: libncursesw6, openssh-client, libprotobuf23
+Depends: libncursesw6, openssh-client, libprotobuf23, gettext-localizations, libssl1.1
 Section: Networking
 Priority: standard
 Description: Mobile shell, surviving disconnects with local echo and line editing


### PR DESCRIPTION
Issue this fixes:
```
~/iOS-Projects/Procursus moshfix* 9s
❯ mosh tester
The locale requested by LANG=en_US.UTF-8 isn't available here.
Running `locale-gen en_US.UTF-8' may be necessary.

mosh-server needs a UTF-8 native locale to run.

Unfortunately, the local environment ([no charset variables]) specifies
the character set "US-ASCII",

The client-supplied environment (LANG=en_US.UTF-8) specifies
the character set "US-ASCII".

sh: locale: command not found
Connection to 192.168.1.87 closed.
/usr/bin/mosh: Did not find mosh server startup message. (Have you installed mosh on your server?)
```
