### PR TITLE
Update youtube-dl

### DIFF
--- a/build_info/youtube-dl.control
+++ b/build_info/youtube-dl.control
@@ -6,6 +6,7 @@ Depends: python3
 Recommends: aria2 | wget | curl, ffmpeg, rtmpdump
 Section: Multimedia
 Priority: optional
+Homepage: https://www.github.com/ytdl-org/youtube-dl
 Description: downloader of videos from YouTube and other sites
  youtube-dl is a small command-line program to download videos from
  YouTube.com and other sites that don't provide direct links to the

--- a/youtube-dl.mk
+++ b/youtube-dl.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS        += youtube-dl
-YOUTUBE-DL_VERSION := 2021.04.26
+YOUTUBE-DL_VERSION := 2021.05.16
 DEB_YOUTUBE-DL_V   ?= $(YOUTUBE-DL_VERSION)
 
 youtube-dl-setup: setup


### PR DESCRIPTION
This PR updates ``youtube-dl`` to version 2021.05.16, while adding the Homepage field to the package's control file.
