### PR TITLE
Fix Xephyr depend

### DIFF
--- a/build_info/xserver-xephyr.control
+++ b/build_info/xserver-xephyr.control
@@ -2,8 +2,7 @@ Package: xserver-xephyr
 Version: @DEB_XORG-SERVER_V@
 Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
-Depends: libepoxy0, libmd0, libpixman-1-0, libx11-6, libx11-xcb1, libxau6, libxcb-glx0, libxcb-icccm4, libxcb-image0, libxcb-keysyms1, libxcb-randr0, libxcb-render-util0, libxcb-render0, libxcb-shape0, libxcb-shm0, libxcb-util1, libxcb-xf86dri0, libxcb-xkb1, libxcb1, libxdmcp6, libxfont2, libxcb-xv0, xserver-common
-Recommends: libgl1-mesa-dri
+Depends: libepoxy0, libmd0, libpixman-1-0, libx11-6, libx11-xcb1, libxau6, libxcb-glx0, libxcb-icccm4, libxcb-image0, libxcb-keysyms1, libxcb-randr0, libxcb-render-util0, libxcb-render0, libxcb-shape0, libxcb-shm0, libxcb-util1, libxcb-xf86dri0, libxcb-xkb1, libxcb1, libxdmcp6, libxfont2, libxcb-xv0, xserver-common, libgl1-mesa-glx 
 Section: X11
 Priority: optional
 Description: nested X server


### PR DESCRIPTION
Turns out Xephyr needs libgl-mesa-glx (it queues dri anyways) or else the command won't even run.