### PR TITLE
Add siguza-utils

### DIFF
--- a/build_info/siguza-utils.control
+++ b/build_info/siguza-utils.control
@@ -5,7 +5,6 @@ Maintainer: @DEB_MAINTAINER@
 Author: Siguza
 Section: Utilities
 Priority: optional
-Tag: purpose::console, role::hacker
 Homepage: https://www.github.com/Siguza/misc
 Description: Various C written tools.
  This package provides specific C written tools designed by Siguza that do specific things.

--- a/build_info/siguza-utils.control
+++ b/build_info/siguza-utils.control
@@ -1,5 +1,5 @@
 Package: siguza-utils
-Version: @DEB_MISC_V@
+Version: @DEB_SIGUZA-UTILS_V@
 Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
 Author: Siguza

--- a/build_info/siguza-utils.control
+++ b/build_info/siguza-utils.control
@@ -1,0 +1,19 @@
+Package: siguza-utils
+Version: @DEB_MISC_V@
+Architecture: @DEB_ARCH@
+Maintainer: @DEB_MAINTAINER@
+Author: Siguza
+Section: Utilities
+Priority: optional
+Tag: purpose::console, role::hacker
+Homepage: https://www.github.com/Siguza/misc
+Description: Various C written tools.
+ This package provides specific C written tools designed by Siguza that do specific things.
+ This software and all its binaries, which are listed below, is provided without any kind of warranty and as-is. Use at your own risk.
+ - bindump: Prints a 64-bit command line arg in binary
+ - clz: Clang's __builtin_clz, but for the command line
+ - dsc_syms: Prints symbol addresses of a dyld_shared_cache in radare2 format
+ - rand: Generates random numbers or strings
+ - strerror: Prints description for a Darwin error code. Simply calls strerror, mach_error_string, or SecCopyErrorMessageString with the given command line argument
+ - vmacho: Extracts a Mach-O into a raw, headless binary
+ - xref: Parses an arm64 Mach-O and tries to find xrefs to a specific address

--- a/siguza-utils.mk
+++ b/siguza-utils.mk
@@ -4,8 +4,8 @@ endif
 
 SUBPROJECTS             += siguza-utils
 # Don't change the version, just the date and git hash
-SIGUZA-UTILS_COMMIT     := 43852780a20ebf2c990681aa1ab42577ae630555
-SIGUZA-UTILS_VERSION    := 1.0+git20210410.$(shell echo $(SIGUZA-UTILS_COMMIT) | cut -c -7)
+SIGUZA-UTILS_COMMIT     := c67cb07b365f8e3e473f1ed306c8ca82370285a7
+SIGUZA-UTILS_VERSION    := 1.0+git20210413.$(shell echo $(SIGUZA-UTILS_COMMIT) | cut -c -7)
 DEB_SIGUZA-UTILS_V      ?= $(SIGUZA-UTILS_VERSION)
 
 siguza-utils-setup: setup

--- a/siguza-utils.mk
+++ b/siguza-utils.mk
@@ -3,8 +3,6 @@ $(error Use the main Makefile)
 endif
 
 SUPROJECTS      += siguza-utils
-STRERROR_LIBS   := -framework CoreFoundation -framework Security
-
 # Don't change the version, just the date and git hash
 MISC_COMMIT     := 43852780a20ebf2c990681aa1ab42577ae630555
 MISC_VERSION    := 1.0+git20210410.$(shell echo $(MISC_COMMIT) | cut -c -7)
@@ -47,7 +45,7 @@ siguza-utils: siguza-utils-setup
 	# Compile strerror.c
 	$(CC) $(CFLAGS) \
 		$(BUILD_WORK)/siguza-utils/strerror.c \
-		-o $(BUILD_STAGE)/siguza-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/strerror $(LDFLAGS) $(STRERROR_LIBS)
+		-o $(BUILD_STAGE)/siguza-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/strerror $(LDFLAGS) -framework CoreFoundation -framework Security
 
 	# Compile vmacho.c
 	$(CC) $(CFLAGS) \

