### PR TITLE
Update speedtest-cli to latest version

### DIFF
--- a/speedtest-cli.mk
+++ b/speedtest-cli.mk
@@ -3,8 +3,8 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS           += speedtest-cli
-SPEEDTEST-CLI_VERSION := 2.1.2
-DEB_SPEEDTEST-CLI_V   ?= $(SPEEDTEST-CLI_VERSION)-1
+SPEEDTEST-CLI_VERSION := 2.1.3
+DEB_SPEEDTEST-CLI_V   ?= $(SPEEDTEST-CLI_VERSION)
 
 speedtest-cli-setup: setup
 	$(call GITHUB_ARCHIVE,sivel,speedtest-cli,$(SPEEDTEST-CLI_VERSION),v$(SPEEDTEST-CLI_VERSION))


### PR DESCRIPTION
This PR updates ``speedtest-cli`` to the latest version, 2.1.3, which addresses the following issues
- Address issue where ``ignore_ids`` may be empty or have empty values
- Address issue where a test server may return an HTTP error during upload or download

There's not much to this PR; I tested building on iOS and everything seems to be working. Remember to stay hydrated :)