### PR TITLE
Repopulate extreme-clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -975,4 +975,7 @@ endif # ($(MEMO_QUIET),1)
 clean::
 	rm -rf $(BUILD_WORK) $(BUILD_BASE) $(BUILD_STAGE)
 
+extreme-clean: clean
+	rm -rf $(BUILD_DIST)
+
 .PHONY: clean setup


### PR DESCRIPTION
This PR adds back the ``extreme-clean`` option, which removes all files (including compiled debs) from the working tree.