### PR TITLE
GNU Make EPERM patch

### DIFF
--- a/build_patch/make/0000-fix-make-eperm.patch
+++ b/build_patch/make/0000-fix-make-eperm.patch
@@ -1,0 +1,13 @@
+diff --git src/job.c src/job.c
+index ee59b95..b7381d7 100644
+--- src/job.c
++++ src/job.c
+@@ -2408,7 +2408,7 @@ child_execute_job (struct childbase *child, int good_stdin, char **argv)
+   /* posix_spawn() doesn't provide sh fallback like exec() does; implement
+      it here.  POSIX doesn't specify the path to sh so use the default.  */
+ 
+-  if (r == ENOEXEC)
++  if (r == ENOEXEC || r == EPERM)
+     {
+       char **nargv;
+       char **pp;

--- a/make.mk
+++ b/make.mk
@@ -14,6 +14,7 @@ make-setup: setup
 	wget -q -nc -P $(BUILD_SOURCE) https://ftpmirror.gnu.org/make/make-$(MAKE_VERSION).tar.gz{,.sig}
 	$(call PGP_VERIFY,make-$(MAKE_VERSION).tar.gz)
 	$(call EXTRACT_TAR,make-$(MAKE_VERSION).tar.gz,make-$(MAKE_VERSION),make)
+	$(call DO_PATCH,make,make,-p0)
 
 ifneq ($(wildcard $(BUILD_WORK)/make/.build_complete),)
 make:


### PR DESCRIPTION
I guess make sometimes executes commands directly instead of in a sub shell, so it needs an EPERM patch as well