### PR TITLE
Update youtube-dl to latest version

### DIFF
--- a/youtube-dl.mk
+++ b/youtube-dl.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS        += youtube-dl
-YOUTUBE-DL_VERSION := 2021.03.03
+YOUTUBE-DL_VERSION := 2021.04.01
 DEB_YOUTUBE-DL_V   ?= $(YOUTUBE-DL_VERSION)
 
 youtube-dl-setup: setup


### PR DESCRIPTION
This PR updates ``youtube-dl`` to the latest released version. This should fix any errors users experience with older installations. Go outside with your friends and prank your boss today!