### PR TITLE
zsh: Change installation path

### DIFF
--- a/build_info/zsh-syntax-highlighting.control
+++ b/build_info/zsh-syntax-highlighting.control
@@ -6,10 +6,11 @@ Depends: zsh
 Enhances: zsh
 Section: Terminal_Support
 Priority: optional
+Homepage: https://github.com/zsh-users/zsh-syntax-highlighting
 Description: Fish shell like syntax highlighting for zsh
- This package provides syntax highlighting for the shell zsh.  It enables
+ This package provides syntax highlighting for the shell zsh. It enables
  highlighting of commands whilst they are typed at a zsh prompt into an
- interactive terminal.  This helps in reviewing commands before running
+ interactive terminal. This helps in reviewing commands before running
  them, particularly in catching syntax errors.
  .
  This feature is inspired by the Fish shell, which provides it by default.

--- a/zsh-syntax-highlighting.mk
+++ b/zsh-syntax-highlighting.mk
@@ -4,7 +4,7 @@ endif
 
 SUBPROJECTS                     += zsh-syntax-highlighting
 ZSH-SYNTAX-HIGHLIGHTING_VERSION := 0.7.1
-DEB_ZSH-SYNTAX-HIGHLIGHTING_V   ?= $(ZSH-SYNTAX-HIGHLIGHTING_VERSION)
+DEB_ZSH-SYNTAX-HIGHLIGHTING_V   ?= $(ZSH-SYNTAX-HIGHLIGHTING_VERSION)-1
 
 zsh-syntax-highlighting-setup: setup
 	$(call GITHUB_ARCHIVE,zsh-users,zsh-syntax-highlighting,$(ZSH-SYNTAX-HIGHLIGHTING_VERSION),$(ZSH-SYNTAX-HIGHLIGHTING_VERSION))
@@ -16,7 +16,9 @@ zsh-syntax-highlighting:
 else
 zsh-syntax-highlighting: zsh-syntax-highlighting-setup ncurses gettext file
 	+$(MAKE) -C $(BUILD_WORK)/zsh-syntax-highlighting install \
-		PREFIX='$(BUILD_STAGE)/zsh-syntax-highlighting/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)'
+		NAME="zsh" \
+		PREFIX="$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)" \
+		DESTDIR="$(BUILD_STAGE)/zsh-syntax-highlighting"
 	touch $(BUILD_WORK)/zsh-syntax-highlighting/.build_complete
 endif
 


### PR DESCRIPTION
This PR introduces a minor change on where ``zsh-syntax-highlighting`` is installed; sourcing ``zsh-syntax-highlighting.zsh`` should be a lot shorter as opposed to older versions.

```zsh
# Before
$ source /usr/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh

# After
$ source /usr/share/zsh/zsh-syntax-highlighting.zsh
```

I also changed some minor mistakes in the control file and added a link to the homepage of the project.
