### PR TITLE
Critical: Filter out iPods in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ EXTRA    := INSTALL="/usr/bin/install -c --strip-program=$(STRIP)"
 LIBTOOL  := $(GNU_HOST_TRIPLE)-libtool
 
 else ifeq ($(UNAME),Darwin)
-ifeq ($(filter $(shell uname -m | cut -c -4), iPad iPho),)
+ifeq ($(filter $(shell uname -m | cut -c -4), iPad iPho iPod),)
 $(warning Building on MacOS)
 TARGET_SYSROOT  ?= $(shell xcrun --sdk $(PLATFORM) --show-sdk-path)
 MACOSX_SYSROOT  ?= $(shell xcrun --show-sdk-path)


### PR DESCRIPTION
This small, but pretty significant PR filters iPods in the Makefile, preventing Procursus from using incorrect variables.

What happens is that, prior to this change, Procursus would "report" that packages were being built on macOS, despite that not being the case (they were actually being built on an iPod). This fixes the issue, meaning that iPods are now recognized as an iOS platform, and the correct iOS variables are used.