### PR TITLE
Add theos metapackages

### DIFF
--- a/build_info/ios-toolchain.control
+++ b/build_info/ios-toolchain.control
@@ -1,0 +1,14 @@
+Package: ios-toolchain
+Version: @DEB_THEOSDEPS_V@
+Architecture: @DEB_ARCH@
+Maintainer: @DEB_MAINTAINER@
+Depends: clang, ldid, make, odcctools
+Conflicts: org.coolstar.iostoolchain
+Provides: org.coolstar.iostoolchain
+Replaces: org.coolstar.iostoolchain
+Section: Utilities
+Priority: optional
+Tag: purpose::console, role::developer
+Description: LLVM+Clang, ld64, Darwin CC Tools, Make, ldid
+    This metapackage installs LLVM+Clang, ld64, Darwin CC Tools, GNU Make, and ldid in one go.
+Name: iOS Toolchain

--- a/build_info/theos-dependencies.control
+++ b/build_info/theos-dependencies.control
@@ -4,7 +4,7 @@ Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
 Pre-Depends: coreutils, dpkg, firmware (>= 11.0)
 Depends: ca-certificates, git, grep, ios-toolchain, perl, rsync, unzip, xz-utils
-Recommends: plutil, swift
+Recommends: plutil
 Conflicts: org.theos.dependencies
 Provides: org.theos.dependencies
 Replaces: org.theos.dependencies

--- a/build_info/theos-dependencies.control
+++ b/build_info/theos-dependencies.control
@@ -1,0 +1,15 @@
+Packages: theos-dependencies
+Version: @DEB_THEOSDEPS_V@
+Architecture: @DEB_ARCH@
+Maintainer: @DEB_MAINTAINER@
+Pre-Depends: coreutils, dpkg, firmware (>= 11.0)
+Depends: ca-certificates, git, grep, ios-toolchain, perl, rsync, unzip, xz-utils
+Conflicts: org.theos.dependencies
+Provides: org.theos.dependencies
+Replaces: org.theos.dependencies
+Section: Utilities
+Priority: optional
+Tags: purpose::console, role::developer
+Description: What Theos needs.
+    This metapackage installs grep, rsync, unzip, Git, Perl, CA Certs, XZ Utils, and the iOS Toolchain in one go.
+Name: Theos Dependencies

--- a/build_info/theos-dependencies.control
+++ b/build_info/theos-dependencies.control
@@ -4,7 +4,7 @@ Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
 Pre-Depends: coreutils, dpkg, firmware (>= 11.0)
 Depends: ca-certificates, git, grep, ios-toolchain, perl, rsync, unzip, xz-utils
-Recommends: plutil
+Recommends: plutil, swift
 Conflicts: org.theos.dependencies
 Provides: org.theos.dependencies
 Replaces: org.theos.dependencies

--- a/build_info/theos-dependencies.control
+++ b/build_info/theos-dependencies.control
@@ -4,6 +4,7 @@ Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
 Pre-Depends: coreutils, dpkg, firmware (>= 11.0)
 Depends: ca-certificates, git, grep, ios-toolchain, perl, rsync, unzip, xz-utils
+Recommends: plutil, swift
 Conflicts: org.theos.dependencies
 Provides: org.theos.dependencies
 Replaces: org.theos.dependencies

--- a/build_info/theos-dependencies.control
+++ b/build_info/theos-dependencies.control
@@ -1,4 +1,4 @@
-Packages: theos-dependencies
+Package: theos-dependencies
 Version: @DEB_THEOSDEPS_V@
 Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@

--- a/theos-dependencies.mk
+++ b/theos-dependencies.mk
@@ -1,0 +1,28 @@
+ifneq ($(PROCURSUS),1)
+$(error Use the main Makefile)
+endif
+
+SUBPROJECTS     += theos-dependencies
+THEOSDEPS_VER   := 0-1
+DEB_THEOSDEPS_V ?= $(THEOSDEPS_VER)
+
+theos-dependencies: setup
+	@echo "Theos dependencies is just a metapackage"
+
+theos-dependencies-package: theos-dependencies-stage
+	# theos-dependencies.mk Package Structure
+	rm -rf $(BUILD_DIST)/ios-toolchain
+	rm -rf $(BUILD_DIST)/theos-dependencies
+
+	mkdir -p $(BUILD_DIST)/ios-toolchain
+	mkdir -p $(BUILD_DIST)/theos-dependencies
+
+	# theos-dependencies.mk Make .debs
+	$(call PACK,ios-toolchain,DEB_THEOSDEPS_V)
+	$(call PACK,theos-dependencies,DEB_THEOSDEPS_V)
+
+	# theos-dependencies.mk Build cleanup
+	rm -rf $(BUILD_DIST)/ios-toolchain
+	rm -rf $(BUILD_DIST)/theos-dependencies
+
+.PHONY: theos-dependencies theos-dependencies-package


### PR DESCRIPTION
This PR adds ``theos-dependencies`` and ``ios-toolchain`` to Procursus, allowing users to setup Theos with the right packages. This should also prevent users from installing the BigBoss counterparts of these packages, since those can cause conflicts with other Procursus packages (such as ``clang``).

This is a duplicate of [#474](https://github.com/ProcursusTeam/Procursus/pull/474), but it actually compiles...