### PR TITLE
Update Golang to 1.16.3

### DIFF
--- a/build_info/golang-1.16-go.control
+++ b/build_info/golang-1.16-go.control
@@ -1,11 +1,12 @@
-Package: golang-1.15-src
+Package: golang-1.16-go
 Version: @DEB_GOLANG_V@
 Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
+Depends: golang-1.16-src (>= @DEB_GOLANG_V@), clang
 Section: Development
 Priority: optional
 Homepage: https://golang.org
-Description: Go programming language - source files
+Description: Go programming language compiler, linker, compiled stdlib
  The Go programming language is an open source project to make programmers more
  productive. Go is expressive, concise, clean, and efficient. Its concurrency
  mechanisms make it easy to write programs that get the most out of multicore
@@ -15,5 +16,8 @@ Description: Go programming language - source files
  fast, statically typed, compiled language that feels like a dynamically typed,
  interpreted language.
  .
- This package provides the Go programming language source files needed for
- cross-compilation.
+ This package provides an assembler, compiler, linker, and compiled libraries
+ for the Go programming language.
+ .
+ Go supports cross-compilation, but as of Go 1.5, it is no longer necessary to
+ pre-compile the standard library inside GOROOT for cross-compilation to work.

--- a/build_info/golang-1.16-src.control
+++ b/build_info/golang-1.16-src.control
@@ -1,12 +1,11 @@
-Package: golang-1.15-go
+Package: golang-1.16-src
 Version: @DEB_GOLANG_V@
 Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
-Depends: golang-1.15-src (>= @DEB_GOLANG_V@), clang
 Section: Development
 Priority: optional
 Homepage: https://golang.org
-Description: Go programming language compiler, linker, compiled stdlib
+Description: Go programming language - source files
  The Go programming language is an open source project to make programmers more
  productive. Go is expressive, concise, clean, and efficient. Its concurrency
  mechanisms make it easy to write programs that get the most out of multicore
@@ -16,8 +15,5 @@ Description: Go programming language compiler, linker, compiled stdlib
  fast, statically typed, compiled language that feels like a dynamically typed,
  interpreted language.
  .
- This package provides an assembler, compiler, linker, and compiled libraries
- for the Go programming language.
- .
- Go supports cross-compilation, but as of Go 1.5, it is no longer necessary to
- pre-compile the standard library inside GOROOT for cross-compilation to work.
+ This package provides the Go programming language source files needed for
+ cross-compilation.

--- a/build_info/golang-go.control
+++ b/build_info/golang-go.control
@@ -2,7 +2,7 @@ Package: golang-go
 Version: @DEB_GOLANG_V@
 Architecture: all
 Maintainer: @DEB_MAINTAINER@
-Depends: golang-1.15-go (>= @DEB_GOLANG_V@)
+Depends: golang-1.16-go (>= @DEB_GOLANG_V@)
 Section: Development
 Priority: optional
 Homepage: https://golang.org

--- a/golang.mk
+++ b/golang.mk
@@ -3,8 +3,8 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS    += golang
-GOLANG_MAJOR_V := 1.15
-GOLANG_VERSION := $(GOLANG_MAJOR_V).7
+GOLANG_MAJOR_V := 1.16
+GOLANG_VERSION := $(GOLANG_MAJOR_V).3
 DEB_GOLANG_V   ?= $(GOLANG_VERSION)
 
 golang-setup: setup
@@ -32,7 +32,7 @@ golang: golang-setup
 			GOHOSTARCH=amd64 \
 			GOHOSTOS=darwin \
 			GOARCH=arm64 \
-			GOOS=darwin \
+			GOOS=ios \
 			CC=cc \
 			CC_FOR_TARGET=clang \
 			./make.bash
@@ -50,10 +50,10 @@ golang-package: golang-stage
 
 	# golang.mk Prep golang-$(GOLANG_MAJOR_V)-src
 	cp -a $(BUILD_STAGE)/golang/usr/lib/go-$(GOLANG_MAJOR_V)/{api,misc,src,test} $(BUILD_DIST)/golang-$(GOLANG_MAJOR_V)-src/usr/lib/go-$(GOLANG_MAJOR_V)
-	
+
 	# golang.mk Prep golang-$(GOLANG_MAJOR_V)-go
 	cp -a $(BUILD_STAGE)/golang/usr/lib/go-$(GOLANG_MAJOR_V)/VERSION $(BUILD_DIST)/golang-$(GOLANG_MAJOR_V)-go/usr/lib/go-$(GOLANG_MAJOR_V)
-	cp -a $(BUILD_STAGE)/golang/usr/lib/go-$(GOLANG_MAJOR_V)/bin/darwin_arm64/go{,fmt} $(BUILD_DIST)/golang-$(GOLANG_MAJOR_V)-go/usr/lib/go-$(GOLANG_MAJOR_V)/bin
+	cp -a $(BUILD_STAGE)/golang/usr/lib/go-$(GOLANG_MAJOR_V)/bin/ios_arm64/go{,fmt} $(BUILD_DIST)/golang-$(GOLANG_MAJOR_V)-go/usr/lib/go-$(GOLANG_MAJOR_V)/bin
 	cp -a $(BUILD_STAGE)/golang/usr/lib/go-$(GOLANG_MAJOR_V)/pkg/{*_*,include,tool} $(BUILD_DIST)/golang-$(GOLANG_MAJOR_V)-go/usr/lib/go-$(GOLANG_MAJOR_V)/pkg
 	
 	# golang.mk Prep golang-go


### PR DESCRIPTION
The main change in 1.16 is how it renamed the build target for iOS from `darwin/arm64` to `ios/arm64`, because now there's ARM64 Macs and that gets confusing. Of course, there are some bugfixes too.