### PR TITLE
Add python3-prompt-toolkit

### DIFF
--- a/build_info/python3-prompt-toolkit.control
+++ b/build_info/python3-prompt-toolkit.control
@@ -1,0 +1,29 @@
+Package: python3-prompt-toolkit
+Version: @DEB_PYTHON3-PROMPT-TOOLKIT_V@
+Architecture: @DEB_ARCH@
+Maintainer: @DEB_MAINTAINER@
+Depends: python3
+Section: Python
+Priority: optional
+Homepage: https://github.com/prompt-toolkit/python-prompt-toolkit
+Description: Library for interactive command-line applications.
+ python-prompt-toolkit is a library for building powerful interactive
+ command-line applications in Python. It can also work as an alternative
+ for GNU readline, but it can do much more than that.
+ .
+ Some features:
+ * Pure Python
+ * Syntax highlighting of the input while typing
+ * Multi-line input editing
+ * Advanced code completion
+ * Both Emacs and Vi key bindings (similar to readline)
+ * Even some advanced Vi functionality, like named registers and digraphs
+ * Reverse and forward incremental search
+ * Works well with Unicode double width characters (e.g Chinese input)
+ * Selecting text for copy/paste
+ * Support for bracketed paste
+ * Mouse support for cursor positioning and scrolling
+ * Auto suggestions (e.g fish)
+ * Multiple input buffers
+ * No global state
+ * Lightweight, the only dependencies are Pygments and wcwidth

--- a/python3-prompt-toolkit.mk
+++ b/python3-prompt-toolkit.mk
@@ -1,0 +1,40 @@
+ifneq ($(PROCURSUS),1)
+$(error Use the main Makefile)
+endif
+
+SUBPROJECTS                    += python3-prompt-toolkit
+PYTHON3-PROMPT-TOOLKIT_VERSION := 3.0.18
+DEB_PYTHON3-PROMPT-TOOLKIT_V   ?= $(PYTHON3-PROMPT-TOOLKIT_VERSION)
+
+python3-prompt-toolkit-setup: setup
+	$(call GITHUB_ARCHIVE,prompt-toolkit,python-prompt-toolkit,$(PYTHON3-PROMPT-TOOLKIT_VERSION),$(PYTHON3-PROMPT-TOOLKIT_VERSION))
+	$(call EXTRACT_TAR,python-prompt-toolkit-$(PYTHON3-PROMPT-TOOLKIT_VERSION).tar.gz,python-prompt-toolkit-$(PYTHON3-PROMPT-TOOLKIT_VERSION),python3-prompt-toolkit)
+
+ifneq ($(wildcard $(BUILD_WORK)/python3-prompt-toolkit/.build_complete),)
+python3-prompt-toolkit:
+	@echo "Using previously built python-prompt-toolkit."
+else
+python3-prompt-toolkit: python3-prompt-toolkit-setup python3
+	cd $(BUILD_WORK)/python3-prompt-toolkit && $(DEFAULT_SETUP_PY_ENV) python3 ./setup.py install \
+		--install-layout=deb \
+		--prefix=$(MEMO_PREFIX)$(MEMO_SUB_PREFIX) \
+		--root=$(BUILD_STAGE)/python3-prompt-toolkit
+	find $(BUILD_STAGE)/python3-prompt-toolkit -name __pycache__ -prune -exec rm -rf {} \;
+	touch $(BUILD_WORK)/python3-prompt-toolkit/.build_complete
+endif
+
+python3-prompt-toolkit-package: python3-prompt-toolkit-stage
+	# python-prompt-toolkit.mk Package Structure
+	rm -rf $(BUILD_DIST)/python3-prompt-toolkit
+	cp -a $(BUILD_STAGE)/python3-prompt-toolkit $(BUILD_DIST)
+
+	# python-prompt-toolkit.mk Sign
+	$(call SIGN,python3-prompt-toolkit,general.xml)
+
+	# python-prompt-toolkit.mk Make .debs
+	$(call PACK,python3-prompt-toolkit,DEB_PYTHON3-PROMPT-TOOLKIT_V)
+
+	# python-prompt-toolkit.mk Build Cleanup
+	rm -rf $(BUILD_DIST)/python3-prompt-toolkit
+
+.PHONY: python3-prompt-toolkit python3-prompt-toolkit-package


### PR DESCRIPTION
This PR adds ``python3-prompt-toolkit``, a library that makes it easier to make command-line applications in Python; this is a dependency needed by ``xonsh``, and is also an alternative to GNU ``readline``.