### PR TITLE
add smartmontools

### DIFF
--- a/build_info/apfs.xml
+++ b/build_info/apfs.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.container.crypto.io</key>
+	<true/>
+	<key>com.apple.keystore.device</key>
+	<true/>
+	<key>com.apple.keystore.devicebackup</key>
+	<true/>
+	<key>com.apple.private.apfs.create-sealed-snapshot</key>
+	<true/>
+	<key>com.apple.private.apfs.revert-to-snapshot</key>
+	<true/>
+	<key>com.apple.private.iopol.case_sensitivity</key>
+	<true/>
+	<key>com.apple.private.security.disk-device-access</key>
+	<true/>
+	<key>com.apple.private.vfs.dataless-manipulation</key>
+	<true/>
+	<key>com.apple.private.vfs.move-data-extents</key>
+	<true/>
+	<key>com.apple.private.vfs.snapshot</key>
+	<true/>
+    <key>get-task-allow</key>
+    <true/>
+    <key>task_for_pid-allow</key>
+    <true/>
+    <key>com.apple.private.kernel.get-kext-info</key>
+    <true/>
+    <key>com.apple.private.security.no-container</key>
+    <true/>
+	<key>com.apple.security.iokit-user-client-class</key>
+	<string>AppleAPFSUserClient</string>
+</dict>
+</plist>

--- a/build_info/smartmontools.control
+++ b/build_info/smartmontools.control
@@ -2,7 +2,6 @@ Package: smartmontools
 Version: @DEB_SMARTMONTOOLS_V@
 Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
-Depends: 
 Section: Utilities
 Priority: optional
 Description: smartmontools contains utility programs (smartctl, smartd) to control/monitor storage systems using the Self-Monitoring, Analysis and Reporting Technology System (S.M.A.R.T.) built into most modern ATA and SCSI disks. It is derived from smartsuite.

--- a/build_info/smartmontools.control
+++ b/build_info/smartmontools.control
@@ -4,6 +4,6 @@ Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
 Depends: 
 Section: Utilities
-Priority: default
+Priority: optional
 Description: smartmontools contains utility programs (smartctl, smartd) to control/monitor storage systems using the Self-Monitoring, Analysis and Reporting Technology System (S.M.A.R.T.) built into most modern ATA and SCSI disks. It is derived from smartsuite.
 Name: S.M.A.R.T. Monitoring Tools

--- a/build_info/smartmontools.control
+++ b/build_info/smartmontools.control
@@ -1,0 +1,9 @@
+Package: smartmontools
+Version: @DEB_SMARTMONTOOLS_V@
+Architecture: @DEB_ARCH@
+Maintainer: @DEB_MAINTAINER@
+Depends: 
+Section: Utilities
+Priority: default
+Description: smartmontools contains utility programs (smartctl, smartd) to control/monitor storage systems using the Self-Monitoring, Analysis and Reporting Technology System (S.M.A.R.T.) built into most modern ATA and SCSI disks. It is derived from smartsuite.
+Name: S.M.A.R.T. Monitoring Tools

--- a/smartmontools.mk
+++ b/smartmontools.mk
@@ -2,7 +2,7 @@ ifneq ($(PROCURSUS),1)
 $(error Use the main Makefile)
 endif
 
-SUBPROJECT             += smartmontools 
+SUBPROJECTS            += smartmontools 
 SMARTMONTOOLS_VERSION  := 7.2
 DEB_SMARTMONTOOLS_V    ?= $(SMARTMONTOOLS_VERSION)
 

