### PR TITLE
Globalize GITHUB_ARCHIVE

### DIFF
--- a/axel.mk
+++ b/axel.mk
@@ -2,7 +2,7 @@ ifneq ($(PROCURSUS),1)
 $(error Use the main Makefile)
 endif
 
-SUBPROJECTS      += axel
+SUBPROJECTS  += axel
 AXEL_VERSION := 2.17.10
 DEB_AXEL_V   ?= $(AXEL_VERSION)
 

--- a/bash-completion.mk
+++ b/bash-completion.mk
@@ -39,4 +39,3 @@ bash-completion-package: bash-completion-stage
 	rm -rf $(BUILD_DIST)/bash-completion
 
 .PHONY: bash-completion bash-completion-package
-

--- a/bsd-progress.mk
+++ b/bsd-progress.mk
@@ -8,9 +8,7 @@ BSD_PROGRESS_COMMIT  := a9bda63998e2f358b07a50a8dd4ed48100f9a9ee
 DEB_BSD_PROGRESS_V   ?= $(BSD_PROGRESS_VERSION)
 
 bsd-progress-setup: setup
-	-[ ! -e "$(BUILD_SOURCE)/bsd-progress-$(BSD_PROGRESS_VERSION).tar.gz" ] \
-		&& wget -q -nc -O$(BUILD_SOURCE)/bsd-progress-$(BSD_PROGRESS_VERSION).tar.gz \
-			https://github.com/CRKatri/bsd-progress/archive/$(BSD_PROGRESS_COMMIT).tar.gz
+	$(call GITHUB_ARCHIVE,CRKatri,bsd-progress,$(BSD_PROGRESS_VERSION),$(BSD_PROGRESS_COMMIT))
 	$(call EXTRACT_TAR,bsd-progress-$(BSD_PROGRESS_VERSION).tar.gz,bsd-progress-$(BSD_PROGRESS_COMMIT),bsd-progress)
 
 ifneq ($(wildcard $(BUILD_WORK)/bsd-progress/.build_complete),)

--- a/chezmoi.mk
+++ b/chezmoi.mk
@@ -7,8 +7,8 @@ CHEZMOI_VERSION := 2.0.10
 DEB_CHEZMOI_V   ?= $(CHEZMOI_VERSION)
 
 chezmoi-setup: setup
-	wget -q -nc -P $(BUILD_SOURCE) https://github.com/twpayne/chezmoi/archive/refs/tags/v$(CHEZMOI_VERSION).tar.gz
-	$(call EXTRACT_TAR,v$(CHEZMOI_VERSION).tar.gz,chezmoi-$(CHEZMOI_VERSION),chezmoi)
+	$(call GITHUB_ARCHIVE,twpayne,chezmoi,$(CHEZMOI_VERSION),v$(CHEZMOI_VERSION))
+	$(call EXTRACT_TAR,chezmoi-v$(CHEZMOI_VERSION).tar.gz,chezmoi-$(CHEZMOI_VERSION),chezmoi)
 	mkdir -p $(BUILD_STAGE)/chezmoi/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin
 
 ifneq ($(wildcard $(BUILD_WORK)/chezmoi/.build_complete),)

--- a/cowsay.mk
+++ b/cowsay.mk
@@ -7,9 +7,8 @@ COWSAY_VERSION := 3.04
 DEB_COWSAY_V   ?= $(COWSAY_VERSION)
 
 cowsay-setup: setup
-	$(call,GITHUB_ARCHIVE,tnalpgge,rank-amateur-cowsay,$(COWSAY_VERSION),$(COWSAY_VERSION),cowsay)
-	wget -q -nc -P $(BUILD_SOURCE) https://github.com/tnalpgge/rank-amateur-cowsay/archive/cowsay-$(COWSAY_VERSION).tar.gz
-	$(call EXTRACT_TAR,cowsay-$(COWSAY_VERSION).tar.gz,rank-amateur-cowsay-cowsay-$(COWSAY_VERSION),cowsay)
+	$(call GITHUB_ARCHIVE,tnalpgge,rank-amateur-cowsay,$(COWSAY_VERSION),cowsay-$(COWSAY_VERSION))
+	$(call EXTRACT_TAR,cowsay-$(COWSAY_VERSION).tar.gz,cowsay-cowsay-$(COWSAY_VERSION),cowsay)
 	mkdir -p $(BUILD_STAGE)/cowsay/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/{games,share/man/man1}
 
 ifneq ($(wildcard $(BUILD_WORK)/cowsay/.build_complete),)

