### PR TITLE
Case insensitive grepping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ ifeq ($(firstword $(subst ., ,$(MAKE_VERSION))),3)
 $(error Install latest make from Homebrew - brew install make)
 endif
 
-ifeq ($(shell /usr/bin/env bash --version | grep -q 'version 5' && echo 1),1)
+ifeq ($(shell /usr/bin/env bash --version | grep -iq 'version 5' && echo 1),1)
 SHELL := /usr/bin/env bash
 else
 $(error Install bash 5.0)


### PR DESCRIPTION
`bash --version` gives on my machine
```
GNU bash, Version 5.1.4(1)-release (x86_64-apple-darwin20.2.0)
```
Thus you should do case insensitive grepping for the string.