--- a/smartmontools.mk
+++ b/smartmontools.mk
@@ -1,0 +1,45 @@
+ifneq ($(PROCURSUS),1)
+$(error Use the main Makefile)
+endif
+
+STRAPPROJECTS += smartmontools 
+SMARTMONTOOLS_VERSION  := 7.2
+DEB_SMARTMONTOOLS_V    ?= $(SMARTMONTOOLS_VERSION)
+
+smartmontools-setup: setup
+	wget -q -nc -P $(BUILD_SOURCE) https://managedway.dl.sourceforge.net/project/smartmontools/smartmontools/7.2/smartmontools-$(SMARTMONTOOLS_VERSION).tar.gz
+	$(call EXTRACT_TAR,smartmontools-$(SMARTMONTOOLS_VERSION).tar.gz,smartmontools-$(SMARTMONTOOLS_VERSION),smartmontools)
+
+ifneq ($(wildcard $(BUILD_WORK)/smartmontools/.build_complete),)
+smartmontools:
+	@echo "Using previously built smartmontools."
+else
+smartmontools: smartmontools-setup
+	cd $(BUILD_WORK)/smartmontools && ./configure -C \
+		--with-savestates \
+		--with-attributelog \
+		$(DEFAULT_CONFIGURE_FLAGS) \
+	+$(MAKE) -C $(BUILD_WORK)/smartmontools
+	+$(MAKE) -C $(BUILD_WORK)/smartmontools install \
+		DESTDIR=$(BUILD_STAGE)/smartmontools
+	touch $(BUILD_WORK)/smartmontools/.build_complete
+endif
+
+smartmontools-package: smartmontools-stage
+	# smartmontools.mk Package Structure
+	rm -rf $(BUILD_DIST)/smartmontools
+	mkdir -p $(BUILD_DIST)/smartmontools/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/
+	
+	# smartmontools.mk Prep smartmontools
+	cp -a $(BUILD_STAGE)/smartmontools/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/* $(BUILD_DIST)/smartmontools$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/
+	
+	# smartmontools.mk Sign
+	$(call SIGN,smartmontools,apfs.xml)
+	
+	# smartmontools.mk Make .debs
+	$(call PACK,smartmontools,DEB_SMARTMONTOOLS_V)
+	
+	# smartmontools.mk Build cleanup
+	rm -rf $(BUILD_DIST)/smartmontools
+
+.PHONY: smartmontools smartmontools-package

--- a/smartmontools.mk
+++ b/smartmontools.mk
@@ -7,7 +7,7 @@ SMARTMONTOOLS_VERSION  := 7.2
 DEB_SMARTMONTOOLS_V    ?= $(SMARTMONTOOLS_VERSION)
 
 smartmontools-setup: setup
-	wget -q -nc -P $(BUILD_SOURCE) https://managedway.dl.sourceforge.net/project/smartmontools/smartmontools/7.2/smartmontools-$(SMARTMONTOOLS_VERSION).tar.gz
+	wget -q -nc -P $(BUILD_SOURCE) https://managedway.dl.sourceforge.net/project/smartmontools/smartmontools/$(SMARTMONTOOLS_VERSION)/smartmontools-$(SMARTMONTOOLS_VERSION).tar.gz
 	$(call EXTRACT_TAR,smartmontools-$(SMARTMONTOOLS_VERSION).tar.gz,smartmontools-$(SMARTMONTOOLS_VERSION),smartmontools)
 
 ifneq ($(wildcard $(BUILD_WORK)/smartmontools/.build_complete),)

--- a/smartmontools.mk
+++ b/smartmontools.mk
@@ -30,7 +30,7 @@ smartmontools-package: smartmontools-stage
 	rm -rf $(BUILD_DIST)/smartmontools
 	
 	# smartmontools.mk Prep smartmontools
-	cp -a $(BUILD_STAGE)/smartmontools/* $(BUILD_DIST)/smartmontools/
+	cp -a $(BUILD_STAGE)/smartmontools $(BUILD_DIST)
 	
 	# smartmontools.mk Sign
 	$(call SIGN,smartmontools,apfs.xml)

--- a/smartmontools.mk
+++ b/smartmontools.mk
@@ -2,7 +2,7 @@ ifneq ($(PROCURSUS),1)
 $(error Use the main Makefile)
 endif
 
-STRAPPROJECTS += smartmontools 
+SUBPROJECT             += smartmontools 
 SMARTMONTOOLS_VERSION  := 7.2
 DEB_SMARTMONTOOLS_V    ?= $(SMARTMONTOOLS_VERSION)
 
@@ -16,9 +16,9 @@ smartmontools:
 else
 smartmontools: smartmontools-setup
 	cd $(BUILD_WORK)/smartmontools && ./configure -C \
-		--with-savestates \
-		--with-attributelog \
 		$(DEFAULT_CONFIGURE_FLAGS) \
+		--with-savestates \
+		--with-attributelog
 	+$(MAKE) -C $(BUILD_WORK)/smartmontools
 	+$(MAKE) -C $(BUILD_WORK)/smartmontools install \
 		DESTDIR=$(BUILD_STAGE)/smartmontools
@@ -28,10 +28,9 @@ endif
 smartmontools-package: smartmontools-stage
 	# smartmontools.mk Package Structure
 	rm -rf $(BUILD_DIST)/smartmontools
-	mkdir -p $(BUILD_DIST)/smartmontools/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/
 	
 	# smartmontools.mk Prep smartmontools
-	cp -a $(BUILD_STAGE)/smartmontools/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/* $(BUILD_DIST)/smartmontools$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/
+	cp -a $(BUILD_STAGE)/smartmontools/* $(BUILD_DIST)/smartmontools/
 	
 	# smartmontools.mk Sign
 	$(call SIGN,smartmontools,apfs.xml)


### PR DESCRIPTION
This is a port of smartmontools to Procursus. 
There is currently an issue on iOS, hence why it is a draft. Doing any operation to disk0 on iOS returns an error: 
![image](https://user-images.githubusercontent.com/70823629/115306909-7cdb8800-a136-11eb-8db8-e7d7a0598a45.png)
This might be an entitlement issue, however Siguza said this in response to it: 
<img width="529" alt="Screen Shot 2021-04-19 at 5 42 32 PM" src="https://user-images.githubusercontent.com/70823629/115306999-9f6da100-a136-11eb-9e19-5c55b1dcef94.png">
Hopefully this can be fixed. Works fine on amd64 however, to the extent of my testing. 
(Smartmontools's homepage is [this](https://www.smartmontools.org))

