### PR TITLE
Revert back file structure consistency on zsh

### DIFF
--- a/zsh.mk
+++ b/zsh.mk
@@ -8,7 +8,7 @@ else # ($(MEMO_TARGET),darwin-\*)
 SUBPROJECTS   += zsh
 endif # ($(MEMO_TARGET),darwin-\*)
 ZSH_VERSION   := 5.8
-DEB_ZSH_V     ?= $(ZSH_VERSION)-3
+DEB_ZSH_V     ?= $(ZSH_VERSION)-4
 
 zsh-setup: setup
 	wget -q -nc -P $(BUILD_SOURCE) https://www.zsh.org/pub/zsh-$(ZSH_VERSION).tar.xz{,.asc}
@@ -33,11 +33,11 @@ zsh: zsh-setup pcre ncurses
 		--build=$$($(BUILD_MISC)/config.guess) \
 		--host=$(GNU_HOST_TRIPLE) \
 		--prefix=$(MEMO_PREFIX)$(MEMO_SUB_PREFIX) \
-		--enable-fndir=$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/functions \
-		--enable-scriptdir=$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/scripts \
+		--enable-fndir=$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/zsh/functions \
+		--enable-scriptdir=$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/zsh/scripts \
 		--enable-site-fndir=$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/zsh/site-functions \
 		--enable-site-scriptdir=$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/zsh/site-scripts \
-		--enable-runhelpdir=$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/help \
+		--enable-runhelpdir=$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/zsh/help \
 		--enable-cap \
 		--enable-pcre \
 		--enable-multibyte \


### PR DESCRIPTION
This PR provides a small change to ``zsh`` and its flags to moves zsh-related files back to their designated path, ``/usr/share/zsh/``, maintaining consistency. This also bumps the version as means of pushing a new update to the package. Suggestions to changes are welcome!

