### PR TITLE
Minor changes to youtube-dl

### DIFF
--- a/youtube-dl.mk
+++ b/youtube-dl.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS        += youtube-dl
-YOUTUBE-DL_VERSION := 2021.04.17
+YOUTUBE-DL_VERSION := 2021.04.26
 DEB_YOUTUBE-DL_V   ?= $(YOUTUBE-DL_VERSION)
 
 youtube-dl-setup: setup

--- a/youtube-dl.mk
+++ b/youtube-dl.mk
@@ -3,11 +3,12 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS        += youtube-dl
-YOUTUBE-DL_VERSION := 2021.04.01
+YOUTUBE-DL_VERSION := 2021.04.17
 DEB_YOUTUBE-DL_V   ?= $(YOUTUBE-DL_VERSION)
 
 youtube-dl-setup: setup
-	wget -q -nc -P $(BUILD_SOURCE) https://github.com/ytdl-org/youtube-dl/releases/download/$(YOUTUBE-DL_VERSION)/youtube-dl-$(YOUTUBE-DL_VERSION).tar.gz
+	wget -q -nc -P $(BUILD_SOURCE) https://github.com/ytdl-org/youtube-dl/releases/download/$(YOUTUBE-DL_VERSION)/youtube-dl-$(YOUTUBE-DL_VERSION).tar.gz{,.sig}
+	$(call PGP_VERIFY,youtube-dl-$(YOUTUBE-DL_VERSION).tar.gz)
 	$(call EXTRACT_TAR,youtube-dl-$(YOUTUBE-DL_VERSION).tar.gz,youtube-dl-$(YOUTUBE-DL_VERSION),youtube-dl)
 	$(call DO_PATCH,youtube-dl,youtube-dl,-p1)
 


### PR DESCRIPTION
This PR updates ``youtube-dl`` to the latest released version, 2021.04.17, and retrieves the tarballs' signature, which is later checked with the ``PGP_VERIFY`` function. Making this into a draft until I've confirmed everything works.