--- a/cowsay.mk
+++ b/cowsay.mk
@@ -7,8 +7,8 @@ COWSAY_VERSION := 3.04
 DEB_COWSAY_V   ?= $(COWSAY_VERSION)
 
 cowsay-setup: setup
-	$(call GITHUB_ARCHIVE,tnalpgge,rank-amateur-cowsay,$(COWSAY_VERSION),cowsay-$(COWSAY_VERSION))
-	$(call EXTRACT_TAR,cowsay-$(COWSAY_VERSION).tar.gz,cowsay-cowsay-$(COWSAY_VERSION),cowsay)
+	$(call GITHUB_ARCHIVE,tnalpgge,rank-amateur-cowsay,$(COWSAY_VERSION),cowsay-$(COWSAY_VERSION),cowsay)
+	$(call EXTRACT_TAR,cowsay-$(COWSAY_VERSION).tar.gz,rank-amateur-cowsay-cowsay-$(COWSAY_VERSION),cowsay)
 	mkdir -p $(BUILD_STAGE)/cowsay/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/{games,share/man/man1}
 
 ifneq ($(wildcard $(BUILD_WORK)/cowsay/.build_complete),)

--- a/hello.mk
+++ b/hello.mk
@@ -7,7 +7,7 @@ HELLO_VERSION := 2.10
 DEB_HELLO_V   ?= $(HELLO_VERSION)
 
 hello-setup: setup
-	wget -q -nc -P$(BUILD_SOURCE) http://ftpmirror.gnu.org/gnu/hello/hello-$(HELLO_VERSION).tar.gz
+	wget -q -nc -P $(BUILD_SOURCE) http://ftpmirror.gnu.org/gnu/hello/hello-$(HELLO_VERSION).tar.gz
 	$(call EXTRACT_TAR,hello-$(HELLO_VERSION).tar.gz,hello-$(HELLO_VERSION),hello)
 	$(call DO_PATCH,hello,hello,-p1)
 

