### PR TITLE
Add dialog

### DIFF
--- a/build_info/dialog.control
+++ b/build_info/dialog.control
@@ -1,0 +1,26 @@
+Package: dialog
+Version: @DEB_DIALOG_V@
+Architecture: @DEB_ARCH@
+Maintainer: @DEB_MAINTAINER@
+Depends: libncursesw6, libintl8
+Section: Utilities
+Priority: standard
+Homepage: http://invisible-island.net/dialog/dialog.html
+Description: Displays user-friendly dialog boxes from shell scripts
+ This application provides a method of displaying several different types
+ of dialog boxes from shell scripts.  This allows a developer of a script
+ to interact with the user in a much friendlier manner.
+ .
+ The following types of boxes are at your disposal:
+  yes/no           Typical query style box with "Yes" and "No" answer buttons
+  menu             A scrolling list of menu choices with single entry selection
+  input            Query style box with text entry field
+  message          Similar to the yes/no box, but with only an "Ok" button
+  text             A scrollable text box that works like a simple file viewer
+  info             A message display that allows asynchronous script execution
+  checklist        Similar to the menu box, but allowing multiple selections
+  radiolist        Checklist style box allowing single selections
+  gauge            Typical "progress report" style box
+  tail             Allows viewing the end of files (tail) that auto updates
+  background tail  Similar to tail but runs in the background.
+  editbox          Allows editing an existing file

--- a/dialog.mk
+++ b/dialog.mk
@@ -1,0 +1,52 @@
+ifneq ($(PROCURSUS),1)
+$(error Use the main Makefile)
+endif
+
+SUBPROJECTS    += dialog
+DIALOG_VERSION := 1.3
+DIALOG_DATE    := 20200327
+DEB_DIALOG_V   ?= $(DIALOG_VERSION)-$(DIALOG_DATE)
+
+dialog-setup: setup
+	wget -q -nc -P $(BUILD_SOURCE) https://invisible-mirror.net/archives/dialog/dialog-$(DIALOG_VERSION)-$(DIALOG_DATE).tgz
+	$(call EXTRACT_TAR,dialog-$(DIALOG_VERSION)-$(DIALOG_DATE).tgz,dialog-$(DIALOG_VERSION)-$(DIALOG_DATE),dialog)
+
+ifneq ($(wildcard $(BUILD_WORK)/dialog/.build_complete),)
+dialog:
+	@echo "Using previously built dialog."
+else
+dialog: dialog-setup ncurses gettext
+	cd $(BUILD_WORK)/dialog && ./configure -C \
+		--host=$(GNU_HOST_TRIPLE) \
+		--prefix=/usr \
+		--with-ncursesw \
+		--enable-nls
+	+$(MAKE) -C $(BUILD_WORK)/dialog
+	+$(MAKE) -C $(BUILD_WORK)/dialog install-full \
+		DESTDIR=$(BUILD_STAGE)/dialog
+	touch $(BUILD_WORK)/dialog/.build_complete
+endif
+
+dialog-package: dialog-stage
+	# dialog.mk Package Structure
+	rm -rf $(BUILD_DIST)/dialog
+	mkdir -p $(BUILD_DIST)/dialog
+	
+	# dialog.mk Prep dialog
+	# To keep parity with debian, dialog is not
+	# being split, it also is only having a static 
+	# lib. I can't install the headers without
+	# dialog-config so that gets deleted here.
+	cp -a $(BUILD_STAGE)/dialog $(BUILD_DIST)
+	rm $(BUILD_DIST)/dialog/usr/bin/dialog-config
+	
+	# dialog.mk Sign
+	$(call SIGN,dialog,general.xml)
+	
+	# dialog.mk Make .debs
+	$(call PACK,dialog,DEB_DIALOG_V)
+	
+	# dialog.mk Build cleanup
+	rm -rf $(BUILD_DIST)/dialog
+
+.PHONY: dialog dialog-package


### PR DESCRIPTION
To keep parity with debian, dialog is not being split, it also is only having a static lib. I can't install the headers without dialog-config so that has to get deleted.
