### PR TITLE
remove tcg interpreter from qemu's Makefile

### DIFF
--- a/qemu.mk
+++ b/qemu.mk
@@ -29,7 +29,6 @@ qemu: qemu-setup glib2.0 gnutls libjpeg-turbo libpng16 libssh libusb liblzo2 ncu
 		--enable-lzfse \
 		--enable-vde \
 		--enable-zstd \
-		--enable-tcg-interpreter \
 		--enable-tools \
 		--disable-sdl \
 		--disable-gtk \


### PR DESCRIPTION
Linux does not boot in tcg interpreter mode plus it is slower. 