### PR TITLE
Update bender to v1.1.1

### DIFF
--- a/bender.mk
+++ b/bender.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS      += bender
-BENDER_VERSION   := 1.1.0
+BENDER_VERSION   := 1.1.1
 DEB_BENDER_V     ?= $(BENDER_VERSION)
 
 bender-setup: setup


### PR DESCRIPTION
This fixes an issue where it would just crash instead of showing a help screen if you did `bender list`