--- a/siguza-utils.mk
+++ b/siguza-utils.mk
@@ -1,0 +1,85 @@
+ifneq ($(PROCURSUS),1)
+$(error Use the main Makefile)
+endif
+
+SUPROJECTS      += siguza-utils
+STRERROR_LIBS   := -framework CoreFoundation -framework Security
+
+# Don't change the version, just the date and git hash
+MISC_COMMIT     := 43852780a20ebf2c990681aa1ab42577ae630555
+MISC_VERSION    := 1.0+git20210410.$(shell echo $(MISC_COMMIT) | cut -c -7)
+DEB_MISC_V      ?= $(MISC_VERSION)
+
+siguza-utils-setup: setup
+	$(call GITHUB_ARCHIVE,Siguza,misc,$(MISC_COMMIT),$(MISC_COMMIT))
+	$(call EXTRACT_TAR,misc-$(MISC_COMMIT).tar.gz,misc-$(MISC_COMMIT),misc)
+	mkdir -p $(BUILD_STAGE)/siguza-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin
+
+ifneq ($(wildcard $(BUILD_WORK)/siguza-utils/.build_complete),)
+siguza-utils:
+	@echo "Using previously built siguza-utils."
+else
+siguza-utils: siguza-utils-setup
+	# Delete mesu, it's broken afaik
+	rm -rf $(BUILD_WORK)/siguza-utils/mesu.c
+	mv $(BUILD_WORK)/misc $(BUILD_WORK)/siguza-utils
+
+	# Compile bindump.c
+	$(CC) $(CFLAGS) \
+		$(BUILD_WORK)/siguza-utils/bindump.c \
+		-o $(BUILD_STAGE)/siguza-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/bindump $(LDFLAGS)
+
+	# Compile clz.c
+	$(CC) $(CFLAGS) \
+		$(BUILD_WORK)/siguza-utils/clz.c \
+		-o $(BUILD_STAGE)/siguza-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/clz $(LDFLAGS)
+
+	# Compile dsc_syms.c
+	$(CC) $(CFLAGS) \
+		$(BUILD_WORK)/siguza-utils/dsc_syms.c \
+		-o $(BUILD_STAGE)/siguza-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/dsc_syms $(LDFLAGS)
+
+	# Compile rand.c
+	$(CC) $(CFLAGS) \
+		$(BUILD_WORK)/siguza-utils/rand.c \
+		-o $(BUILD_STAGE)/siguza-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/rand $(LDFLAGS)
+
+	# Compile strerror.c
+	$(CC) $(CFLAGS) \
+		$(BUILD_WORK)/siguza-utils/strerror.c \
+		-o $(BUILD_STAGE)/siguza-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/strerror $(LDFLAGS) $(STRERROR_LIBS)
+
+	# Compile vmacho.c
+	$(CC) $(CFLAGS) \
+		$(BUILD_WORK)/siguza-utils/vmacho.c \
+		-o $(BUILD_STAGE)/siguza-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/vmacho $(LDFLAGS)
+
+	# Compile xref.c
+	$(CC) $(CFLAGS) \
+		$(BUILD_WORK)/siguza-utils/xref.c \
+		-o $(BUILD_STAGE)/siguza-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/xref $(LDFLAGS)
+
+	chmod +x $(BUILD_STAGE)/siguza-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/bindump
+	chmod +x $(BUILD_STAGE)/siguza-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/clz
+	chmod +x $(BUILD_STAGE)/siguza-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/dsc_syms
+	chmod +x $(BUILD_STAGE)/siguza-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/rand
+	chmod +x $(BUILD_STAGE)/siguza-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/strerror
+	chmod +x $(BUILD_STAGE)/siguza-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/vmacho
+	chmod +x $(BUILD_STAGE)/siguza-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/xref
+	touch $(BUILD_WORK)/siguza-utils/.build_complete
+endif
+
+siguza-utils-package: siguza-utils-stage
+	# siguza-utils.mk Package Structure
+	cp -a $(BUILD_STAGE)/siguza-utils $(BUILD_DIST)
+
+	# siguza-utils.mk Sign
+	$(call SIGN,siguza-utils,general.xml)
+
+	# siguza-utils.mk Make .debs
+	$(call PACK,siguza-utils,DEB_MISC_V)
+
+	# siguza-utils.mk Build cleanup
+	rm -rf $(BUILD_DIST)/siguza-utils
+
+.PHONY: siguza-utils siguza-utils-package

