### PR TITLE
Remove unnecessary STRAPPROJECTS

### DIFF
--- a/frei0r.mk
+++ b/frei0r.mk
@@ -2,7 +2,7 @@ ifneq ($(PROCURSUS),1)
 $(error Use the main Makefile)
 endif
 
-STRAPPROJECTS  += frei0r
+SUBPROJECTS    += frei0r
 FREI0R_VERSION := 1.7.0
 DEB_FREI0R_V   ?= $(FREI0R_VERSION)-1
 

--- a/libvidstab.mk
+++ b/libvidstab.mk
@@ -2,7 +2,7 @@ ifneq ($(PROCURSUS),1)
 $(error Use the main Makefile)
 endif
 
-STRAPPROJECTS      += libvidstab
+SUBPROJECTS        += libvidstab
 LIBVIDSTAB_VERSION := 1.1.0
 DEB_LIBVIDSTAB_V   ?= $(LIBVIDSTAB_VERSION)
 

--- a/libvpx.mk
+++ b/libvpx.mk
@@ -2,7 +2,7 @@ ifneq ($(PROCURSUS),1)
 $(error Use the main Makefile)
 endif
 
-STRAPPROJECTS  += libvpx
+SUBPROJECTS    += libvpx
 LIBVPX_VERSION := 1.9.0
 DEB_LIBVPX_V   ?= $(LIBVPX_VERSION)
 


### PR DESCRIPTION
How do so many get pass review **except** vi
