### PR TITLE
Add a function to fetch an archive from GitHub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -363,6 +363,16 @@ PACK_LOCALE = mkdir -p $(BUILD_DIST)/$(1)-locale/{DEBIAN,$(MEMO_PREFIX)$(MEMO_SU
 	$(FAKEROOT) $(DPKG_DEB) -b $(BUILD_DIST)/$(1)-locale $(BUILD_DIST)/$$(grep Package: $(BUILD_DIST)/$(1)/DEBIAN/control | cut -f2 -d ' ')-locale_$${VERSION}_$$(grep Architecture: $(BUILD_DIST)/$(1)/DEBIAN/control | cut -f2 -d ' ').deb; \
 	rm -rf $(BUILD_DIST)/$(1)-locale
 
+GITHUB_ARCHIVE = -if [ $(5) ]; then \
+		[ ! -f "$(BUILD_SOURCE)/$(5)-$(3).tar.gz" ] && \
+			wget -q -nc -O$(BUILD_SOURCE)/$(5)-$(3).tar.gz \
+				https://github.com/$(1)/$(2)/archive/$(4).tar.gz; \
+	else \
+		[ ! -f "$(BUILD_SOURCE)/$(2)-$(3).tar.gz" ] && \
+			wget -q -nc -O$(BUILD_SOURCE)/$(2)-$(3).tar.gz \
+				https://github.com/$(1)/$(2)/archive/$(4).tar.gz; \
+	fi
+
 ###
 #
 # Fix this dep checking section dumbass

--- a/appuninst.mk
+++ b/appuninst.mk
@@ -10,9 +10,7 @@ DEB_APPUNINST_V   ?= $(APPUNINST_VERSION)
 APPUNINST_LIBS    := -framework Foundation -framework CoreServices
 
 appuninst-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/appuninst-$(APPUNINST_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/appuninst-$(APPUNINST_VERSION).tar.gz \
-			https://github.com/quiprr/appuninst/archive/v$(APPUNINST_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,quiprr,appuninst,$(APPUNINST_VERSION),v$(APPUNINST_VERSION))
 	$(call EXTRACT_TAR,appuninst-$(APPUNINST_VERSION).tar.gz,appuninst-$(APPUNINST_VERSION),appuninst)
 	mkdir -p $(BUILD_STAGE)/appuninst/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin
 

--- a/argon2.mk
+++ b/argon2.mk
@@ -7,7 +7,7 @@ ARGON2_VERSION := 20190702
 DEB_ARGON2_V   ?= 0~$(ARGON2_VERSION)
 
 argon2-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/argon2-$(ARGON2_VERSION).tar.gz" ] && wget -q -nc -O$(BUILD_SOURCE)/argon2-$(ARGON2_VERSION).tar.gz https://github.com/P-H-C/phc-winner-argon2/archive/$(ARGON2_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,P-H-C,phc-winner-argon2,$(ARGON2_VERSION),$(ARGON2_VERSION),argon2)
 	$(call EXTRACT_TAR,argon2-$(ARGON2_VERSION).tar.gz,phc-winner-argon2-$(ARGON2_VERSION),argon2)
 	$(call DO_PATCH,argon2,argon2,-p1)
 

--- a/attach.mk
+++ b/attach.mk
@@ -7,9 +7,7 @@ ATTACH_VERSION := 0.0.2
 DEB_ATTACH_V   ?= $(ATTACH_VERSION)-1
 
 attach-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/attach-$(ATTACH_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/attach-$(ATTACH_VERSION).tar.gz \
-			https://github.com/NyaMisty/Attach-Detach/archive/$(ATTACH_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,NyaMisty,Attach-Detach,$(ATTACH_VERSION),$(ATTACH_VERSION),attach)
 	$(call EXTRACT_TAR,attach-$(ATTACH_VERSION).tar.gz,attach-detach-$(ATTACH_VERSION),attach)
 	mkdir -p $(BUILD_STAGE)/attach/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin
 

--- a/bastet.mk
+++ b/bastet.mk
@@ -7,7 +7,7 @@ BASTET_VERSION := 0.43.2
 DEB_BASTET_V   ?= $(BASTET_VERSION)
 
 bastet-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/bastet-$(BASTET_VERSION).tar.gz" ] && wget -q -nc -O$(BUILD_SOURCE)/bastet-$(BASTET_VERSION).tar.gz https://github.com/fph/bastet/archive/$(BASTET_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,fph,bastet,$(BASTET_VERSION),$(BASTET_VERSION))
 	$(call EXTRACT_TAR,bastet-$(BASTET_VERSION).tar.gz,bastet-$(BASTET_VERSION),bastet)
 	$(call DO_PATCH,bastet,bastet,-p1)
 	$(SED) -i 's/-lncurses/-lncursesw/' $(BUILD_WORK)/bastet/Makefile

--- a/bat.mk
+++ b/bat.mk
@@ -7,7 +7,7 @@ BAT_VERSION := 0.17.1
 DEB_BAT_V   ?= $(BAT_VERSION)
 
 bat-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/bat-$(BAT_VERSION).tar.gz" ] && wget -q -nc -O$(BUILD_SOURCE)/bat-$(BAT_VERSION).tar.gz https://github.com/sharkdp/bat/archive/v$(BAT_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,sharkdp,bat,$(BAT_VERSION),v$(BAT_VERSION))
 	$(call EXTRACT_TAR,bat-$(BAT_VERSION).tar.gz,bat-$(BAT_VERSION),bat)
 
 ifneq ($(wildcard $(BUILD_WORK)/bat/.build_complete),)

--- a/bender.mk
+++ b/bender.mk
@@ -7,7 +7,7 @@ BENDER_VERSION   := 1.1.1
 DEB_BENDER_V     ?= $(BENDER_VERSION)
 
 bender-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/bender-$(BENDER_VERSION).tar.gz" ] && wget -q -nc -O$(BUILD_SOURCE)/bender-$(BENDER_VERSION).tar.gz https://github.com/aspenluxxxy/bender/archive/v$(BENDER_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,aspenluxxxy,bender,$(BENDER_VERSION),v$(BENDER_VERSION))
 	$(call EXTRACT_TAR,bender-$(BENDER_VERSION).tar.gz,bender-$(BENDER_VERSION),bender)
 
 ifneq ($(wildcard $(BUILD_WORK)/bender/.build_complete),)

--- a/brotli.mk
+++ b/brotli.mk
@@ -7,9 +7,7 @@ BROTLI_VERSION   := 1.0.9
 DEB_BROTLI_V     ?= $(BROTLI_VERSION)
 
 brotli-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/brotli-$(BROTLI_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/brotli-$(BROTLI_VERSION).tar.gz \
-			https://github.com/google/brotli/archive/v$(BROTLI_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,google,brotli,$(BROTLI_VERSION),v$(BROTLI_VERSION))
 	$(call EXTRACT_TAR,brotli-$(BROTLI_VERSION).tar.gz,brotli-$(BROTLI_VERSION),brotli)
 
 ifneq ($(wildcard $(BUILD_WORK)/brotli/.build_complete),)

--- a/bsdiff.mk
+++ b/bsdiff.mk
@@ -7,9 +7,7 @@ BSDIFF_VERSION := 4.3
 DEB_BSDIFF_V   ?= $(BSDIFF_VERSION)
 
 bsdiff-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/bsdiff-$(BSDIFF_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/bsdiff-$(BSDIFF_VERSION).tar.gz \
-			https://github.com/mendsley/bsdiff/archive/v$(BSDIFF_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,mendsley,bsdiff,$(BSDIFF_VERSION),v$(BSDIFF_VERSION))
 	$(call EXTRACT_TAR,bsdiff-$(BSDIFF_VERSION).tar.gz,bsdiff-$(BSDIFF_VERSION),bsdiff)
 	$(call DO_PATCH,bsdiff,bsdiff)
 

--- a/cctools.mk
+++ b/cctools.mk
@@ -9,8 +9,8 @@ DEB_CCTOOLS_V   ?= $(CCTOOLS_VERSION)-2
 DEB_LD64_V      ?= $(LD64_VERSION)-3
 
 cctools-setup: setup
-	wget -q -nc -P $(BUILD_SOURCE) https://github.com/Diatrus/cctools-port/archive/$(CCTOOLS_VERSION)-ld64-$(LD64_VERSION).tar.gz
-	$(call EXTRACT_TAR,$(CCTOOLS_VERSION)-ld64-$(LD64_VERSION).tar.gz,cctools-port-$(CCTOOLS_VERSION)-ld64-$(LD64_VERSION)/cctools,cctools)
+	$(call GITHUB_ARCHIVE,Diatrus,cctools-port,$(CCTOOLS_VERSION)-ld64-$(LD64_VERSION),$(CCTOOLS_VERSION)-ld64-$(LD64_VERSION),cctools)
+	$(call EXTRACT_TAR,cctools-$(CCTOOLS_VERSION)-ld64-$(LD64_VERSION).tar.gz,cctools-port-$(CCTOOLS_VERSION)-ld64-$(LD64_VERSION)/cctools,cctools)
 	rm -rf $(BUILD_WORK)/cctools-*
 
 ifneq ($(wildcard $(BUILD_WORK)/cctools/.build_complete),)

--- a/cowsay.mk
+++ b/cowsay.mk
@@ -7,6 +7,7 @@ COWSAY_VERSION := 3.04
 DEB_COWSAY_V   ?= $(COWSAY_VERSION)
 
 cowsay-setup: setup
+	$(call,GITHUB_ARCHIVE,tnalpgge,rank-amateur-cowsay,$(COWSAY_VERSION),$(COWSAY_VERSION),cowsay)
 	wget -q -nc -P $(BUILD_SOURCE) https://github.com/tnalpgge/rank-amateur-cowsay/archive/cowsay-$(COWSAY_VERSION).tar.gz
 	$(call EXTRACT_TAR,cowsay-$(COWSAY_VERSION).tar.gz,rank-amateur-cowsay-cowsay-$(COWSAY_VERSION),cowsay)
 	mkdir -p $(BUILD_STAGE)/cowsay/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/{games,share/man/man1}

--- a/darwintools.mk
+++ b/darwintools.mk
@@ -8,9 +8,7 @@ ZBRFIRMWARE_COMMIT  := 09e2673391e03a0405838f7ebdf02fa1020c88fd
 DEB_DARWINTOOLS_V   ?= $(DARWINTOOLS_VERSION)-2
 
 darwintools-setup: setup
-	-[ ! -e "$(BUILD_SOURCE)/Firmware-$(ZBRFIRMWARE_COMMIT).tar.gz" ] \
-		&& wget -q -nc -O$(BUILD_SOURCE)/Firmware-$(ZBRFIRMWARE_COMMIT).tar.gz \
-			https://github.com/zbrateam/Firmware/archive/$(ZBRFIRMWARE_COMMIT).tar.gz
+	$(call GITHUB_ARCHIVE,zbrateam,Firmware,$(ZBRFIRMWARE_COMMIT),$(ZBRFIRMWARE_COMMIT))
 	$(call EXTRACT_TAR,Firmware-$(ZBRFIRMWARE_COMMIT).tar.gz,Firmware-$(ZBRFIRMWARE_COMMIT),darwintools)
 
 ifneq ($(wildcard $(BUILD_WORK)/darwintools/.build_complete),)

--- a/dimentio.mk
+++ b/dimentio.mk
@@ -13,9 +13,7 @@ DIMENTIO_SOVERSION := 0
 DIMENTIO_LIBS      := -framework CoreFoundation -framework IOKit -lcompression
 
 dimentio-setup: setup
-	-[ ! -e "$(BUILD_SOURCE)/dimentio-v$(DIMENTIO_COMMIT).tar.gz" ] \
-		&& wget -q -nc -O$(BUILD_SOURCE)/dimentio-v$(DIMENTIO_COMMIT).tar.gz \
-			https://github.com/0x7ff/dimentio/archive/$(DIMENTIO_COMMIT).tar.gz
+	$(call GITHUB_ARCHIVE,0x7ff,dimentio,v$(DIMENTIO_COMMIT),$(DIMENTIO_COMMIT))
 	$(call EXTRACT_TAR,dimentio-v$(DIMENTIO_COMMIT).tar.gz,dimentio-$(DIMENTIO_COMMIT),dimentio)
 	mkdir -p $(BUILD_STAGE)/dimentio/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/{bin,lib,include}
 

--- a/fd.mk
+++ b/fd.mk
@@ -7,7 +7,7 @@ FD_VERSION  := 8.2.1
 DEB_FD_V    ?= $(FD_VERSION)
 
 fd-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/fd-$(FD_VERSION).tar.gz" ] && wget -q -nc -O$(BUILD_SOURCE)/fd-$(FD_VERSION).tar.gz https://github.com/sharkdp/fd/archive/v$(FD_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,sharkdp,fd,$(FD_VERSION),v$(FD_VERSION))
 	$(call EXTRACT_TAR,fd-$(FD_VERSION).tar.gz,fd-$(FD_VERSION),fd)
 	$(call DO_PATCH,fd,fd,-p1)
 

--- a/fff.mk
+++ b/fff.mk
@@ -7,8 +7,9 @@ FFF_VERSION := 2.2
 DEB_FFF_V   ?= $(FFF_VERSION)
 
 fff-setup: setup
+	$(call GITHUB_ARCHIVE,dylanaraps,fff,$(FFF_VERSION),$(FFF_VERSION))
 	wget -q -nc -P $(BUILD_SOURCE) https://github.com/dylanaraps/fff/archive/$(FFF_VERSION).tar.gz
-	$(call EXTRACT_TAR,$(FFF_VERSION).tar.gz,fff-$(FFF_VERSION),fff)
+	$(call EXTRACT_TAR,fff-$(FFF_VERSION).tar.gz,fff-$(FFF_VERSION),fff)
 
 ifneq ($(wildcard $(BUILD_WORK)/fff/.build_complete),)
 fff:

--- a/futurerestore.mk
+++ b/futurerestore.mk
@@ -10,12 +10,12 @@ FUTURERESTORE_COMMIT  := 55db758b5d4d6c08daa48af9aad1abf2b6466f36
 FUTURERESTORE_IDEVICERESTORE_COMMIT := d7d9996b3910902a56462fa8d9dc5909fcf8f4c9
 
 futurerestore-setup: setup tsschecker-setup
-	wget -q -nc -P $(BUILD_SOURCE) https://github.com/marijuanARM/futurerestore/archive/$(FUTURERESTORE_COMMIT).tar.gz
-	wget -q -nc -P $(BUILD_SOURCE) https://github.com/marijuanARM/idevicerestore/archive/$(FUTURERESTORE_IDEVICERESTORE_COMMIT).tar.gz
-	$(call EXTRACT_TAR,$(FUTURERESTORE_COMMIT).tar.gz,futurerestore-$(FUTURERESTORE_COMMIT),futurerestore)
+	$(call GITHUB_ARCHIVE,marijuanARM,futurerestore,$(FUTURERESTORE_COMMIT),$(FUTURERESTORE_COMMIT))
+	$(call GITHUB_ARCHIVE,marijuanARM,idevicerestore,$(FUTURERESTORE_IDEVICERESTORE_COMMIT),$(FUTURERESTORE_IDEVICERESTORE_COMMIT))
+	$(call EXTRACT_TAR,futurerestore-$(FUTURERESTORE_COMMIT).tar.gz,futurerestore-$(FUTURERESTORE_COMMIT),futurerestore)
 
 	-rmdir $(BUILD_WORK)/futurerestore/external/{idevicerestore,tsschecker}
-	$(call EXTRACT_TAR,$(FUTURERESTORE_IDEVICERESTORE_COMMIT).tar.gz,idevicerestore-$(FUTURERESTORE_IDEVICERESTORE_COMMIT),futurerestore/external/idevicerestore)
+	$(call EXTRACT_TAR,idevicerestore-$(FUTURERESTORE_IDEVICERESTORE_COMMIT).tar.gz,idevicerestore-$(FUTURERESTORE_IDEVICERESTORE_COMMIT),futurerestore/external/idevicerestore)
 	cp -R $(BUILD_WORK)/tsschecker $(BUILD_WORK)/futurerestore/external
 
 ifneq ($(wildcard $(BUILD_WORK)/futurerestore/.build_complete),)

--- a/fzf.mk
+++ b/fzf.mk
@@ -7,9 +7,7 @@ FZF_VERSION  := 0.25.0
 DEB_FZF_V    ?= $(FZF_VERSION)
 
 fzf-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/fzf-$(FZF_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/fzf-$(FZF_VERSION).tar.gz \
-			https://github.com/junegunn/fzf/archive/$(FZF_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,junegunn,fzf,$(FZF_VERSION),$(FZF_VERSION))
 	$(call EXTRACT_TAR,fzf-$(FZF_VERSION).tar.gz,fzf-$(FZF_VERSION),fzf)
 	mkdir -p $(BUILD_STAGE)/fzf/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share
 

--- a/gh.mk
+++ b/gh.mk
@@ -7,9 +7,7 @@ GH_VERSION  := 1.3.0
 DEB_GH_V    ?= $(GH_VERSION)
 
 gh-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/gh-$(GH_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/gh-$(GH_VERSION).tar.gz \
-			https://github.com/cli/cli/archive/v$(GH_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,cli,cli,$(GH_VERSION),v$(GH_VERSION),gh)
 	$(call EXTRACT_TAR,gh-$(GH_VERSION).tar.gz,cli-$(GH_VERSION),gh)
 	mkdir -p $(BUILD_STAGE)/gh/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin
 

--- a/ghostbin.mk
+++ b/ghostbin.mk
@@ -8,9 +8,7 @@ GHOSTBIN_VERSION  := 1.0+git20201225.$(shell echo $(GHOSTBIN_COMMIT) | cut -c -7
 DEB_GHOSTBIN_V    ?= $(GHOSTBIN_VERSION)
 
 ghostbin-setup: setup
-	-[ ! -e "$(BUILD_SOURCE)/ghostbin-v$(GHOSTBIN_COMMIT).tar.gz" ] \
-		&& wget -q -nc -O$(BUILD_SOURCE)/ghostbin-v$(GHOSTBIN_COMMIT).tar.gz \
-			https://github.com/DHowett/spectre/archive/$(GHOSTBIN_COMMIT).tar.gz
+	$(call GITHUB_ARCHIVE,DHowett,spectre,v$(GHOSTBIN_COMMIT),$(GHOSTBIN_COMMIT),ghostbin)
 	$(call EXTRACT_TAR,ghostbin-v$(GHOSTBIN_COMMIT).tar.gz,spectre-$(GHOSTBIN_COMMIT),ghostbin)
 	$(SED) -i '/account creation has been disabled/,+3d' $(BUILD_WORK)/ghostbin/auth.go
 

--- a/golb.mk
+++ b/golb.mk
@@ -10,9 +10,7 @@ GOLB_VERSION   := 1.0.1+git20210401.$(shell echo $(GOLB_COMMIT) | cut -c -7)
 DEB_GOLB_V     ?= $(GOLB_VERSION)
 
 golb-setup: setup
-	-[ ! -e "$(BUILD_SOURCE)/golb-v$(GOLB_COMMIT).tar.gz" ] \
-		&& wget -nc -O$(BUILD_SOURCE)/golb-v$(GOLB_COMMIT).tar.gz \
-			https://github.com/0x7ff/golb/archive/$(GOLB_COMMIT).tar.gz
+	$(call GITHUB_ARCHIVE,0x7ff,golb,v$(GOLB_COMMIT),$(GOLB_COMMIT))
 	$(call EXTRACT_TAR,golb-v$(GOLB_COMMIT).tar.gz,golb-$(GOLB_COMMIT),golb)
 	mkdir -p $(BUILD_STAGE)/golb/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin
 

--- a/googletest.mk
+++ b/googletest.mk
@@ -7,8 +7,8 @@ GOOGLETEST_VERSION := 1.10.0
 DEB_GOOGLETEST_V   ?= $(GOOGLETEST_VERSION)
 
 googletest-setup: setup
-	wget -q -nc -P $(BUILD_SOURCE) https://github.com/google/googletest/archive/release-$(GOOGLETEST_VERSION).tar.gz
-	$(call EXTRACT_TAR,release-$(GOOGLETEST_VERSION).tar.gz,googletest-release-$(GOOGLETEST_VERSION),googletest)
+	$(call GITHUB_ARCHIVE,google,googletest,$(GOOGLETEST_VERSION),release-$(GOOGLETEST_VERSION))
+	$(call EXTRACT_TAR,googletest-$(GOOGLETEST_VERSION).tar.gz,googletest-release-$(GOOGLETEST_VERSION),googletest)
 
 ifneq ($(wildcard $(BUILD_WORK)/googletest/.build_complete),)
 googletest:

--- a/harfbuzz.mk
+++ b/harfbuzz.mk
@@ -7,9 +7,7 @@ HARFBUZZ_VERSION := 2.7.4
 DEB_HARFBUZZ_V   ?= $(HARFBUZZ_VERSION)-1
 
 harfbuzz-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/harfbuzz-$(HARFBUZZ_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/harfbuzz-$(HARFBUZZ_VERSION).tar.gz \
-			https://github.com/harfbuzz/harfbuzz/archive/$(HARFBUZZ_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,harfbuzz,harfbuzz,$(HARFBUZZ_VERSION),$(HARFBUZZ_VERSION))
 	$(call EXTRACT_TAR,harfbuzz-$(HARFBUZZ_VERSION).tar.gz,harfbuzz-$(HARFBUZZ_VERSION),harfbuzz)
 
 ifneq ($(wildcard $(BUILD_WORK)/harfbuzz/.build_complete),)

--- a/hidapi.mk
+++ b/hidapi.mk
@@ -7,7 +7,7 @@ HIDAPI_VERSION := 0.9.0
 DEB_HIDAPI_V   ?= $(HIDAPI_VERSION)
 
 hidapi-setup: setup
-	wget -q -nc -P $(BUILD_SOURCE) https://github.com/libusb/hidapi/archive/hidapi-$(HIDAPI_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,libusb,hidapi,$(HIDAPI_VERSION),hidapi-$(HIDAPI_VERSION))
 	$(call EXTRACT_TAR,hidapi-$(HIDAPI_VERSION).tar.gz,hidapi-hidapi-$(HIDAPI_VERSION),hidapi)
 
 ifneq ($(wildcard $(BUILD_WORK)/hidapi/.build_complete),)

--- a/htop.mk
+++ b/htop.mk
@@ -7,7 +7,7 @@ HTOP_VERSION := 3.0.5
 DEB_HTOP_V   ?= $(HTOP_VERSION)
 
 htop-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/htop-$(HTOP_VERSION).tar.gz" ] && wget -q -nc -O$(BUILD_SOURCE)/htop-$(HTOP_VERSION).tar.gz https://github.com/htop-dev/htop/archive/$(HTOP_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,htop-dev,htop,$(HTOP_VERSION),$(HTOP_VERSION))
 	$(call EXTRACT_TAR,htop-$(HTOP_VERSION).tar.gz,htop-$(HTOP_VERSION),htop)
 
 ifneq ($(wildcard $(BUILD_WORK)/htop/.build_complete),)

--- a/idevicerestore.mk
+++ b/idevicerestore.mk
@@ -8,9 +8,7 @@ IDEVICERESTORE_VERSION := 1.0.0+git20210304.$(shell echo $(IDEVICERESTORE_COMMIT
 DEB_IDEVICERESTORE_V   ?= $(IDEVICERESTORE_VERSION)
 
 idevicerestore-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/idevicerestore-$(IDEVICERESTORE_COMMIT).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/idevicerestore-$(IDEVICERESTORE_COMMIT).tar.gz \
-			https://github.com/libimobiledevice/idevicerestore/archive/$(IDEVICERESTORE_COMMIT).tar.gz
+	$(call GITHUB_ARCHIVE,libimobiledevice,idevicerestore,$(IDEVICERESTORE_COMMIT),$(IDEVICERESTORE_COMMIT))
 	$(call EXTRACT_TAR,idevicerestore-$(IDEVICERESTORE_COMMIT).tar.gz,idevicerestore-$(IDEVICERESTORE_COMMIT),idevicerestore)
 
 ifneq ($(wildcard $(BUILD_WORK)/idevicerestore/.build_complete),)

--- a/img4lib.mk
+++ b/img4lib.mk
@@ -8,9 +8,7 @@ IMG4LIB_VERSION := 1.0+git20201209.$(shell echo $(IMG4LIB_COMMIT) | cut -c -7)
 DEB_IMG4LIB_V   ?= $(IMG4LIB_VERSION)-1
 
 img4lib-setup: setup
-	-[ ! -e "$(BUILD_SOURCE)/img4lib-v$(IMG4LIB_COMMIT).tar.gz" ] \
-		&& wget -q -nc -O$(BUILD_SOURCE)/img4lib-v$(IMG4LIB_COMMIT).tar.gz \
-			https://github.com/xerub/img4lib/archive/$(IMG4LIB_COMMIT).tar.gz
+	$(call GITHUB_ARCHIVE,xerub,img4lib,v$(IMG4LIB_COMMIT),$(IMG4LIB_COMMIT))
 	$(call EXTRACT_TAR,img4lib-v$(IMG4LIB_COMMIT).tar.gz,img4lib-$(IMG4LIB_COMMIT),img4lib)
 	$(SED) -i 's/CFLAGS =/CFLAGS ?=/' $(BUILD_WORK)/img4lib/Makefile
 	$(SED) -i 's/LDFLAGS =/LDFLAGS ?=/' $(BUILD_WORK)/img4lib/Makefile

--- a/img4tool.mk
+++ b/img4tool.mk
@@ -7,8 +7,8 @@ IMG4TOOL_VERSION := 197
 DEB_IMG4TOOL_V   ?= $(IMG4TOOL_VERSION)
 
 img4tool-setup: setup
-	wget -q -nc -P $(BUILD_SOURCE) https://github.com/tihmstar/img4tool/archive/$(IMG4TOOL_VERSION).tar.gz
-	$(call EXTRACT_TAR,$(IMG4TOOL_VERSION).tar.gz,img4tool-$(IMG4TOOL_VERSION),img4tool)
+	$(call GITHUB_ARCHIVE,tihmstar,img4tool,$(IMG4TOOL_VERSION),$(IMG4TOOL_VERSION))
+	$(call EXTRACT_TAR,img4tool-$(IMG4TOOL_VERSION).tar.gz,img4tool-$(IMG4TOOL_VERSION),img4tool)
 
 ifneq ($(wildcard $(BUILD_WORK)/img4tool/.build_complete),)
 img4tool:

--- a/jbig2dec.mk
+++ b/jbig2dec.mk
@@ -7,9 +7,7 @@ JBIG2DEC_VERSION := 0.19
 DEB_JBIG2DEC_V   ?= $(JBIG2DEC_VERSION)
 
 jbig2dec-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/jbig2dec-$(JBIG2DEC_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/jbig2dec-$(JBIG2DEC_VERSION).tar.gz \
-			https://github.com/ArtifexSoftware/jbig2dec/archive/$(JBIG2DEC_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,ArtifexSoftware,jbig2dec,$(JBIG2DEC_VERSION),$(JBIG2DEC_VERSION))
 	$(call EXTRACT_TAR,jbig2dec-$(JBIG2DEC_VERSION).tar.gz,jbig2dec-$(JBIG2DEC_VERSION),jbig2dec)
 
 ifneq ($(wildcard $(BUILD_WORK)/jbig2dec/.build_complete),)

--- a/ldid.mk
+++ b/ldid.mk
@@ -8,9 +8,7 @@ LDID_VERSION  := 2.1.2+20210222.$(shell echo $(LDID_COMMIT) | cut -c -7)
 DEB_LDID_V    ?= $(LDID_VERSION)
 
 ldid-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/saurik-ldid-$(LDID_COMMIT).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/saurik-ldid-$(LDID_COMMIT).tar.gz \
-			https://github.com/Diatrus/saurik-ldid/archive/$(LDID_COMMIT).tar.gz
+	$(call GITHUB_ARCHIVE,Diatrus,saurik-ldid,$(LDID_COMMIT),$(LDID_COMMIT))
 	$(call EXTRACT_TAR,saurik-ldid-$(LDID_COMMIT).tar.gz,saurik-ldid-$(LDID_COMMIT),ldid)
 	mkdir -p $(BUILD_STAGE)/ldid/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin
 

--- a/libfmt.mk
+++ b/libfmt.mk
@@ -7,9 +7,7 @@ LIBFMT_VERSION  := 7.1.3
 DEB_LIBFMT_V    ?= $(LIBFMT_VERSION)
 
 libfmt-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/libfmt-$(LIBFMT_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/libfmt-$(LIBFMT_VERSION).tar.gz \
-			https://github.com/fmtlib/fmt/archive/$(LIBFMT_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,fmtlib,fmt,$(LIBFMT_VERSION),$(LIBFMT_VERSION),libfmt)
 	$(call EXTRACT_TAR,libfmt-$(LIBFMT_VERSION).tar.gz,fmt-$(LIBFMT_VERSION),libfmt)
 
 ifneq ($(wildcard $(BUILD_WORK)/libfmt/.build_complete),)

--- a/libfragmentzip.mk
+++ b/libfragmentzip.mk
@@ -7,8 +7,8 @@ LIBFRAGMENTZIP_VERSION := 60
 DEB_LIBFRAGMENTZIP_V   ?= $(LIBFRAGMENTZIP_VERSION)-2
 
 libfragmentzip-setup: setup
-	wget -q -nc -P $(BUILD_SOURCE) https://github.com/tihmstar/libfragmentzip/archive/$(LIBFRAGMENTZIP_VERSION).tar.gz
-	$(call EXTRACT_TAR,$(LIBFRAGMENTZIP_VERSION).tar.gz,libfragmentzip-$(LIBFRAGMENTZIP_VERSION),libfragmentzip)
+	$(call GITHUB_ARCHIVE,tihmstar,libfragmentzip,$(LIBFRAGMENTZIP_VERSION),$(LIBFRAGMENTZIP_VERSION))
+	$(call EXTRACT_TAR,libfragmentzip-$(LIBFRAGMENTZIP_VERSION).tar.gz,libfragmentzip-$(LIBFRAGMENTZIP_VERSION),libfragmentzip)
 	$(SED) -i 's/@libz_requires@//;s/\(Libs:.*\)/\1 -lz/' $(BUILD_WORK)/libfragmentzip/libfragmentzip.pc.in
 
 ifneq ($(wildcard $(BUILD_WORK)/libfragmentzip/.build_complete),)

--- a/libgeneral.mk
+++ b/libgeneral.mk
@@ -7,8 +7,8 @@ LIBGENERAL_VERSION := 54
 DEB_LIBGENERAL_V   ?= $(LIBGENERAL_VERSION)
 
 libgeneral-setup: setup
-	wget -q -nc -P $(BUILD_SOURCE) https://github.com/tihmstar/libgeneral/archive/$(LIBGENERAL_VERSION).tar.gz
-	$(call EXTRACT_TAR,$(LIBGENERAL_VERSION).tar.gz,libgeneral-$(LIBGENERAL_VERSION),libgeneral)
+	$(call GITHUB_ARCHIVE,tihmstar,libgeneral,$(LIBGENERAL_VERSION),$(LIBGENERAL_VERSION))
+	$(call EXTRACT_TAR,libgeneral-$(LIBGENERAL_VERSION).tar.gz,libgeneral-$(LIBGENERAL_VERSION),libgeneral)
 
 ifneq ($(wildcard $(BUILD_WORK)/libgeneral/.build_complete),)
 libgeneral:

--- a/libgit2.mk
+++ b/libgit2.mk
@@ -7,9 +7,7 @@ LIBGIT2_VERSION  := 1.1.0
 DEB_LIBGIT2_V    ?= $(LIBGIT2_VERSION)
 
 libgit2-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/libgit2-$(LIBGIT2_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/libgit2-$(LIBGIT2_VERSION).tar.gz \
-			https://github.com/libgit2/libgit2/archive/v$(LIBGIT2_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,libgit2,libgit2,$(LIBGIT2_VERSION),v$(LIBGIT2_VERSION))
 	$(call EXTRACT_TAR,libgit2-$(LIBGIT2_VERSION).tar.gz,libgit2-$(LIBGIT2_VERSION),libgit2)
 
 ifneq ($(wildcard $(BUILD_WORK)/libgit2/.build_complete),)

--- a/libinsn.mk
+++ b/libinsn.mk
@@ -8,9 +8,7 @@ LIBINSN_COMMIT  := 64124fd2b1b57d7b76a0e2b0c06434a7048758d2
 DEB_LIBINSN_V   ?= $(LIBINSN_VERSION)-1
 
 libinsn-setup: setup
-	-[ ! -e "$(BUILD_SOURCE)/libinsn-$(LIBINSN_COMMIT).tar.gz" ] \
-		&& wget -q -nc -O$(BUILD_SOURCE)/libinsn-$(LIBINSN_COMMIT).tar.gz \
-			https://github.com/tihmstar/libinsn/archive/$(LIBINSN_COMMIT).tar.gz
+	$(call GITHUB_ARCHIVE,tihmstar,libinsn,$(LIBINSN_COMMIT),$(LIBINSN_COMMIT))
 	$(call EXTRACT_TAR,libinsn-$(LIBINSN_COMMIT).tar.gz,libinsn-$(LIBINSN_COMMIT),libinsn)
 
 ifneq ($(wildcard $(BUILD_WORK)/libinsn/.build_complete),)

--- a/libipatcher.mk
+++ b/libipatcher.mk
@@ -7,20 +7,14 @@ LIBIPATCHER_VERSION := 81
 DEB_LIBIPATCHER_V   ?= $(LIBIPATCHER_VERSION)
 
 libipatcher-setup: setup
-	-[ ! -e "$(BUILD_SOURCE)/libipatcher-$(LIBIPATCHER_VERSION).tar.gz" ] \
-		&& wget -q -nc -O$(BUILD_SOURCE)/libipatcher-$(LIBIPATCHER_VERSION).tar.gz \
-			https://github.com/tihmstar/libipatcher/archive/$(LIBIPATCHER_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,tihmstar,libipatcher,$(LIBIPATCHER_VERSION),$(LIBIPATCHER_VERSION))
 	$(call EXTRACT_TAR,libipatcher-$(LIBIPATCHER_VERSION).tar.gz,libipatcher-$(LIBIPATCHER_VERSION),libipatcher)
 
-	-[ ! -f "$(BUILD_SOURCE)/iBoot32Patcher.tar.gz" ] \
-		&& wget -q -nc -O$(BUILD_SOURCE)/iBoot32Patcher.tar.gz \
-			https://github.com/tihmstar/iBoot32Patcher/tarball/master
-	-[ ! -f "$(BUILD_SOURCE)/jssy.tar.gz" ] \
-		&& wget -q -nc -O$(BUILD_SOURCE)/jssy.tar.gz \
-			https://github.com/tihmstar/jssy/tarball/master
+	$(call GITHUB_ARCHIVE,tihmstar,iBoot32Patcher,master,master)
+	$(call GITHUB_ARCHIVE,tihmstar,jssy,master,master)
 	rm -rf $(BUILD_WORK)/libipatcher/external/{jssy,iBoot32Patcher}
-	$(call EXTRACT_TAR,jssy.tar.gz,tihmstar-jssy-*,libipatcher/external/jssy)
-	$(call EXTRACT_TAR,iBoot32Patcher.tar.gz,tihmstar-iBoot32Patcher-*,libipatcher/external/iBoot32Patcher)
+	$(call EXTRACT_TAR,jssy-master.tar.gz,tihmstar-jssy-*,libipatcher/external/jssy)
+	$(call EXTRACT_TAR,iBoot32Patcher-master.tar.gz,tihmstar-iBoot32Patcher-*,libipatcher/external/iBoot32Patcher)
 
 	$(SED) -i '/AC_FUNC_MALLOC/d' $(BUILD_WORK)/libipatcher/configure.ac
 	$(SED) -i '/AC_FUNC_REALLOC/d' $(BUILD_WORK)/libipatcher/configure.ac

--- a/libirecovery.mk
+++ b/libirecovery.mk
@@ -8,9 +8,7 @@ LIBIRECOVERY_VERSION := 1.0.0+git20210124.$(shell echo $(LIBIRECOVERY_COMMIT) | 
 DEB_LIBIRECOVERY_V   ?= $(LIBIRECOVERY_VERSION)
 
 libirecovery-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/libirecovery-$(LIBIRECOVERY_COMMIT).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/libirecovery-$(LIBIRECOVERY_COMMIT).tar.gz \
-			https://github.com/libimobiledevice/libirecovery/archive/$(LIBIRECOVERY_COMMIT).tar.gz
+	$(call GITHUB_ARCHIVE,libimobiledevice,libirecovery,$(LIBIRECOVERY_COMMIT),$(LIBIRECOVERY_COMMIT))
 	$(call EXTRACT_TAR,libirecovery-$(LIBIRECOVERY_COMMIT).tar.gz,libirecovery-$(LIBIRECOVERY_COMMIT),libirecovery)
 
 ifneq ($(wildcard $(BUILD_WORK)/libirecovery/.build_complete),)

--- a/liblqr.mk
+++ b/liblqr.mk
@@ -7,9 +7,7 @@ LIBLQR_VERSION := 0.4.2
 DEB_LIBLQR_V   ?= $(LIBLQR_VERSION)
 
 liblqr-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/liblqr-$(LIBLQR_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/liblqr-$(LIBLQR_VERSION).tar.gz \
-			https://github.com/carlobaldassi/liblqr/archive/v$(LIBLQR_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,carlobaldassi,liblqr,$(LIBLQR_VERSION),v$(LIBLQR_VERSION))
 	$(call EXTRACT_TAR,liblqr-$(LIBLQR_VERSION).tar.gz,liblqr-$(LIBLQR_VERSION),liblqr)
 	$(call DO_PATCH,liblqr,liblqr,-p1)
 

--- a/libmpack-lua.mk
+++ b/libmpack-lua.mk
@@ -7,9 +7,7 @@ LIBMPACK-LUA_VERSION := 1.0.8
 DEB_LIBMPACK-LUA_V   ?= $(LIBMPACK-LUA_VERSION)
 
 libmpack-lua-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/libmpack-lua-$(LIBMPACK-LUA_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/libmpack-lua-$(LIBMPACK-LUA_VERSION).tar.gz \
-			https://github.com/libmpack/libmpack-lua/archive/$(LIBMPACK-LUA_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,libmpack,libmpack-lua,$(LIBMPACK-LUA_VERSION),$(LIBMPACK-LUA_VERSION))
 	$(call EXTRACT_TAR,libmpack-lua-$(LIBMPACK-LUA_VERSION).tar.gz,libmpack-lua-$(LIBMPACK-LUA_VERSION),libmpack-lua/build51)
 	$(call EXTRACT_TAR,libmpack-lua-$(LIBMPACK-LUA_VERSION).tar.gz,libmpack-lua-$(LIBMPACK-LUA_VERSION),libmpack-lua/build51/bundle)
 	$(call EXTRACT_TAR,libmpack-lua-$(LIBMPACK-LUA_VERSION).tar.gz,libmpack-lua-$(LIBMPACK-LUA_VERSION),libmpack-lua/build52)

--- a/libmpack.mk
+++ b/libmpack.mk
@@ -7,9 +7,7 @@ LIBMPACK_VERSION := 1.0.5
 DEB_LIBMPACK_V   ?= $(LIBMPACK_VERSION)
 
 libmpack-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/libmpack-$(LIBMPACK_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/libmpack-$(LIBMPACK_VERSION).tar.gz \
-			https://github.com/libmpack/libmpack/archive/$(LIBMPACK_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,libmpack,libmpack,$(LIBMPACK_VERSION),$(LIBMPACK_VERSION))
 	$(call EXTRACT_TAR,libmpack-$(LIBMPACK_VERSION).tar.gz,libmpack-$(LIBMPACK_VERSION),libmpack)
 
 ifneq ($(wildcard $(BUILD_WORK)/libmpack/.build_complete),)

--- a/liboffsetfinder64.mk
+++ b/liboffsetfinder64.mk
@@ -8,9 +8,7 @@ LIBOFFSETFINDER64_COMMIT  := 35d3411bf675a83bdb768bc0ec26fe2344be16f3
 DEB_LIBOFFSETFINDER64_V   ?= $(LIBOFFSETFINDER64_VERSION)
 
 liboffsetfinder64-setup: setup
-	-[ ! -e "$(BUILD_SOURCE)/liboffsetfinder64-$(LIBOFFSETFINDER64_COMMIT).tar.gz" ] \
-		&& wget -q -nc -O$(BUILD_SOURCE)/liboffsetfinder64-$(LIBOFFSETFINDER64_COMMIT).tar.gz \
-			https://github.com/tihmstar/liboffsetfinder64/archive/$(LIBOFFSETFINDER64_COMMIT).tar.gz
+	$(call GITHUB_ARCHIVE,tihmstar,liboffsetfinder64,$(LIBOFFSETFINDER64_COMMIT),$(LIBOFFSETFINDER64_COMMIT))
 	$(call EXTRACT_TAR,liboffsetfinder64-$(LIBOFFSETFINDER64_COMMIT).tar.gz,liboffsetfinder64-$(LIBOFFSETFINDER64_COMMIT),liboffsetfinder64)
 
 ifneq ($(wildcard $(BUILD_WORK)/liboffsetfinder64/.build_complete),)

--- a/libplist.mk
+++ b/libplist.mk
@@ -7,8 +7,8 @@ LIBPLIST_VERSION  := 2.2.0
 DEB_LIBPLIST_V    ?= $(LIBPLIST_VERSION)
 
 libplist-setup: setup
-	wget -q -nc -P $(BUILD_SOURCE) https://github.com/libimobiledevice/libplist/archive/$(LIBPLIST_VERSION).tar.gz
-	$(call EXTRACT_TAR,$(LIBPLIST_VERSION).tar.gz,libplist-$(LIBPLIST_VERSION),libplist)
+	$(call GITHUB_ARCHIVE,libimobiledevice,libplist,$(LIBPLIST_VERSION),$(LIBPLIST_VERSION))
+	$(call EXTRACT_TAR,libplist-$(LIBPLIST_VERSION).tar.gz,libplist-$(LIBPLIST_VERSION),libplist)
 
 ifneq ($(wildcard $(BUILD_WORK)/libplist/.build_complete),)
 libplist:

--- a/libscrypt.mk
+++ b/libscrypt.mk
@@ -7,9 +7,7 @@ LIBSCRYPT_VERSION := 1.21
 DEB_LIBSCRYPT_V   ?= $(LIBSCRYPT_VERSION)-1
 
 libscrypt-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/libscrypt-$(LIBSCRYPT_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/libscrypt-$(LIBSCRYPT_VERSION).tar.gz \
-			https://github.com/technion/libscrypt/archive/v$(LIBSCRYPT_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,technion,libscrypt,$(LIBSCRYPT_VERSION),v$(LIBSCRYPT_VERSION))
 	$(call EXTRACT_TAR,libscrypt-$(LIBSCRYPT_VERSION).tar.gz,libscrypt-$(LIBSCRYPT_VERSION),libscrypt)
 
 ifneq ($(wildcard $(BUILD_WORK)/libscrypt/.build_complete),)

--- a/libsnappy.mk
+++ b/libsnappy.mk
@@ -7,9 +7,7 @@ LIBSNAPPY_VERSION := 1.1.8
 DEB_LIBSNAPPY_V   ?= $(LIBSNAPPY_VERSION)
 
 libsnappy-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/libsnappy-$(LIBSNAPPY_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/libsnappy-$(LIBSNAPPY_VERSION).tar.gz \
-			https://github.com/google/snappy/archive/$(LIBSNAPPY_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,google,snappy,$(LIBSNAPPY_VERSION),$(LIBSNAPPY_VERSION),libsnappy)
 	$(call EXTRACT_TAR,libsnappy-$(LIBSNAPPY_VERSION).tar.gz,snappy-$(LIBSNAPPY_VERSION),libsnappy)
 	$(call DO_PATCH,libsnappy,libsnappy,-p1)
 

--- a/libsrt.mk
+++ b/libsrt.mk
@@ -7,9 +7,7 @@ LIBSRT_VERSION := 1.4.2
 DEB_LIBSRT_V   ?= $(LIBSRT_VERSION)-1
 
 libsrt-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/libsrt-$(LIBSRT_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/libsrt-$(LIBSRT_VERSION).tar.gz \
-			https://github.com/Haivision/srt/archive/v$(LIBSRT_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,Haivision,srt,$(LIBSRT_VERSION),v$(LIBSRT_VERSION),libsrt)
 	$(call EXTRACT_TAR,libsrt-$(LIBSRT_VERSION).tar.gz,srt-$(LIBSRT_VERSION),libsrt)
 
 ifneq ($(wildcard $(BUILD_WORK)/libsrt/.build_complete),)

--- a/libucontext.mk
+++ b/libucontext.mk
@@ -8,9 +8,7 @@ SUBPROJECTS        += libucontext
 LIBUCONTEXT_COMMIT := 455ecd495f706d5b57be3ff5b572c120c2a7a5a2
 
 libucontext-setup: setup
-	-[ ! -e "$(BUILD_SOURCE)/libucontext-$(LIBUCONTEXT_COMMIT).tar.gz" ] \
-		&& wget -q -nc -O$(BUILD_SOURCE)/libucontext-$(LIBUCONTEXT_COMMIT).tar.gz \
-			https://github.com/utmapp/libucontext/archive/$(LIBUCONTEXT_COMMIT).tar.gz
+	$(call GITHUB_ARCHIVE,utmapp,libucontext,$(LIBUCONTEXT_COMMIT),$(LIBUCONTEXT_COMMIT))
 	$(call EXTRACT_TAR,libucontext-$(LIBUCONTEXT_COMMIT).tar.gz,libucontext-$(LIBUCONTEXT_COMMIT),libucontext)
 
 ifneq ($(wildcard $(BUILD_WORK)/libucontext/.build_complete),)

--- a/libusbmuxd.mk
+++ b/libusbmuxd.mk
@@ -7,8 +7,8 @@ LIBUSBMUXD_VERSION := 2.0.2
 DEB_LIBUSBMUXD_V   ?= $(LIBUSBMUXD_VERSION)
 
 libusbmuxd-setup: setup
-	wget -q -nc -P $(BUILD_SOURCE) https://github.com/libimobiledevice/libusbmuxd/archive/$(LIBUSBMUXD_VERSION).tar.gz
-	$(call EXTRACT_TAR,$(LIBUSBMUXD_VERSION).tar.gz,libusbmuxd-$(LIBUSBMUXD_VERSION),libusbmuxd)
+	$(call GITHUB_ARCHIVE,libimobiledevice,libusbmuxd,$(LIBUSBMUXD_VERSION),$(LIBUSBMUXD_VERSION))
+	$(call EXTRACT_TAR,libusbmuxd-$(LIBUSBMUXD_VERSION).tar.gz,libusbmuxd-$(LIBUSBMUXD_VERSION),libusbmuxd)
 
 ifneq ($(wildcard $(BUILD_WORK)/libusbmuxd/.build_complete),)
 libusbmuxd:

--- a/libutf8proc.mk
+++ b/libutf8proc.mk
@@ -7,9 +7,7 @@ LIBUTF8PROC_VERSION := 2.5.0
 DEB_LIBUTF8PROC_V   ?= $(LIBUTF8PROC_VERSION)-2
 
 libutf8proc-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/libutf8proc-$(LIBUTF8PROC_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/libutf8proc-$(LIBUTF8PROC_VERSION).tar.gz \
-			https://github.com/JuliaStrings/utf8proc/archive/v$(LIBUTF8PROC_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,JuliaStrings,utf8proc,$(LIBUTF8PROC_VERSION),v$(LIBUTF8PROC_VERSION),libutf8proc)
 	$(call EXTRACT_TAR,libutf8proc-$(LIBUTF8PROC_VERSION).tar.gz,utf8proc-$(LIBUTF8PROC_VERSION),libutf8proc)
 
 ifneq ($(wildcard $(BUILD_WORK)/libutf8proc/.build_complete),)

--- a/libvidstab.mk
+++ b/libvidstab.mk
@@ -7,9 +7,7 @@ LIBVIDSTAB_VERSION := 1.1.0
 DEB_LIBVIDSTAB_V   ?= $(LIBVIDSTAB_VERSION)
 
 libvidstab-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/vid.stab-$(LIBVIDSTAB_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/vid.stab-$(LIBVIDSTAB_VERSION).tar.gz \
-			https://github.com/georgmartius/vid.stab/archive/v$(LIBVIDSTAB_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,georgmartius,vid.stab,$(LIBVIDSTAB_VERSION),v$(LIBVIDSTAB_VERSION))
 	$(call EXTRACT_TAR,vid.stab-$(LIBVIDSTAB_VERSION).tar.gz,vid.stab-$(LIBVIDSTAB_VERSION),libvidstab)
 
 ifneq ($(wildcard $(BUILD_WORK)/libvidstab/.build_complete),)

--- a/libvpx.mk
+++ b/libvpx.mk
@@ -7,9 +7,7 @@ LIBVPX_VERSION := 1.9.0
 DEB_LIBVPX_V   ?= $(LIBVPX_VERSION)
 
 libvpx-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/libvpx-$(LIBVPX_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/libvpx-$(LIBVPX_VERSION).tar.gz \
-			https://github.com/webmproject/libvpx/archive/v$(LIBVPX_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,webmproject,libvpx,$(LIBVPX_VERSION),v$(LIBVPX_VERSION))
 	$(call EXTRACT_TAR,libvpx-$(LIBVPX_VERSION).tar.gz,libvpx-$(LIBVPX_VERSION),libvpx)
 
 ifneq ($(wildcard $(BUILD_WORK)/libvpx/.build_complete),)

--- a/libxcrypt.mk
+++ b/libxcrypt.mk
@@ -9,7 +9,7 @@ LIBXCRYPT_VERSION := 4.4.17
 DEB_LIBXCRYPT_V   ?= $(LIBXCRYPT_VERSION)
 
 libxcrypt-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/libxcrypt-$(LIBXCRYPT_VERSION).tar.gz" ] && wget -q -nc -O$(BUILD_SOURCE)/libxcrypt-$(LIBXCRYPT_VERSION).tar.gz https://github.com/besser82/libxcrypt/archive/v$(LIBXCRYPT_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,besser82,libxcrypt,$(LIBXCRYPT_VERSION),v$(LIBXCRYPT_VERSION))
 	$(call EXTRACT_TAR,libxcrypt-$(LIBXCRYPT_VERSION).tar.gz,libxcrypt-$(LIBXCRYPT_VERSION),libxcrypt)
 
 ifneq ($(wildcard $(BUILD_WORK)/libxcrypt/.build_complete),)

--- a/libyaml.mk
+++ b/libyaml.mk
@@ -7,9 +7,7 @@ LIBYAML_VERSION := 0.2.5
 DEB_LIBYAML_V   ?= $(LIBYAML_VERSION)
 
 libyaml-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/libyaml-$(LIBYAML_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/libyaml-$(LIBYAML_VERSION).tar.gz \
-			https://github.com/yaml/libyaml/archive/$(LIBYAML_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,yaml,libyaml,$(LIBYAML_VERSION),$(LIBYAML_VERSION))
 	$(call EXTRACT_TAR,libyaml-$(LIBYAML_VERSION).tar.gz,libyaml-$(LIBYAML_VERSION),libyaml)
 
 ifneq ($(wildcard $(BUILD_WORK)/libyaml/.build_complete),)

--- a/llvm.mk
+++ b/llvm.mk
@@ -34,8 +34,8 @@ endif
 
 llvm-setup: setup
 	wget -q -nc -P $(BUILD_SOURCE) https://github.com/apple/llvm-project/archive/swift-$(SWIFT_VERSION)-$(SWIFT_SUFFIX).tar.gz
-	-[ ! -e "$(BUILD_SOURCE)/swift-swift-$(SWIFT_VERSION)-$(SWIFT_SUFFIX).tar.gz" ] && wget -O $(BUILD_SOURCE)/swift-swift-$(SWIFT_VERSION)-$(SWIFT_SUFFIX).tar.gz https://github.com/apple/swift/archive/swift-$(SWIFT_VERSION)-$(SWIFT_SUFFIX).tar.gz
-	-[ ! -e "$(BUILD_SOURCE)/swift-cmark-$(SWIFT_VERSION)-$(SWIFT_SUFFIX).tar.gz" ] && wget -O $(BUILD_SOURCE)/swift-cmark-$(SWIFT_VERSION)-$(SWIFT_SUFFIX).tar.gz https://github.com/apple/cmark/archive/swift-$(SWIFT_VERSION)-$(SWIFT_SUFFIX).tar.gz
+	$(call GITHUB_ARCHIVE,apple,swift,$(SWIFT_VERSION)-$(SWIFT_SUFFIX),swift-$(SWIFT_VERSION)-$(SWIFT_SUFFIX),swift-swift)
+	$(call GITHUB_ARCHIVE,apple,cmark,$(SWIFT_VERSION)-$(SWIFT_SUFFIX),swift-$(SWIFT_VERSION)-$(SWIFT_SUFFIX),swift-cmark)
 	$(call EXTRACT_TAR,swift-$(SWIFT_VERSION)-$(SWIFT_SUFFIX).tar.gz,llvm-project-swift-$(SWIFT_VERSION)-$(SWIFT_SUFFIX),llvm)
 	$(call EXTRACT_TAR,swift-swift-$(SWIFT_VERSION)-$(SWIFT_SUFFIX).tar.gz,swift-swift-$(SWIFT_VERSION)-$(SWIFT_SUFFIX),llvm/swift)
 	$(call EXTRACT_TAR,swift-cmark-$(SWIFT_VERSION)-$(SWIFT_SUFFIX).tar.gz,swift-cmark-swift-$(SWIFT_VERSION)-$(SWIFT_SUFFIX),llvm/cmark)

--- a/lolcat.mk
+++ b/lolcat.mk
@@ -7,8 +7,7 @@ LOLCAT_VERSION := 1.2
 DEB_LOLCAT_V   ?= $(LOLCAT_VERSION)
 
 lolcat-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/lolcat-$(LOLCAT_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/lolcat-$(LOLCAT_VERSION).tar.gz https://github.com/jaseg/lolcat/archive/v$(LOLCAT_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,jaseg,lolcat,$(LOLCAT_VERSION),v$(LOLCAT_VERSION))
 	$(call EXTRACT_TAR,lolcat-$(LOLCAT_VERSION).tar.gz,lolcat-$(LOLCAT_VERSION),lolcat)
 	mkdir -p $(BUILD_STAGE)/lolcat/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin
 

--- a/lua-inspect.mk
+++ b/lua-inspect.mk
@@ -7,9 +7,7 @@ LUA-INSPECT_VERSION := 3.1.1
 DEB_LUA-INSPECT_V   ?= $(LUA-INSPECT_VERSION)
 
 lua-inspect-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/inspect.lua-$(LUA-INSPECT_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/inspect.lua-$(LUA-INSPECT_VERSION).tar.gz \
-			https://github.com/kikito/inspect.lua/archive/v$(LUA-INSPECT_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,kikito,inspect.lua,$(LUA-INSPECT_VERSION),v$(LUA-INSPECT_VERSION))
 	$(call EXTRACT_TAR,inspect.lua-$(LUA-INSPECT_VERSION).tar.gz,inspect.lua-$(LUA-INSPECT_VERSION),lua-inspect)
 	mkdir -p $(BUILD_STAGE)/lua-inspect/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/lua/5.{1..3}
 

--- a/luajit.mk
+++ b/luajit.mk
@@ -9,9 +9,7 @@ DEB_LUAJIT_V   ?= $(shell echo $(LUAJIT_VERSION) | cut -d- -f1)~beta3+git$(shell
 LUAJIT_COMMIT    := 377a8488b62a9f1b589bb68875dd1288aa70e76e
 
 luajit-setup: setup
-	-[ ! -e "$(BUILD_SOURCE)/LuaJIT-$(LUAJIT_COMMIT).tar.gz" ] \
-		&& wget -nc -O$(BUILD_SOURCE)/LuaJIT-$(LUAJIT_COMMIT).tar.gz \
-			https://github.com/LuaJIT/LuaJIT/archive/$(LUAJIT_COMMIT).tar.gz
+	$(call GITHUB_ARCHIVE,LuaJIT,LuaJIT,$(LUAJIT_COMMIT),$(LUAJIT_COMMIT))
 	$(call EXTRACT_TAR,LuaJIT-$(LUAJIT_COMMIT).tar.gz,LuaJIT-$(LUAJIT_COMMIT),luajit)
 	$(SED) -i 's/#BUILDMODE= dynamic/BUILDMODE= dynamic/' $(BUILD_WORK)/luajit/src/Makefile
 	$(SED) -i 's/#define LJ_OS_NOJIT		1/#undef LJ_OS_NOJIT/' $(BUILD_WORK)/luajit/src/lj_arch.h

--- a/lz4.mk
+++ b/lz4.mk
@@ -7,9 +7,7 @@ LZ4_VERSION   := 1.9.2
 DEB_LZ4_V     ?= $(LZ4_VERSION)-2
 
 lz4-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/lz4-$(LZ4_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/lz4-$(LZ4_VERSION).tar.gz \
-			https://github.com/lz4/lz4/archive/v$(LZ4_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,lz4,lz4,$(LZ4_VERSION),v$(LZ4_VERSION))
 	$(call EXTRACT_TAR,lz4-$(LZ4_VERSION).tar.gz,lz4-$(LZ4_VERSION),lz4)
 
 ifneq ($(wildcard $(BUILD_WORK)/lz4/.build_complete),)

--- a/lzfse.mk
+++ b/lzfse.mk
@@ -7,7 +7,7 @@ LZFSE_VERSION := 1.0
 DEB_LZFSE_V   ?= $(LZFSE_VERSION)-1
 
 lzfse-setup: setup
-	wget -q -nc -P $(BUILD_SOURCE) https://github.com/lzfse/lzfse/archive/lzfse-$(LZFSE_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,lzfse,lzfse,$(LZFSE_VERSION),$(LZFSE_VERSION))
 	$(call EXTRACT_TAR,lzfse-$(LZFSE_VERSION).tar.gz,lzfse-lzfse-$(LZFSE_VERSION),lzfse)
 
 ifneq ($(wildcard $(BUILD_WORK)/lzfse/.build_complete),)

--- a/mtr.mk
+++ b/mtr.mk
@@ -7,9 +7,7 @@ MTR_VERSION := 0.94
 DEB_MTR_V   ?= $(MTR_VERSION)
 
 mtr-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/mtr-$(MTR_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/mtr-$(MTR_VERSION).tar.gz \
-			https://github.com/traviscross/mtr/archive/v$(MTR_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,traviscross,mtr,$(MTR_VERSION),v$(MTR_VERSION))
 	$(call EXTRACT_TAR,mtr-$(MTR_VERSION).tar.gz,mtr-$(MTR_VERSION),mtr)
 
 ifneq ($(wildcard $(BUILD_WORK)/mtr/.build_complete),)

--- a/neofetch.mk
+++ b/neofetch.mk
@@ -7,8 +7,8 @@ NEOFETCH_VERSION := 7.1.0
 DEB_NEOFETCH_V   ?= $(NEOFETCH_VERSION)-1
 
 neofetch-setup: setup
-	wget -q -nc -P $(BUILD_SOURCE) https://github.com/dylanaraps/neofetch/archive/$(NEOFETCH_VERSION).tar.gz
-	$(call EXTRACT_TAR,$(NEOFETCH_VERSION).tar.gz,neofetch-$(NEOFETCH_VERSION),neofetch)
+	$(call GITHUB_ARCHIVE,dylanaraps,neofetch,$(NEOFETCH_VERSION),$(NEOFETCH_VERSION))
+	$(call EXTRACT_TAR,neofetch-$(NEOFETCH_VERSION).tar.gz,neofetch-$(NEOFETCH_VERSION),neofetch)
 	$(call DO_PATCH,neofetch,neofetch,-p1)
 
 ifneq ($(wildcard $(BUILD_WORK)/neofetch/.build_complete),)

--- a/neovim.mk
+++ b/neovim.mk
@@ -7,9 +7,7 @@ NEOVIM_VERSION := 0.4.4
 DEB_NEOVIM_V   ?= $(NEOVIM_VERSION)
 
 neovim-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/neovim-$(NEOVIM_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/neovim-$(NEOVIM_VERSION).tar.gz \
-			https://github.com/neovim/neovim/archive/v$(NEOVIM_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,neovim,neovim,$(NEOVIM_VERSION),v$(NEOVIM_VERSION))
 	$(call EXTRACT_TAR,neovim-$(NEOVIM_VERSION).tar.gz,neovim-$(NEOVIM_VERSION),neovim)
 	$(call DO_PATCH,neovim,neovim,-p1)
 	mkdir -p $(BUILD_WORK)/neovim/build

--- a/ninja.mk
+++ b/ninja.mk
@@ -7,9 +7,7 @@ NINJA_VERSION := 1.10.0
 DEB_NINJA_V   ?= $(NINJA_VERSION)
 
 ninja-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/ninja-$(NINJA_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/ninja-$(NINJA_VERSION).tar.gz \
-			https://github.com/ninja-build/ninja/archive/v$(NINJA_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,ninja-build,ninja,$(NINJA_VERSION),v$(NINJA_VERSION))
 	$(call EXTRACT_TAR,ninja-$(NINJA_VERSION).tar.gz,ninja-$(NINJA_VERSION),ninja)
 	mkdir -p $(BUILD_WORK)/ninja/build $(BUILD_STAGE)/ninja/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin
 

--- a/nload.mk
+++ b/nload.mk
@@ -7,9 +7,7 @@ NLOAD_VERSION := 0.7.4
 DEB_NLOAD_V   ?= $(NLOAD_VERSION)-1
 
 nload-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/nload-$(NLOAD_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/nload-$(NLOAD_VERSION).tar.gz \
-			https://github.com/rolandriegel/nload/archive/v$(NLOAD_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,rolandriegel,nload,$(NLOAD_VERSION),v$(NLOAD_VERSION))
 	$(call EXTRACT_TAR,nload-$(NLOAD_VERSION).tar.gz,nload-$(NLOAD_VERSION),nload)
 	$(call DO_PATCH,nload,nload,-p1)
 

--- a/openexr.mk
+++ b/openexr.mk
@@ -7,9 +7,7 @@ OPENEXR_VERSION := 2.5.3
 DEB_OPENEXR_V   ?= $(OPENEXR_VERSION)-1
 
 openexr-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/openexr-$(OPENEXR_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/openexr-$(OPENEXR_VERSION).tar.gz \
-			https://github.com/openexr/openexr/archive/v$(OPENEXR_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,openexr,openexr,$(OPENEXR_VERSION),v$(OPENEXR_VERSION))
 	$(call EXTRACT_TAR,openexr-$(OPENEXR_VERSION).tar.gz,openexr-$(OPENEXR_VERSION),openexr) 
 ifneq ($(wildcard $(BUILD_WORK)/openexr/.build_complete),)
 openexr:

--- a/openjdk.mk
+++ b/openjdk.mk
@@ -16,9 +16,7 @@ DEB_OPENJDK_V   ?= $(OPENJDK_VERSION)-2
 ###
 
 openjdk-setup: setup
-	-[ ! -e "$(BUILD_SOURCE)/openjdk-$(OPENJDK_COMMIT).tar.gz" ] \
-		&& wget -q -nc -O$(BUILD_SOURCE)/openjdk-$(OPENJDK_COMMIT).tar.gz \
-			https://github.com/openjdk/aarch64-port/archive/$(OPENJDK_COMMIT).tar.gz
+	$(call GITHUB_ARCHIVE,openjdk,aarch64-port,$(OPENJDK_COMMIT),$(OPENJDK_COMMIT),openjdk)
 	wget -q -nc -P $(BUILD_SOURCE) \
 		https://github.com/apple/cups/releases/download/v2.3.3/cups-2.3.3-source.tar.gz \
 		https://download.java.net/java/GA/jdk15/779bf45e88a44cbd9ea6621d33e33db1/36/GPL/openjdk-15_osx-x64_bin.tar.gz

--- a/openjpeg.mk
+++ b/openjpeg.mk
@@ -7,9 +7,7 @@ OPENJPEG_VERSION := 2.3.1
 DEB_OPENJPEG_V   ?= $(OPENJPEG_VERSION)
 
 openjpeg-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/openjpeg-$(OPENJPEG_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/openjpeg-$(OPENJPEG_VERSION).tar.gz \
-			https://github.com/uclouvain/openjpeg/archive/v$(OPENJPEG_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,uclouvain,openjpeg,$(OPENJPEG_VERSION),v$(OPENJPEG_VERSION))
 	$(call EXTRACT_TAR,openjpeg-$(OPENJPEG_VERSION).tar.gz,openjpeg-$(OPENJPEG_VERSION),openjpeg)
 
 ifneq ($(wildcard $(BUILD_WORK)/openjpeg/.build_complete),)

--- a/p7zip.mk
+++ b/p7zip.mk
@@ -7,9 +7,7 @@ P7ZIP_VERSION  := 17.03
 DEB_P7ZIP_V    ?= $(P7ZIP_VERSION)
 
 p7zip-setup: setup
-	-[ ! -e "$(BUILD_SOURCE)/p7zip-$(P7ZIP_VERSION).tar.gz" ] \
-		&& wget -q -nc -O$(BUILD_SOURCE)/p7zip-$(P7ZIP_VERSION).tar.gz \
-			https://github.com/jinfeihan57/p7zip/archive/v$(P7ZIP_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,jinfeihan57,p7zip,$(P7ZIP_VERSION),v$(P7ZIP_VERSION))
 	$(call EXTRACT_TAR,p7zip-$(P7ZIP_VERSION).tar.gz,p7zip-$(P7ZIP_VERSION),p7zip)
 	$(call DO_PATCH,p7zip,p7zip,-p1) # Remove after next release.
 	chmod 0755 $(BUILD_WORK)/p7zip/install.sh

--- a/pam-biometrics.mk
+++ b/pam-biometrics.mk
@@ -9,7 +9,7 @@ PAM-BIOMETRICS_VERSION := 1.1.2
 DEB_PAM-BIOMETRICS_V   ?= $(PAM-BIOMETRICS_VERSION)
 
 pam-biometrics-setup: setup
-	-wget -q -nc -O$(BUILD_SOURCE)/pam-biometrics-$(PAM-BIOMETRICS_VERSION).tar.gz https://github.com/ProcursusTeam/pam-biometrics/archive/refs/tags/$(PAM-BIOMETRICS_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,ProcursusTeam,pam-biometrics,$(PAM-BIOMETRICS_VERSION),$(PAM-BIOMETRICS_VERSION))
 	$(call EXTRACT_TAR,pam-biometrics-$(PAM-BIOMETRICS_VERSION).tar.gz,pam-biometrics-$(PAM-BIOMETRICS_VERSION),pam-biometrics)
 	mkdir -p $(BUILD_STAGE)/pam-biometrics/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/{share/man/man8,lib/pam}
 

--- a/pasteboard-utils.mk
+++ b/pasteboard-utils.mk
@@ -8,9 +8,7 @@ DEB_PASTEBOARD-UTILS_V        ?= $(PASTEBOARD-UTILS_VERSION)
 PASTEBOARD-UTILS_LIBS         := -framework Foundation -framework UIKit
 
 pasteboard-utils-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/pasteboard-utils-$(PASTEBOARD-UTILS_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/pasteboard-utils-$(PASTEBOARD-UTILS_VERSION).tar.gz \
-			https://github.com/quiprr/pasteboard-utils/archive/v$(PASTEBOARD-UTILS_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,quiprr,pasteboard-utils,$(PASTEBOARD-UTILS_VERSION),v$(PASTEBOARD-UTILS_VERSION))
 	$(call EXTRACT_TAR,pasteboard-utils-$(PASTEBOARD-UTILS_VERSION).tar.gz,pasteboard-utils-$(PASTEBOARD-UTILS_VERSION),pasteboard-utils)
 	mkdir -p $(BUILD_STAGE)/pasteboard-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin
 

--- a/pbzx.mk
+++ b/pbzx.mk
@@ -7,9 +7,7 @@ PBZX_VERSION   := 1.0.2
 DEB_PBZX_V     ?= $(PBZX_VERSION)
 
 pbzx-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/pbzx-$(PBZX_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/pbzx-$(PBZX_VERSION).tar.gz \
-			https://github.com/NiklasRosenstein/pbzx/archive/v$(PBZX_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,NiklasRosenstein,pbzx,$(PBZX_VERSION),v$(PBZX_VERSION))
 	$(call EXTRACT_TAR,pbzx-$(PBZX_VERSION).tar.gz,pbzx-$(PBZX_VERSION),pbzx)
 
 ifneq ($(wildcard $(BUILD_WORK)/pbzx/.build_complete),)

--- a/pfetch.mk
+++ b/pfetch.mk
@@ -7,8 +7,8 @@ PFETCH_VERSION := 0.6.0
 DEB_PFETCH_V   ?= $(PFETCH_VERSION)
 
 pfetch-setup: setup
-	wget -q -nc -P $(BUILD_SOURCE) https://github.com/dylanaraps/pfetch/archive/$(PFETCH_VERSION).tar.gz
-	$(call EXTRACT_TAR,$(PFETCH_VERSION).tar.gz,pfetch-$(PFETCH_VERSION),pfetch)
+	$(call GITHUB_ARCHIVE,dylanaraps,pfetch,$(PFETCH_VERSION),$(PFETCH_VERSION))
+	$(call EXTRACT_TAR,pfetch-$(PFETCH_VERSION).tar.gz,pfetch-$(PFETCH_VERSION),pfetch)
 
 ifneq ($(wildcard $(BUILD_WORK)/pfetch/.build_complete),)
 pfetch:

--- a/pincrush.mk
+++ b/pincrush.mk
@@ -7,8 +7,8 @@ PINCRUSH_VERSION := 0.9.2
 DEB_PINCRUSH_V   ?= $(PINCRUSH_VERSION)
 
 pincrush-setup: setup
-	wget -q -nc -P $(BUILD_SOURCE) https://github.com/DHowett/pincrush/archive/$(PINCRUSH_VERSION).tar.gz
-	$(call EXTRACT_TAR,$(PINCRUSH_VERSION).tar.gz,pincrush-$(PINCRUSH_VERSION),pincrush)
+	$(call GITHUB_ARCHIVE,DHowett,pincrush,$(PINCRUSH_VERSION),$(PINCRUSH_VERSION))
+	$(call EXTRACT_TAR,pincrush-$(PINCRUSH_VERSION).tar.gz,pincrush-$(PINCRUSH_VERSION),pincrush)
 	mkdir -p $(BUILD_STAGE)/pincrush/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin
 
 ifneq ($(wildcard $(BUILD_WORK)/pincrush/.build_complete),)

--- a/pojavlauncher.mk
+++ b/pojavlauncher.mk
@@ -12,9 +12,7 @@ POJAVLAUNCHER_VERSION   := 1.1+git20210304.$(shell echo $(POJAVLAUNCHER_COMMIT) 
 DEB_POJAVLAUNCHER_V     ?= $(POJAVLAUNCHER_VERSION)
 
 pojavlauncher-setup: setup
-	-[ ! -e "$(BUILD_SOURCE)/PojavLauncher_iOS-$(POJAVLAUNCHER_COMMIT).tar.gz" ] \
-		&& wget -q -nc -O$(BUILD_SOURCE)/PojavLauncher_iOS-$(POJAVLAUNCHER_COMMIT).tar.gz \
-			https://github.com/PojavLauncherTeam/PojavLauncher_iOS/archive/$(POJAVLAUNCHER_COMMIT).tar.gz
+	$(call GITHUB_ARCHIVE,PojavLauncherTeam,PojavLauncher_iOS,$(POJAVLAUNCHER_COMMIT),$(POJAVLAUNCHER_COMMIT))
 	$(call EXTRACT_TAR,PojavLauncher_iOS-$(POJAVLAUNCHER_COMMIT).tar.gz,PojavLauncher_iOS-$(POJAVLAUNCHER_COMMIT),pojavlauncher)
 	mkdir -p $(BUILD_STAGE)/pojavlauncher/{Applications,var/mobile/Documents/minecraft,var/mobile/Documents/.pojavlauncher}
 

--- a/pyyaml.mk
+++ b/pyyaml.mk
@@ -7,9 +7,7 @@ PYYAML_VERSION := 5.3.1
 DEB_PYYAML_V   ?= $(PYYAML_VERSION)
 
 pyyaml-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/pyyaml-$(PYYAML_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/pyyaml-$(PYYAML_VERSION).tar.gz \
-			https://github.com/yaml/pyyaml/archive/$(PYYAML_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,yaml,pyyaml,$(PYYAML_VERSION),$(PYYAML_VERSION))
 	$(call EXTRACT_TAR,pyyaml-$(PYYAML_VERSION).tar.gz,pyyaml-$(PYYAML_VERSION),pyyaml)
 
 ifneq ($(wildcard $(BUILD_WORK)/pyyaml/.build_complete),)

--- a/pzb.mk
+++ b/pzb.mk
@@ -7,8 +7,8 @@ PZB_VERSION := 36
 DEB_PZB_V   ?= $(PZB_VERSION)-1
 
 pzb-setup: setup
-	wget -q -nc -P $(BUILD_SOURCE) https://github.com/tihmstar/partialZipBrowser/archive/$(PZB_VERSION).tar.gz
-	$(call EXTRACT_TAR,$(PZB_VERSION).tar.gz,partialZipBrowser-$(PZB_VERSION),pzb)
+	$(call GITHUB_ARCHIVE,tihmstar,partialZipBrowser,$(PZB_VERSION),$(PZB_VERSION))
+	$(call EXTRACT_TAR,partialZipBrowser-$(PZB_VERSION).tar.gz,partialZipBrowser-$(PZB_VERSION),pzb)
 
 ifneq ($(wildcard $(BUILD_WORK)/pzb/.build_complete),)
 pzb:

--- a/rav1e.mk
+++ b/rav1e.mk
@@ -11,7 +11,7 @@ ifeq (, $(shell which cargo-cbuild))
 	$(error "No cargo-cbuild in PATH, please run cargo install cargo-c")
 endif
 
-	-[ ! -f "$(BUILD_SOURCE)/rav1e-$(RAV1E_VERSION).tar.gz" ] && wget -q -nc -O$(BUILD_SOURCE)/rav1e-$(RAV1E_VERSION).tar.gz https://github.com/xiph/rav1e/archive/v$(RAV1E_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,xiph,rav1e,$(RAV1E_VERSION),v$(RAV1E_VERSION))
 	$(call EXTRACT_TAR,rav1e-$(RAV1E_VERSION).tar.gz,rav1e-$(RAV1E_VERSION),rav1e)
 	$(call DO_PATCH,rav1e,rav1e,-p1)
 

--- a/rbw.mk
+++ b/rbw.mk
@@ -9,7 +9,7 @@ RBW_VERSION := 1.0.0
 DEB_RBW_V   ?= $(RBW_VERSION)
 
 rbw-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/rbw-$(RBW_VERSION).tar.gz" ] && wget -q -nc -O $(BUILD_SOURCE)/rbw-$(RBW_VERSION).tar.gz https://github.com/doy/rbw/archive/$(RBW_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,doy,rbw,$(RBW_VERSION),$(RBW_VERSION))
 	$(call EXTRACT_TAR,rbw-$(RBW_VERSION).tar.gz,rbw-$(RBW_VERSION),rbw)
 
 ifneq ($(wildcard $(BUILD_WORK)/rbw/.build_complete),)

--- a/rclone.mk
+++ b/rclone.mk
@@ -7,9 +7,7 @@ RCLONE_VERSION := 1.53.3
 DEB_RCLONE_V   ?= $(RCLONE_VERSION)
 
 rclone-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/rclone-$(RCLONE_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/rclone-$(RCLONE_VERSION).tar.gz \
-			https://github.com/rclone/rclone/archive/v$(RCLONE_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,rclone,rclone,$(RCLONE_VERSION),v$(RCLONE_VERSION))
 	$(call EXTRACT_TAR,rclone-$(RCLONE_VERSION).tar.gz,rclone-$(RCLONE_VERSION),rclone)
 	mkdir -p $(BUILD_STAGE)/rclone/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/{bin,share/man/man1}
 

--- a/ripgrep.mk
+++ b/ripgrep.mk
@@ -7,7 +7,7 @@ RIPGREP_VERSION := 12.1.1
 DEB_RIPGREP_V   ?= $(RIPGREP_VERSION)
 
 ripgrep-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/ripgrep-$(RIPGREP_VERSION).tar.gz" ] && wget -q -nc -O$(BUILD_SOURCE)/ripgrep-$(RIPGREP_VERSION).tar.gz https://github.com/BurntSushi/ripgrep/archive/$(RIPGREP_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,BurntSushi,ripgrep,$(RIPGREP_VERSION),$(RIPGREP_VERSION))
 	$(call EXTRACT_TAR,ripgrep-$(RIPGREP_VERSION).tar.gz,ripgrep-$(RIPGREP_VERSION),ripgrep)
 
 ifneq ($(wildcard $(BUILD_WORK)/ripgrep/.build_complete),)

--- a/rust.mk
+++ b/rust.mk
@@ -11,9 +11,7 @@ DEB_RUST_V   ?= $(RUST_VERSION)
 ##### THIS MAKEFILE IS CURRENTLY WIP AGAIN #####
 
 rust-setup: setup
-	-[[ ! -f $(BUILD_SOURCE)/rust-$(RUST_VERSION).tar.gz ]] && \
-		wget -q -nc -O $(BUILD_SOURCE)/rust-$(RUST_VERSION).tar.gz \
-			https://github.com/rust-lang/rust/archive/$(RUST_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,rust-lang,rust,$(RUST_VERSION),$(RUST_VERSION))
 	$(call EXTRACT_TAR,rust-$(RUST_VERSION).tar.gz,rust-$(RUST_VERSION),rust)
 
 	mkdir -p "$(BUILD_WORK)/rust/build"

--- a/sl.mk
+++ b/sl.mk
@@ -7,7 +7,7 @@ SL_VERSION  := 5.05
 DEB_SL_V    ?= $(SL_VERSION)
 
 sl-setup: setup
-	-[[ ! -f $(BUILD_SOURCE)/sl-$(SL_VERSION).tar.gz ]] && wget -q -nc -O $(BUILD_SOURCE)/sl-$(SL_VERSION).tar.gz https://github.com/eyJhb/sl/archive/$(SL_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,eyJhb,sl,$(SL_VERSION),$(SL_VERSION))
 	$(call EXTRACT_TAR,sl-$(SL_VERSION).tar.gz,sl-$(SL_VERSION),sl)
 	mkdir -p $(BUILD_STAGE)/sl/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin
 

--- a/snaputil.mk
+++ b/snaputil.mk
@@ -7,9 +7,7 @@ SNAPUTIL_VERSION := 10.15.1
 DEB_SNAPUTIL_V   ?= $(SNAPUTIL_VERSION)
 
 snaputil-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/snaputil-$(SNAPUTIL_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/snaputil-$(SNAPUTIL_VERSION).tar.gz \
-			https://github.com/Diatrus/apfs/archive/v$(SNAPUTIL_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,Diatrus,apfs,$(SNAPUTIL_VERSION),v$(SNAPUTIL_VERSION),snaputil)
 	$(call EXTRACT_TAR,snaputil-$(SNAPUTIL_VERSION).tar.gz,apfs-$(SNAPUTIL_VERSION),snaputil)
 	mkdir -p $(BUILD_STAGE)/snaputil/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin
 

--- a/speedtest-cli.mk
+++ b/speedtest-cli.mk
@@ -7,9 +7,7 @@ SPEEDTEST-CLI_VERSION := 2.1.2
 DEB_SPEEDTEST-CLI_V   ?= $(SPEEDTEST-CLI_VERSION)-1
 
 speedtest-cli-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/speedtest-cli-$(SPEEDTEST-CLI_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/speedtest-cli-$(SPEEDTEST-CLI_VERSION).tar.gz \
-			https://github.com/sivel/speedtest-cli/archive/v$(SPEEDTEST-CLI_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,sivel,speedtest-cli,$(SPEEDTEST-CLI_VERSION),v$(SPEEDTEST-CLI_VERSION))
 	$(call EXTRACT_TAR,speedtest-cli-$(SPEEDTEST-CLI_VERSION).tar.gz,speedtest-cli-$(SPEEDTEST-CLI_VERSION),speedtest-cli)
 
 ifneq ($(wildcard $(BUILD_WORK)/speedtest-cli/.build_complete),)

--- a/starship.mk
+++ b/starship.mk
@@ -7,7 +7,7 @@ STARSHIP_VERSION := 0.51.0
 DEB_STARSHIP_V   ?= $(STARSHIP_VERSION)
 
 starship-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/starship-$(STARSHIP_VERSION).tar.gz" ] && wget -q -nc -O$(BUILD_SOURCE)/starship-$(STARSHIP_VERSION).tar.gz https://github.com/starship/starship/archive/v$(STARSHIP_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,starship,starship,$(STARSHIP_VERSION),v$(STARSHIP_VERSION))
 	$(call EXTRACT_TAR,starship-$(STARSHIP_VERSION).tar.gz,starship-$(STARSHIP_VERSION),starship)
 	# remove this when the following upstream PRs are merged:
 	#  https://github.com/FillZpp/sys-info-rs/pull/88

--- a/sudoku.mk
+++ b/sudoku.mk
@@ -7,9 +7,7 @@ SUDOKU_VERSION  := 1.0.5
 DEB_SUDOKU_V    ?= $(SUDOKU_VERSION)
 
 sudoku-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/sudoku-$(SUDOKU_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/sudoku-$(SUDOKU_VERSION).tar.gz \
-			https://github.com/cinemast/sudoku/archive/v$(SUDOKU_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,cinemast,sudoku,$(SUDOKU_VERSION),v$(SUDOKU_VERSION))
 	$(call EXTRACT_TAR,sudoku-$(SUDOKU_VERSION).tar.gz,sudoku-$(SUDOKU_VERSION),sudoku)
 	$(call DO_PATCH,sudoku,sudoku,-p1)
 

--- a/system-cmds.mk
+++ b/system-cmds.mk
@@ -40,13 +40,9 @@ system-cmds-setup: setup libxcrypt
 
 	$(SED) -i '/#include <stdio.h>/a #include <crypt.h>' $(BUILD_WORK)/system-cmds/login.tproj/login.c
 	$(SED) -i '/#include <libutil.h>/a #include <crypt.h>' $(BUILD_WORK)/system-cmds/chpass.tproj/chpass.c
-	-[ ! -e "$(BUILD_SOURCE)/pw-darwin-$(PWDARWIN_COMMIT).tar.gz" ] \
-		&& wget -q -nc -O$(BUILD_SOURCE)/pw-darwin-$(PWDARWIN_COMMIT).tar.gz \
-			https://github.com/CRKatri/pw-darwin/archive/$(PWDARWIN_COMMIT).tar.gz
+	$(call GITHUB_ARCHIVE,CRKatri,pw-darwin,$(PWDARWIN_COMMIT),$(PWDARWIN_COMMIT))
 	$(call EXTRACT_TAR,pw-darwin-$(PWDARWIN_COMMIT).tar.gz,pw-darwin-$(PWDARWIN_COMMIT),system-cmds/pw-darwin)
-	-[ ! -e "$(BUILD_SOURCE)/getent-darwin-$(GETENTDARWIN_COMMIT).tar.gz" ] \
-		&& wget -q -nc -O$(BUILD_SOURCE)/getent-darwin-$(GETENTDARWIN_COMMIT).tar.gz \
-			https://github.com/CRKatri/getent-darwin/archive/$(GETENTDARWIN_COMMIT).tar.gz
+	$(call GITHUB_ARCHIVE,CRKatri,getent-darwin,$(GETENTDARWIN_COMMIT),$(GETENTDARWIN_COMMIT))
 	$(call EXTRACT_TAR,getent-darwin-$(GETENTDARWIN_COMMIT).tar.gz,getent-darwin-$(GETENTDARWIN_COMMIT),system-cmds/getent-darwin)
 
 ifneq ($(wildcard $(BUILD_WORK)/system-cmds/.build_complete),)

--- a/tapi.mk
+++ b/tapi.mk
@@ -7,9 +7,7 @@ TAPI_VERSION   := 1100.0.11
 DEB_TAPI_V     ?= $(TAPI_VERSION)
 
 tapi-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/tapi-$(TAPI_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/tapi-$(TAPI_VERSION).tar.gz \
-			https://github.com/Diatrus/apple-libtapi/archive/v$(TAPI_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,Diatrus,apple-libtapi,$(TAPI_VERSION),v$(TAPI_VERSION),tapi)
 	$(call EXTRACT_TAR,tapi-$(TAPI_VERSION).tar.gz,apple-libtapi-$(TAPI_VERSION),tapi)
 	mkdir -p $(BUILD_WORK)/tapi/build
 

--- a/tesseract.mk
+++ b/tesseract.mk
@@ -12,9 +12,7 @@ DEB_TESSERACT_V   ?= $(TESSERACT_VERSION)
 ###
 
 tesseract-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/tesseract-$(TESSERACT_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/tesseract-$(TESSERACT_VERSION).tar.gz \
-			https://github.com/tesseract-ocr/tesseract/archive/$(TESSERACT_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,tesseract-ocr,tesseract,$(TESSERACT_VERSION),$(TESSERACT_VERSION))
 	$(call EXTRACT_TAR,tesseract-$(TESSERACT_VERSION).tar.gz,tesseract-$(TESSERACT_VERSION),tesseract)
 
 ifneq ($(wildcard $(BUILD_WORK)/tesseract/.build_complete),)

--- a/tsschecker.mk
+++ b/tsschecker.mk
@@ -8,12 +8,12 @@ TSSCHECKER_COMMIT  := 10440005e2ab5f950f76368a0456ad69677da71b
 DEB_TSSCHECKER_V   ?= $(TSSCHECKER_VERSION)-1
 
 tsschecker-setup: setup
-	wget -q -nc -P $(BUILD_SOURCE) https://github.com/tihmstar/tsschecker/archive/$(TSSCHECKER_COMMIT).tar.gz
-	-[ ! -f "$(BUILD_SOURCE)/jssy.tar.gz" ] && wget -q -nc -O$(BUILD_SOURCE)/jssy.tar.gz https://github.com/tihmstar/jssy/tarball/master
-	$(call EXTRACT_TAR,$(TSSCHECKER_COMMIT).tar.gz,tsschecker-$(TSSCHECKER_COMMIT),tsschecker)
+	$(call GITHUB_ARCHIVE,tihmstar,tsschecker,$(TSSCHECKER_COMMIT),$(TSSCHECKER_COMMIT))
+	$(call GITHUB_ARCHIVE,tihmstar,jssy,master,master)
+	$(call EXTRACT_TAR,tsschecker-$(TSSCHECKER_COMMIT).tar.gz,tsschecker-$(TSSCHECKER_COMMIT),tsschecker)
 	# so EXTRACT_TAR wont fail
 	-rmdir $(BUILD_WORK)/tsschecker/external/jssy
-	$(call EXTRACT_TAR,jssy.tar.gz,tihmstar-jssy-*,tsschecker/external/jssy)
+	$(call EXTRACT_TAR,jssy-master.tar.gz,tihmstar-jssy-*,tsschecker/external/jssy)
 	$(call DO_PATCH,tsschecker,tsschecker,-p1) # Remove when PR 165 merged upstream.
 
 

--- a/uikittools.mk
+++ b/uikittools.mk
@@ -11,9 +11,7 @@ UIKITTOOLS_VERSION := 2.0.3
 DEB_UIKITTOOLS_V   ?= $(UIKITTOOLS_VERSION)
 
 uikittools-setup: setup
-	-[ ! -e "$(BUILD_SOURCE)/uikittools-ng-$(UIKITTOOLS_VERSION).tar.gz" ] \
-		&& wget -q -nc -O$(BUILD_SOURCE)/uikittools-ng-$(UIKITTOOLS_VERSION).tar.gz \
-			https://github.com/Diatrus/uikittools-ng/archive/v$(UIKITTOOLS_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,Diatrus,uikittools-ng,$(UIKITTOOLS_VERSION),v$(UIKITTOOLS_VERSION))
 	$(call EXTRACT_TAR,uikittools-ng-$(UIKITTOOLS_VERSION).tar.gz,uikittools-ng-$(UIKITTOOLS_VERSION),uikittools)
 
 ifneq ($(wildcard $(BUILD_WORK)/uikittools/.build_complete),)

--- a/unibilium.mk
+++ b/unibilium.mk
@@ -7,9 +7,7 @@ UNIBILIUM_VERSION := 2.1.0
 DEB_UNIBILIUM_V   ?= $(UNIBILIUM_VERSION)
 
 unibilium-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/unibilium-$(UNIBILIUM_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/unibilium-$(UNIBILIUM_VERSION).tar.gz \
-			https://github.com/neovim/unibilium/archive/v$(UNIBILIUM_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,neovim,unibilium,$(UNIBILIUM_VERSION),v$(UNIBILIUM_VERSION))
 	$(call EXTRACT_TAR,unibilium-$(UNIBILIUM_VERSION).tar.gz,unibilium-$(UNIBILIUM_VERSION),unibilium)
 	$(call DO_PATCH,unibilium,unibilium)
 	mkdir -p $(BUILD_WORK)/unibilium/libtool

--- a/upx.mk
+++ b/upx.mk
@@ -7,8 +7,8 @@ UPX_VERSION := 3.96
 DEB_UPX_V   ?= $(UPX_VERSION)
 
 upx-setup: setup
-	wget -O $(BUILD_SOURCE)/upx-$(UPX_VERSION).tar.gz https://github.com/upx/upx/archive/refs/tags/v$(UPX_VERSION).tar.gz
-	wget -O $(BUILD_SOURCE)/upx-lzma-sdk-$(UPX_VERSION).tar.gz https://github.com/upx/upx-lzma-sdk/archive/refs/tags/v$(UPX_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,upx,upx,$(UPX_VERSION),v$(UPX_VERSION))
+	$(call GITHUB_ARCHIVE,upx,upx-lzma-sdk,$(UPX_VERSION),v$(UPX_VERSION))
 	$(call EXTRACT_TAR,upx-$(UPX_VERSION).tar.gz,upx-$(UPX_VERSION),upx)
 	rm -rf $(BUILD_WORK)/upx/src/lzma-sdk
 	$(call EXTRACT_TAR,upx-lzma-sdk-$(UPX_VERSION).tar.gz,upx-lzma-sdk-$(UPX_VERSION),upx/src/lzma-sdk/)

--- a/usbfluxd.mk
+++ b/usbfluxd.mk
@@ -8,9 +8,7 @@ USBFLUXD_VERSION := 1.2.0+git20200925.$(shell echo $(USBFLUXD_COMMIT) | cut -c -
 DEB_USBFLUXD_V   ?= $(USBFLUXD_VERSION)
 
 usbfluxd-setup: setup
-	-[ ! -e "$(BUILD_SOURCE)/usbfluxd-$(USBFLUXD_VERSION).tar.gz" ] \
-		&& wget -q -nc -O$(BUILD_SOURCE)/usbfluxd-$(USBFLUXD_VERSION).tar.gz \
-			https://github.com/corellium/usbfluxd/archive/$(USBFLUXD_COMMIT).tar.gz
+	$(call GITHUB_ARCHIVE,corellium,usbfluxd,$(USBFLUXD_VERSION),$(USBFLUXD_COMMIT))
 	$(call EXTRACT_TAR,usbfluxd-$(USBFLUXD_VERSION).tar.gz,usbfluxd-$(USBFLUXD_COMMIT),usbfluxd)
 	$(call DO_PATCH,usbfluxd,usbfluxd,-p1)
 

--- a/usbmuxd2.mk
+++ b/usbmuxd2.mk
@@ -9,9 +9,7 @@ DEB_USBMUXD2_V   ?= $(USBMUXD2_VERSION)
 USBMUXD2_COMMIT  := 8bff9068f0245659bb4f10b33a6a1b2ea4630dfe
 
 usbmuxd2-setup: setup
-	-[ ! -e "$(BUILD_SOURCE)/usbmuxd2-$(USBMUXD2_VERSION).tar.gz" ] \
-		&& wget -q -nc -O$(BUILD_SOURCE)/usbmuxd2-$(USBMUXD2_VERSION).tar.gz \
-			https://github.com/tihmstar/usbmuxd2/archive/$(USBMUXD2_COMMIT).tar.gz
+	$(call GITHUB_ARCHIVE,tihmstar,usbmuxd2,$(USBMUXD2_VERSION),$(USBMUXD2_COMMIT))
 	$(call EXTRACT_TAR,usbmuxd2-$(USBMUXD2_VERSION).tar.gz,usbmuxd2-$(USBMUXD2_COMMIT),usbmuxd2)
 	$(SED) -i 's/2.2.1/2.2.0/' $(BUILD_WORK)/usbmuxd2/configure.ac
 	$(SED) -i '/-lstdc++fs/d' $(BUILD_WORK)/usbmuxd2/configure.ac

--- a/vim.mk
+++ b/vim.mk
@@ -8,9 +8,7 @@ VIM_VERSION := 8.2.1800
 DEB_VIM_V   ?= $(VIM_VERSION)
 
 vim-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/vim-$(VIM_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/vim-$(VIM_VERSION).tar.gz \
-			https://github.com/vim/vim/archive/v$(VIM_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,vim,vim,$(VIM_VERSION),v$(VIM_VERSION))
 	$(call EXTRACT_TAR,vim-$(VIM_VERSION).tar.gz,vim-$(VIM_VERSION),vim)
 
 ifneq ($(wildcard $(BUILD_WORK)/vim/.build_complete),)

--- a/xpwn.mk
+++ b/xpwn.mk
@@ -8,10 +8,8 @@ XPWN_VERSION := 0.5.8+git20201206.$(shell echo $(XPWN_COMMIT) | cut -c -7)
 DEB_XPWN_V   ?= $(XPWN_VERSION)
 
 xpwn-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/xpwn-v$(XPWN_COMMIT).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/xpwn-v$(XPWN_COMMIT).tar.gz \
-			https://github.com/OothecaPickle/xpwn/archive/$(XPWN_COMMIT).tar.gz
-	$(call EXTRACT_TAR,xpwn-v$(XPWN_COMMIT).tar.gz,xpwn-$(XPWN_COMMIT),xpwn)
+	$(call GITHUB_ARCHIVE,OothecaPickle,xpwn,$(XPWN_COMMIT),$(XPWN_COMMIT))
+	$(call EXTRACT_TAR,xpwn-$(XPWN_COMMIT).tar.gz,xpwn-$(XPWN_COMMIT),xpwn)
 	$(call DO_PATCH,xpwn,xpwn,-p1)
 
 	$(SED) -i 's/powerpc-apple-darwin8-libtool/libtool/' $(BUILD_WORK)/xpwn/ipsw-patch/CMakeLists.txt

--- a/xxhash.mk
+++ b/xxhash.mk
@@ -7,9 +7,7 @@ XXHASH_VERSION := 0.8.0
 DEB_XXHASH_V   ?= $(XXHASH_VERSION)
 
 xxhash-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/xxhash-$(XXHASH_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/xxhash-$(XXHASH_VERSION).tar.gz \
-			https://github.com/Cyan4973/xxhash/archive/v$(XXHASH_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,Cyan4973,xxhash,$(XXHASH_VERSION),v$(XXHASH_VERSION))
 	$(call EXTRACT_TAR,xxhash-$(XXHASH_VERSION).tar.gz,xxHash-$(XXHASH_VERSION),xxhash)
 	$(SED) -i 's/UNAME :=/UNAME ?=/' $(BUILD_WORK)/xxhash/Makefile
 

--- a/zlib-ng.mk
+++ b/zlib-ng.mk
@@ -7,7 +7,7 @@ ZLIB-NG_VERSION  := 2.0.2
 DEB_ZLIB-NG_V    ?= $(ZLIB-NG_VERSION)
 
 zlib-ng-setup: setup
-	-wget -q -nc -O$(BUILD_SOURCE)/zlib-ng-$(ZLIB-NG_VERSION).tar.gz https://github.com/zlib-ng/zlib-ng/archive/refs/tags/$(ZLIB-NG_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,zlib-ng,zlib-ng,$(ZLIB-NG_VERSION),$(ZLIB-NG_VERSION))
 	$(call EXTRACT_TAR,zlib-ng-$(ZLIB-NG_VERSION).tar.gz,zlib-ng-$(ZLIB-NG_VERSION),zlib-ng)
 ifneq ($(wildcard $(BUILD_WORK)/zlib-ng/.build_complete),)
 zlib-ng:

--- a/zsh-autosuggestions.mk
+++ b/zsh-autosuggestions.mk
@@ -7,9 +7,7 @@ ZSH-AUTOSUGGESTIONS_VERSION := 0.6.4
 DEB_ZSH-AUTOSUGGESTIONS_V   ?= $(ZSH-AUTOSUGGESTIONS_VERSION)
 
 zsh-autosuggestions-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/zsh-autosuggestions-$(ZSH-AUTOSUGGESTIONS_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/zsh-autosuggestions-$(ZSH-AUTOSUGGESTIONS_VERSION).tar.gz \
-			https://github.com/zsh-users/zsh-autosuggestions/archive/v$(ZSH-AUTOSUGGESTIONS_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,zsh-users,zsh-autosuggestions,$(ZSH-AUTOSUGGESTIONS_VERSION),v$(ZSH-AUTOSUGGESTIONS_VERSION))
 	$(call EXTRACT_TAR,zsh-autosuggestions-$(ZSH-AUTOSUGGESTIONS_VERSION).tar.gz,zsh-autosuggestions-$(ZSH-AUTOSUGGESTIONS_VERSION),zsh-autosuggestions)
 
 ifneq ($(wildcard $(BUILD_WORK)/zsh-autosuggestions/.build_complete),)

--- a/zsh-syntax-highlighting.mk
+++ b/zsh-syntax-highlighting.mk
@@ -7,9 +7,7 @@ ZSH-SYNTAX-HIGHLIGHTING_VERSION := 0.7.1
 DEB_ZSH-SYNTAX-HIGHLIGHTING_V   ?= $(ZSH-SYNTAX-HIGHLIGHTING_VERSION)
 
 zsh-syntax-highlighting-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/zsh-syntax-highlighting-$(ZSH-SYNTAX-HIGHLIGHTING_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/zsh-syntax-highlighting-$(ZSH-SYNTAX-HIGHLIGHTING_VERSION).tar.gz \
-			https://github.com/zsh-users/zsh-syntax-highlighting/archive/$(ZSH-SYNTAX-HIGHLIGHTING_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,zsh-users,zsh-syntax-highlighting,$(ZSH-SYNTAX-HIGHLIGHTING_VERSION),$(ZSH-SYNTAX-HIGHLIGHTING_VERSION))
 	$(call EXTRACT_TAR,zsh-syntax-highlighting-$(ZSH-SYNTAX-HIGHLIGHTING_VERSION).tar.gz,zsh-syntax-highlighting-$(ZSH-SYNTAX-HIGHLIGHTING_VERSION),zsh-syntax-highlighting)
 
 ifneq ($(wildcard $(BUILD_WORK)/zsh-syntax-highlighting/.build_complete),)

--- a/zsign.mk
+++ b/zsign.mk
@@ -8,9 +8,7 @@ ZSIGN_VERSION := 0~20210202.$(shell echo $(ZSIGN_COMMIT) | cut -c -7)
 DEB_ZSIGN_V   := $(ZSIGN_VERSION)-1
 
 zsign-setup: setup
-	-[ ! -e "$(BUILD_SOURCE)/zsign-$(ZSIGN_COMMIT).tar.gz" ] \
-		&& wget -nc -O$(BUILD_SOURCE)/zsign-$(ZSIGN_COMMIT).tar.gz \
-			https://github.com/zhlynn/zsign/archive/$(ZSIGN_COMMIT).tar.gz
+	$(call GITHUB_ARCHIVE,zhlynn,zsign,$(ZSIGN_COMMIT),$(ZSIGN_COMMIT))
 	$(call EXTRACT_TAR,zsign-$(ZSIGN_COMMIT).tar.gz,zsign-$(ZSIGN_COMMIT)*,zsign)
 
 ifneq ($(wildcard $(BUILD_WORK)/zsign/.build_complete),)

--- a/zstd.mk
+++ b/zstd.mk
@@ -7,9 +7,7 @@ ZSTD_VERSION  := 1.4.9
 DEB_ZSTD_V    ?= $(ZSTD_VERSION)
 
 zstd-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/zstd-$(ZSTD_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/zstd-$(ZSTD_VERSION).tar.gz \
-			https://github.com/facebook/zstd/archive/v$(ZSTD_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,facebook,zstd,$(ZSTD_VERSION),v$(ZSTD_VERSION))
 	$(call EXTRACT_TAR,zstd-$(ZSTD_VERSION).tar.gz,zstd-$(ZSTD_VERSION),zstd)
 
 ifneq ($(wildcard $(BUILD_WORK)/zstd/.build_complete),)


### PR DESCRIPTION
This pull request adds a new function, `GITHUB_ARCHIVE`, that can be used to download an archive from github.

---

**Parameters:**
| Index | Required | Description |
| :-: | :-: |--- |
| 1 | yes | GitHub user or organisation that owns the repository |
| 2 | yes | the repository to create the archive from, is used as the tarball filename unless parameter `5` is specified |
| 3 | yes | the version to append the tarball filename |
| 4 | yes | tag, commit or branch to archive |
| 5 | no | tarball firename to use if it should be different than the repository specified in parameter `3` |

---

**Tag example:**
```makefile
APPUNINST_VERSION := 1.0.0

$(call GITHUB_ARCHIVE,quiprr,appuninst,$(APPUNINST_VERSION),v$(APPUNINST_VERSION))

# URL:     https://github.com/quiprr/appuninst/archive/v1.0.0.tar.gz
# tarball: $(BUILD_SOURCE)/appuninst-1.0.0.tar.gz
```

**Commit example:**
```makefile
ZBRFIRMWARE_COMMIT  := e4b7cf07bb491ecdbf08519063d7a9fa16aefdb8

$(call GITHUB_ARCHIVE,zbrateam,Firmware,$(ZBRFIRMWARE_COMMIT),$(ZBRFIRMWARE_COMMIT))

# URL:     https://github.com/zbrateam/Firmware/archive/e4b7cf07bb491ecdbf08519063d7a9fa16aefdb8.tar.gz
# tarball: $(BUILD_SOURCE)/Firmware-e4b7cf07bb491ecdbf08519063d7a9fa16aefdb8.tar.gz
```

**Branch example:**
```makefile
$(call GITHUB_ARCHIVE,tihmstar,jssy,master,master)

# URL:     https://github.com/tihmstar/jssy/archive/master.tar.gz
# tarball: $(BUILD_SOURCE)/jssy-master.tar.gz
```

**Different tarball name example:**
```makefile
GHOSTBIN_COMMIT   := 0e0a3b72c3379e51bf03fe676af3a74a01239a47

$(call GITHUB_ARCHIVE,DHowett,spectre,v$(GHOSTBIN_COMMIT),$(GHOSTBIN_COMMIT),ghostbin)

# URL:     https://github.com/DHowett/spectre/archive/0e0a3b72c3379e51bf03fe676af3a74a01239a47.tar.gz
# tarball: $(BUILD_SOURCE)/ghostbin-v0e0a3b72c3379e51bf03fe676af3a74a01239a47.tar.gz
```