--- a/siguza-utils.mk
+++ b/siguza-utils.mk
@@ -9,8 +9,8 @@ MISC_VERSION    := 1.0+git20210410.$(shell echo $(MISC_COMMIT) | cut -c -7)
 DEB_MISC_V      ?= $(MISC_VERSION)
 
 siguza-utils-setup: setup
-	$(call GITHUB_ARCHIVE,Siguza,misc,$(MISC_COMMIT),$(MISC_COMMIT))
-	$(call EXTRACT_TAR,misc-$(MISC_COMMIT).tar.gz,misc-$(MISC_COMMIT),misc)
+	$(call GITHUB_ARCHIVE,Siguza,misc,$(MISC_COMMIT),$(MISC_COMMIT),siguza-utils)
+	$(call EXTRACT_TAR,siguza-utils-$(MISC_COMMIT).tar.gz,misc-$(MISC_COMMIT),siguza-utils)
 	mkdir -p $(BUILD_STAGE)/siguza-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin
 
 ifneq ($(wildcard $(BUILD_WORK)/siguza-utils/.build_complete),)
@@ -20,7 +20,6 @@ else
 siguza-utils: siguza-utils-setup
 	# Delete mesu, it's broken afaik
 	rm -rf $(BUILD_WORK)/siguza-utils/mesu.c
-	mv $(BUILD_WORK)/misc $(BUILD_WORK)/siguza-utils
 
 	# Compile bindump.c
 	$(CC) $(CFLAGS) \

--- a/siguza-utils.mk
+++ b/siguza-utils.mk
@@ -2,15 +2,15 @@ ifneq ($(PROCURSUS),1)
 $(error Use the main Makefile)
 endif
 
-SUPROJECTS      += siguza-utils
+SUBPROJECTS             += siguza-utils
 # Don't change the version, just the date and git hash
-MISC_COMMIT     := 43852780a20ebf2c990681aa1ab42577ae630555
-MISC_VERSION    := 1.0+git20210410.$(shell echo $(MISC_COMMIT) | cut -c -7)
-DEB_MISC_V      ?= $(MISC_VERSION)
+SIGUZA-UTILS_COMMIT     := 43852780a20ebf2c990681aa1ab42577ae630555
+SIGUZA-UTILS_VERSION    := 1.0+git20210410.$(shell echo $(SIGUZA-UTILS_COMMIT) | cut -c -7)
+DEB_SIGUZA-UTILS_V      ?= $(SIGUZA-UTILS_VERSION)
 
 siguza-utils-setup: setup
-	$(call GITHUB_ARCHIVE,Siguza,misc,$(MISC_COMMIT),$(MISC_COMMIT),siguza-utils)
-	$(call EXTRACT_TAR,siguza-utils-$(MISC_COMMIT).tar.gz,misc-$(MISC_COMMIT),siguza-utils)
+	$(call GITHUB_ARCHIVE,Siguza,misc,$(SIGUZA-UTILS_COMMIT),$(SIGUZA-UTILS_COMMIT),siguza-utils)
+	$(call EXTRACT_TAR,siguza-utils-$(SIGUZA-UTILS_COMMIT).tar.gz,misc-$(SIGUZA-UTILS_COMMIT),siguza-utils)
 	mkdir -p $(BUILD_STAGE)/siguza-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin
 
 ifneq ($(wildcard $(BUILD_WORK)/siguza-utils/.build_complete),)
@@ -74,7 +74,7 @@ siguza-utils-package: siguza-utils-stage
 	$(call SIGN,siguza-utils,general.xml)
 
 	# siguza-utils.mk Make .debs
-	$(call PACK,siguza-utils,DEB_MISC_V)
+	$(call PACK,siguza-utils,DEB_SIGUZA-UTILS_V)
 
 	# siguza-utils.mk Build cleanup
 	rm -rf $(BUILD_DIST)/siguza-utils


### PR DESCRIPTION
This PR adds ``siguza-utils``, which includes ``bindump``, ``clz``, ``dsc_syms``, ``rand``, ``strerror``, ``vmacho``, and ``xref`` from [Siguza/misc](https://github.com/Siguza/misc), in one package. The only exception is ``mesu``, which seems to no longer work.

This is my first, somewhat usable package (that isn't just a control file), so I do suggest giving me criticism on how I've compiled this. I've attempted to use functions which make things like downloading and extracting a package easier, but I'm sure this can be improved. Software provided as-is, blah blah not much from here will do anything bad.