### PR TITLE
Critical: Fix system-cmds and Chimera

### DIFF
--- a/build_info/system-cmds.control
+++ b/build_info/system-cmds.control
@@ -3,6 +3,7 @@ Version: @DEB_SYSTEM-CMDS_V@
 Architecture: @DEB_ARCH@
 Essential: yes
 Maintainer: @DEB_MAINTAINER@
+Pre-Depends: libiosexec1
 Depends: firmware-sbin, file-cmds, libcrypt2, libpam2
 Recommends: vi
 Provides: login, passwd, reboot

--- a/system-cmds.mk
+++ b/system-cmds.mk
@@ -7,7 +7,7 @@ ifeq (,$(findstring darwin,$(MEMO_TARGET)))
 STRAPPROJECTS       += system-cmds
 SYSTEM-CMDS_VERSION := 854.40.2
 PWDARWIN_COMMIT     := 5d48a8af168d8ffb24021d32385d3ecfa699e51d
-DEB_SYSTEM-CMDS_V   ?= $(SYSTEM-CMDS_VERSION)-10
+DEB_SYSTEM-CMDS_V   ?= $(SYSTEM-CMDS_VERSION)-11
 
 system-cmds-setup: setup libxcrypt
 	wget -q -nc -P $(BUILD_SOURCE) https://opensource.apple.com/tarballs/system_cmds/system_cmds-$(SYSTEM-CMDS_VERSION).tar.gz


### PR DESCRIPTION
This critical PR fixes a root problem, specifically targeting Chimera users, who's entire bootstrap would break when upgrading ``system-cmds``. This was caused due to the order in which upgrades were installed; ``libiosexec1`` should now be installed beforehand, and upgrades for Chimera users should now work.

Note that this issue only occurs on devices that have recently installed Chimera; users with an already bootstrap'd device should not be affected by this issue. In case this issue pops its head up again, Chimera users will be required to install ``libiosexec1`` first before upgrading other packages, or everything will be borked.