### PR TITLE
Update libjpeg-turbo to version 2.0.6

### DIFF
--- a/libjpeg-turbo.mk
+++ b/libjpeg-turbo.mk
@@ -4,7 +4,7 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS           += libjpeg-turbo
-LIBJPEG_TURBO_VERSION := 2.0.5
+LIBJPEG_TURBO_VERSION := 2.0.6
 DEB_LIBJPEG_TURBO_V   ?= $(LIBJPEG_TURBO_VERSION)
 
 libjpeg-turbo-setup: setup


### PR DESCRIPTION
Note: This package has a beta package in the works for version 2.1. If that get pushed to stable this package maybe updated once again.