### PR TITLE
libuv1 liobiosexec

### DIFF
--- a/build_info/libuv1.control
+++ b/build_info/libuv1.control
@@ -2,7 +2,7 @@ Package: libuv1
 Version: @DEB_LIBUV1_V@
 Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
-Section: Development
+Section: Libraries
 Priority: optional
 Depends: libiosexec1
 Multi-Arch: foreign

--- a/build_info/libuv1.control.macosx
+++ b/build_info/libuv1.control.macosx
@@ -2,7 +2,7 @@ Package: libuv1
 Version: @DEB_LIBUV1_V@
 Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
-Section: Development
+Section: Libraries
 Priority: optional
 Multi-Arch: foreign
 Description: asynchronous event notification library - runtime library

--- a/build_info/libuv1.control.macosx
+++ b/build_info/libuv1.control.macosx
@@ -4,6 +4,5 @@ Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
 Section: Development
 Priority: optional
-Depends: libiosexec1
 Multi-Arch: foreign
 Description: asynchronous event notification library - runtime library

--- a/libuv1.mk
+++ b/libuv1.mk
@@ -6,6 +6,12 @@ SUBPROJECTS    += libuv1
 LIBUV1_VERSION := 1.41.0
 DEB_LIBUV1_V   ?= $(LIBUV1_VERSION)-1
 
+ifeq (,$(findstring darwin,$(MEMO_TARGET)))
+LIBUV1_CONFIGURE_ARGS := LDFLAGS="$$LDFLAGS -liosexec"
+else
+LIBUV1_CONFIGURE_ARGS :=
+endif
+
 libuv1-setup: setup
 	wget -q -nc -P $(BUILD_SOURCE) https://dist.libuv.org/dist/v$(LIBUV1_VERSION)/libuv-v$(LIBUV1_VERSION).tar.gz
 	$(call EXTRACT_TAR,libuv-v$(LIBUV1_VERSION).tar.gz,libuv-v$(LIBUV1_VERSION),libuv1)
@@ -14,17 +20,25 @@ libuv1-setup: setup
 	$(SED) -i '/#include <unistd.h>/a #include "darwin-stub.h"' $(BUILD_WORK)/libuv1/src/unix/darwin.c
 	$(SED) -i 's,Versions/A/CoreFoundation,CoreFoundation,' $(BUILD_WORK)/libuv1/src/unix/darwin.c
 	$(SED) -i 's,Versions/A/IOKit,IOKit,' $(BUILD_WORK)/libuv1/src/unix/darwin.c
+ifeq (,$(findstring darwin,$(MEMO_TARGET)))
+		$(SED) -i '1s/^/#include <libiosexec.h>\n/' $(BUILD_WORK)/libuv1/src/unix/process.c
+endif
 
 ifneq ($(wildcard $(BUILD_WORK)/libuv1/.build_complete),)
 libuv1:
 	@echo "Using previously built libuv1."
 else
+ifeq (,$(findstring darwin,$(MEMO_TARGET)))
+libuv1: libuv1-setup libiosexec
+else
 libuv1: libuv1-setup
+endif
 	if ! [ -f $(BUILD_WORK)/libuv1/configure ]; then \
 		cd $(BUILD_WORK)/libuv1 && ./autogen.sh; \
 	fi
 	cd $(BUILD_WORK)/libuv1 && ./configure -C \
-		$(DEFAULT_CONFIGURE_FLAGS)
+		$(DEFAULT_CONFIGURE_FLAGS) \
+		$(LIBUV1_CONFIGURE_ARGS)
 	+$(MAKE) -C $(BUILD_WORK)/libuv1
 	+$(MAKE) -C $(BUILD_WORK)/libuv1 install \
 		DESTDIR="$(BUILD_STAGE)/libuv1"


### PR DESCRIPTION
This fixes EPERM issues on anything that uses libuv for spawning files (which includes NodeJS). Closes #689  