### PR TITLE
Fix libharfbuzz-dev and libass-dev to refer to libfreetype-dev

### DIFF
--- a/build_info/libass-dev.control
+++ b/build_info/libass-dev.control
@@ -2,7 +2,7 @@ Package: libass-dev
 Version: @DEB_LIBASS_V@
 Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
-Depends: libass9 (= @DEB_LIBASS_V@), libfribidi-dev, libfontconfig-dev, libfreetype6-dev, libharfbuzz-dev
+Depends: libass9 (= @DEB_LIBASS_V@), libfribidi-dev, libfontconfig-dev, libfreetype-dev, libharfbuzz-dev
 Section: Development
 Priority: optional
 Multi-Arch: foreign

--- a/build_info/libharfbuzz-dev.control
+++ b/build_info/libharfbuzz-dev.control
@@ -2,7 +2,7 @@ Package: libharfbuzz-dev
 Version: @DEB_HARFBUZZ_V@
 Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
-Depends: libharfbuzz0b (= @DEB_HARFBUZZ_V@), libharfbuzz-icu0 (= @DEB_HARFBUZZ_V@), libharfbuzz-gobject0 (= @DEB_HARFBUZZ_V@), libgraphite2-dev, libicu-dev, libfreetype6-dev, libglib2.0-dev
+Depends: libharfbuzz0b (= @DEB_HARFBUZZ_V@), libharfbuzz-icu0 (= @DEB_HARFBUZZ_V@), libharfbuzz-gobject0 (= @DEB_HARFBUZZ_V@), libgraphite2-dev, libicu-dev, libfreetype-dev, libglib2.0-dev
 Section: Development
 Priority: standard
 Multi-Arch: foreign

--- a/harfbuzz.mk
+++ b/harfbuzz.mk
@@ -4,7 +4,7 @@ endif
 
 SUBPROJECTS      += harfbuzz
 HARFBUZZ_VERSION := 2.7.4
-DEB_HARFBUZZ_V   ?= $(HARFBUZZ_VERSION)
+DEB_HARFBUZZ_V   ?= $(HARFBUZZ_VERSION)-1
 
 harfbuzz-setup: setup
 	-[ ! -f "$(BUILD_SOURCE)/harfbuzz-$(HARFBUZZ_VERSION).tar.gz" ] && \

--- a/libass.mk
+++ b/libass.mk
@@ -4,7 +4,7 @@ endif
 
 SUBPROJECTS    += libass
 LIBASS_VERSION := 0.15.0
-DEB_LIBASS_V   ?= $(LIBASS_VERSION)
+DEB_LIBASS_V   ?= $(LIBASS_VERSION)-1
 
 libass-setup: setup
 	wget -q -nc -P $(BUILD_SOURCE) https://github.com/libass/libass/releases/download/$(LIBASS_VERSION)/libass-$(LIBASS_VERSION).tar.xz


### PR DESCRIPTION
instead of libfreetype6-dev.

Currently, it is impossible to install libharfbuzz-dev and libass-dev because they have a dependency on libfreetype6-dev, which does not exist. This package is in Procursus, but it is called libfreetype-dev.

I can bump the deb version if needed.