--- a/libao.mk
+++ b/libao.mk
@@ -7,10 +7,9 @@ LIBAO_VERSION := 1.2.2
 DEB_LIBAO_V   ?= $(LIBAO_VERSION)
 
 libao-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/libao-$(LIBAO_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/libao-$(LIBAO_VERSION).tar.gz \
-			https://github.com/xiph/libao/archive/refs/tags/$(LIBAO_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,xiph,libao,$(LIBAO_VERSION),$(LIBAO_VERSION))
 	$(call EXTRACT_TAR,libao-$(LIBAO_VERSION).tar.gz,libao-$(LIBAO_VERSION),libao)
+
 ifeq (,$(findstring darwin,$(MEMO_TARGET)))
 	$(call DO_PATCH,libao-ios,libao,-p1)
 endif

--- a/libimobiledevice.mk
+++ b/libimobiledevice.mk
@@ -8,9 +8,7 @@ LIBIMOBILEDEVICE_VERSION := 1.3.0+git20210304.$(shell echo $(LIBIMOBILEDEVICE_CO
 DEB_LIBIMOBILEDEVICE_V   ?= $(LIBIMOBILEDEVICE_VERSION)
 
 libimobiledevice-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/libimobiledevice-$(LIBIMOBILEDEVICE_COMMIT).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/libimobiledevice-$(LIBIMOBILEDEVICE_COMMIT).tar.gz \
-			https://github.com/libimobiledevice/libimobiledevice/archive/$(LIBIMOBILEDEVICE_COMMIT).tar.gz
+	$(call GITHUB_ARCHIVE,libimobiledevice,libimobiledevice,$(LIBIMOBILEDEVICE_COMMIT),$(LIBIMOBILEDEVICE_COMMIT))
 	$(call EXTRACT_TAR,libimobiledevice-$(LIBIMOBILEDEVICE_COMMIT).tar.gz,libimobiledevice-$(LIBIMOBILEDEVICE_COMMIT),libimobiledevice)
 
 ifneq ($(wildcard $(BUILD_WORK)/libimobiledevice/.build_complete),)

--- a/libpam-google-authenticator.mk
+++ b/libpam-google-authenticator.mk
@@ -8,9 +8,7 @@ LIBPAM-GOOGLE-AUTHENTICATOR_VERSION := 0~20210222.$(shell echo $(LIBPAM-GOOGLE-A
 DEB_LIBPAM-GOOGLE-AUTHENTICATOR_V   := $(LIBPAM-GOOGLE-AUTHENTICATOR_VERSION)
 
 libpam-google-authenticator-setup: setup
-	-[ ! -e "$(BUILD_SOURCE)/libpam-google-authenticator-$(LIBPAM-GOOGLE-AUTHENTICATOR_COMMIT).tar.gz" ] \
-		&& wget -q -nc -O$(BUILD_SOURCE)/libpam-google-authenticator-$(LIBPAM-GOOGLE-AUTHENTICATOR_COMMIT).tar.gz \
-			https://github.com/google/google-authenticator-libpam/archive/$(LIBPAM-GOOGLE-AUTHENTICATOR_COMMIT).tar.gz
+	$(call GITHUB_ARCHIVE,google,google-authenticator-libpam,$(LIBPAM-GOOGLE-AUTHENTICATOR_COMMIT),$(LIBPAM-GOOGLE-AUTHENTICATOR_COMMIT))
 	$(call EXTRACT_TAR,libpam-google-authenticator-$(LIBPAM-GOOGLE-AUTHENTICATOR_COMMIT).tar.gz,google-authenticator-libpam-$(LIBPAM-GOOGLE-AUTHENTICATOR_COMMIT),libpam-google-authenticator)
 
 ifneq ($(wildcard $(BUILD_WORK)/libpam-google-authenticator/.build_complete),)

--- a/libpam-google-authenticator.mk
+++ b/libpam-google-authenticator.mk
@@ -9,7 +9,7 @@ DEB_LIBPAM-GOOGLE-AUTHENTICATOR_V   := $(LIBPAM-GOOGLE-AUTHENTICATOR_VERSION)
 
 libpam-google-authenticator-setup: setup
 	$(call GITHUB_ARCHIVE,google,google-authenticator-libpam,$(LIBPAM-GOOGLE-AUTHENTICATOR_COMMIT),$(LIBPAM-GOOGLE-AUTHENTICATOR_COMMIT))
-	$(call EXTRACT_TAR,libpam-google-authenticator-$(LIBPAM-GOOGLE-AUTHENTICATOR_COMMIT).tar.gz,google-authenticator-libpam-$(LIBPAM-GOOGLE-AUTHENTICATOR_COMMIT),libpam-google-authenticator)
+	$(call EXTRACT_TAR,google-authenticator-libpam-$(LIBPAM-GOOGLE-AUTHENTICATOR_COMMIT).tar.gz,google-authenticator-libpam-$(LIBPAM-GOOGLE-AUTHENTICATOR_COMMIT),libpam-google-authenticator)
 
 ifneq ($(wildcard $(BUILD_WORK)/libpam-google-authenticator/.build_complete),)
 libpam-google-authenticator:

--- a/libsoundio.mk
+++ b/libsoundio.mk
@@ -7,10 +7,9 @@ LIBSOUNDIO_VERSION := 2.0.0
 DEB_LIBSOUNDIO_V   ?= $(LIBSOUNDIO_VERSION)
 
 libsoundio-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/libsoundio-$(LIBSOUNDIO_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/libsoundio-$(LIBSOUNDIO_VERSION).tar.gz \
-			https://github.com/andrewrk/libsoundio/archive/$(LIBSOUNDIO_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,andrewrk,libsoundio,$(LIBSOUNDIO_VERSION),$(LIBSOUNDIO_VERSION))
 	$(call EXTRACT_TAR,libsoundio-$(LIBSOUNDIO_VERSION).tar.gz,libsoundio-$(LIBSOUNDIO_VERSION),libsoundio)
+
 ifeq (,$(findstring darwin,$(MEMO_TARGET)))
 	$(call DO_PATCH,libsoundio-ios,libsoundio,-p1)
 endif

--- a/msgpack.mk
+++ b/msgpack.mk
@@ -7,7 +7,7 @@ MSGPACK_VERSION := 3.3.0
 DEB_MSGPACK_V   ?= $(MSGPACK_VERSION)
 
 msgpack-setup: setup
-	wget -q -nc -P $(BUILD_SOURCE) https://github.com/msgpack/msgpack-c/releases/download/cpp-3.3.0/msgpack-$(MSGPACK_VERSION).tar.gz
+	wget -q -nc -P $(BUILD_SOURCE) https://github.com/msgpack/msgpack-c/releases/download/cpp-$(MSGPACK_VERSION)/msgpack-$(MSGPACK_VERSION).tar.gz
 	$(call EXTRACT_TAR,msgpack-$(MSGPACK_VERSION).tar.gz,msgpack-$(MSGPACK_VERSION),msgpack)
 
 ifneq ($(wildcard $(BUILD_WORK)/msgpack/.build_complete),)

--- a/mtree-netbsd.mk
+++ b/mtree-netbsd.mk
@@ -7,11 +7,9 @@ MTREE_NETBSD_VERSION := 20180822-6
 DEB_MTREE_NETBSD_V   ?= $(MTREE_NETBSD_VERSION)
 
 mtree-netbsd-setup: setup
-	-[ ! -e "$(BUILD_SOURCE)/mtree-netbsd-$(LUAJIT_COMMIT).tar.gz" ] \
-		&& wget -q -nc -O$(BUILD_SOURCE)/mtree-netbsd-$(MTREE_NETBSD_VERSION).tar.gz \
-			https://github.com/jgoerzen/mtree-netbsd/archive/refs/tags/debian/$(MTREE_NETBSD_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,jgoerzen,mtree-netbsd,$(MTREE_NETBSD_VERSION),debian/$(MTREE_NETBSD_VERSION))
 	$(call EXTRACT_TAR,mtree-netbsd-$(MTREE_NETBSD_VERSION).tar.gz,mtree-netbsd-debian-$(MTREE_NETBSD_VERSION),mtree-netbsd)
-	wget -q -nc -P$(BUILD_WORK)/mtree-netbsd https://raw.githubusercontent.com/NetBSD/src/trunk/lib/libc/gen/pwcache.{c,h}
+	wget -q -nc -P $(BUILD_WORK)/mtree-netbsd https://raw.githubusercontent.com/NetBSD/src/trunk/lib/libc/gen/pwcache.{c,h}
 	$(call DO_PATCH,mtree-netbsd,mtree-netbsd,-p1)
 
 ifneq ($(wildcard $(BUILD_WORK)/mtree-netbsd/.build_complete),)

--- a/nekofetch.mk
+++ b/nekofetch.mk
@@ -8,9 +8,7 @@ NEKOFETCH_VERSION := 1.4+git20210404.$(shell echo $(NEKOFETCH_COMMIT) | cut -c -
 DEB_NEKOFETCH_V   ?= $(NEKOFETCH_VERSION)
 
 nekofetch-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/nekofetch-$(NEKOFETCH_COMMIT).tar.gz" ] && \
-		wget -q -nc -O $(BUILD_SOURCE)/nekofetch-$(NEKOFETCH_COMMIT).tar.gz \
-			https://github.com/proprdev/nekofetch/archive/$(NEKOFETCH_COMMIT).tar.gz
+	$(call GITHUB_ARCHIVE,proprdev,nekofetch,$(NEKOFETCH_COMMIT),$(NEKOFETCH_COMMIT))
 	$(call EXTRACT_TAR,nekofetch-$(NEKOFETCH_COMMIT).tar.gz,nekofetch-$(NEKOFETCH_COMMIT),nekofetch)
 
 ifneq ($(wildcard $(BUILD_WORK)/nekofetch/.build_complete),)

--- a/opendoas.mk
+++ b/opendoas.mk
@@ -7,9 +7,7 @@ OPENDOAS_VERSION := 6.8.1
 DEB_OPENDOAS_V   ?= $(OPENDOAS_VERSION)-1
 
 opendoas-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/OpenDoas-$(OPENDOAS_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/OpenDoas-$(OPENDOAS_VERSION).tar.gz \
-			https://github.com/Duncaen/OpenDoas/archive/v$(OPENDOAS_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,Duncaen,OpenDoas,$(OPENDOAS_VERSION),v$(OPENDOAS_VERSION))
 	$(call EXTRACT_TAR,OpenDoas-$(OPENDOAS_VERSION).tar.gz,OpenDoas-$(OPENDOAS_VERSION),opendoas)
 	$(call DO_PATCH,opendoas,opendoas,-p1)
 

--- a/openpam.mk
+++ b/openpam.mk
@@ -10,7 +10,7 @@ DEB_OPENPAM_V   ?= $(OPENPAM_VERSION)
 ifeq (,$(findstring darwin,$(MEMO_TARGET)))
 
 openpam-setup: setup
-	-wget -q -nc -O$(BUILD_SOURCE)/openpam-$(OPENPAM_VERSION).tar.gz https://www.openpam.org/downloads/$(OPENPAM_URL_V)
+	-wget -q -nc -O $(BUILD_SOURCE)/openpam-$(OPENPAM_VERSION).tar.gz https://www.openpam.org/downloads/$(OPENPAM_URL_V)
 	$(call EXTRACT_TAR,openpam-$(OPENPAM_VERSION).tar.gz,openpam-$(OPENPAM_VERSION),openpam)
 	$(call DO_PATCH,openpam,openpam,-p0)
 	# The below line is only if you need to debug PAM with detailed syslogs.

--- a/progress.mk
+++ b/progress.mk
@@ -7,11 +7,10 @@ PROGRESS_VERSION := 0.16
 DEB_PROGRESS_V   ?= $(PROGRESS_VERSION)
 
 progress-setup: setup
-	-[ ! -e "$(BUILD_SOURCE)/progress-$(PROGRESS_VERSION).tar.gz" ] \
-		&& wget -q -nc -O$(BUILD_SOURCE)/progress-$(PROGRESS_VERSION).tar.gz \
-			https://github.com/Xfennec/progress/archive/v$(PROGRESS_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,Xfennec,progress,$(PROGRESS_VERSION),v$(PROGRESS_VERSION))
 	$(call EXTRACT_TAR,progress-$(PROGRESS_VERSION).tar.gz,progress-$(PROGRESS_VERSION),progress)
 	$(SED) -i 's/-lncurses/-lncursesw/g' $(BUILD_WORK)/progress/Makefile
+
 ifeq (,$(findstring darwin,$(MEMO_TARGET)))
 	wget -P $(BUILD_WORK)/progress https://raw.githubusercontent.com/NetBSD/src/trunk/{lib/libc/gen/wordexp.c,include/wordexp.h}
 	$(call DO_PATCH,progress,progress,-p1)

--- a/rc.mk
+++ b/rc.mk
@@ -7,8 +7,7 @@ RC_VERSION  := 1.7.4
 DEB_RC_V    ?= $(RC_VERSION)
 
 rc-setup: setup
-	## Convert this to the GITHUB_ARCHIVE function.
-	wget -O $(BUILD_SOURCE)/rc-$(RC_VERSION).tar.gz https://github.com/rakitzis/rc/archive/refs/tags/v$(RC_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,rakitzis,rc,$(RC_VERSION),v$(RC_VERSION))
 	$(call EXTRACT_TAR,rc-$(RC_VERSION).tar.gz,rc-$(RC_VERSION),rc)
 	$(call DO_PATCH,rc,rc,-p1)
 

--- a/redis.mk
+++ b/redis.mk
@@ -11,8 +11,8 @@ DEB_REDIS_V   ?= $(REDIS_VERSION)-2
 ###
 
 redis-setup: setup
-	wget -q -nc -P $(BUILD_SOURCE) https://github.com/redis/redis/archive/$(REDIS_VERSION).tar.gz
-	$(call EXTRACT_TAR,$(REDIS_VERSION).tar.gz,redis-$(REDIS_VERSION),redis)
+	$(call GITHUB_ARCHIVE,redis,redis,$(REDIS_VERSION),$(REDIS_VERSION))
+	$(call EXTRACT_TAR,redis-$(REDIS_VERSION).tar.gz,redis-$(REDIS_VERSION),redis)
 	$(call DO_PATCH,redis,redis,-p1)
 	# Please don't ask why
 	sed -i 's/$$.AR./$(AR)/g' $(BUILD_WORK)/redis/deps/hiredis/Makefile

--- a/snaprestore.mk
+++ b/snaprestore.mk
@@ -9,9 +9,7 @@ SNAPRESTORE_VERSION := 0.3
 DEB_SNAPRESTORE_V   ?= $(SNAPRESTORE_VERSION)
 
 snaprestore-setup: setup
-	-[ ! -f "$(BUILD_SOURCE)/snaprestore-$(SNAPRESTORE_VERSION).tar.gz" ] && \
-		wget -q -nc -O$(BUILD_SOURCE)/snaprestore-$(SNAPRESTORE_VERSION).tar.gz \
-			https://github.com/CRKatri/snaprestore/archive/v$(SNAPRESTORE_VERSION).tar.gz
+	$(call GITHUB_ARCHIVE,CRKatri,snaprestore,$(SNAPRESTORE_VERSION),v$(SNAPRESTORE_VERSION))
 	$(call EXTRACT_TAR,snaprestore-$(SNAPRESTORE_VERSION).tar.gz,snaprestore-$(SNAPRESTORE_VERSION),snaprestore)
 
 ifneq ($(wildcard $(BUILD_WORK)/snaprestore/.build_complete),)

--- a/ye.mk
+++ b/ye.mk
@@ -7,8 +7,8 @@ YE_VERSION  := 1.0
 DEB_YE_V    ?= $(YE_VERSION)
 
 ye-setup: setup
-	wget -q -nc -P $(BUILD_SOURCE) https://github.com/BBaoVanC/ye/archive/v$(YE_VERSION).tar.gz
-	$(call EXTRACT_TAR,v$(YE_VERSION).tar.gz,ye-$(YE_VERSION),ye)
+	$(call GITHUB_ARCHIVE,BBaoVanC,ye,$(YE_VERSION),v$(YE_VERSION))
+	$(call EXTRACT_TAR,ye-$(YE_VERSION).tar.gz,ye-$(YE_VERSION),ye)
 
 ifneq ($(wildcard $(BUILD_WORK)/ye/.build_complete),)
 ye:

--- a/zpaq.mk
+++ b/zpaq.mk
@@ -7,8 +7,8 @@ ZPAQ_VERSION := 7.15
 DEB_ZPAQ_V   ?= $(ZPAQ_VERSION)
 
 zpaq-setup: setup
-	wget -q -nc -P $(BUILD_SOURCE) https://github.com/zpaq/zpaq/archive/refs/tags/$(ZPAQ_VERSION).tar.gz
-	$(call EXTRACT_TAR,$(ZPAQ_VERSION).tar.gz,zpaq-$(ZPAQ_VERSION),zpaq)
+	$(call GITHUB_ARCHIVE,zpaq,zpaq,$(ZPAQ_VERSION),$(ZPAQ_VERSION))
+	$(call EXTRACT_TAR,zpaq-$(ZPAQ_VERSION).tar.gz,zpaq-$(ZPAQ_VERSION),zpaq)
 
 ifneq ($(wildcard $(BUILD_WORK)/zpaq/.build_complete),)
 zpaq:


### PR DESCRIPTION
This PR transitions all packages coming from Github to the ``GITHUB_ARCHIVE`` function (introduced by absidue in [#419](https://github.com/ProcursusTeam/Procursus/pull/419)). The only exceptions are packages that don't come from Github, or get their tarballs from the projects' Github Release tab. 

From this PR on, new additions should, and (likely) will be required to use the function if the package comes from Github.