### PR TITLE
Critical fix for gzip

### DIFF
--- a/build_info/gzip.control
+++ b/build_info/gzip.control
@@ -1,8 +1,6 @@
 Package: gzip
 Version: @DEB_GZIP_V@
 Architecture: @DEB_ARCH@
-Replaces: file-cmds (<= 272.250.1-1)
-Conflicts: file-cmds (<= 272.250.1-1)
 Maintainer: @DEB_MAINTAINER@
 Section: Archiving
 Priority: standard


### PR DESCRIPTION
Since the new updates to ``file-cmds``, users were affected by a small, but pretty significant "restriction", which removed Filza and other dependencies once upgrading. This PR fixes that by removing such "restriction" from ``gzip``'s control file, allowing affected users to install Filza again without issues.