### PR TITLE
gh: Update to 1.11.0

### DIFF
--- a/build_info/gh.control
+++ b/build_info/gh.control
@@ -6,7 +6,7 @@ Section: Development
 Priority: optional
 Homepage: https://www.github.com/cli/cli
 Description: GitHub command-line tool.
- gh is GitHub on the command line. It brings pull requests, issues, and
- other GitHub concepts to the terminal next to where you are already working
- with git and your code.
+ gh is GitHub on the command line. It brings pull requests,
+ issues, and other GitHub concepts to the terminal text to
+ where you're already working with Git and your code.
 Name: GitHub CLI

--- a/gh.mk
+++ b/gh.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS += gh
-GH_VERSION  := 1.9.2
+GH_VERSION  := 1.11.0
 DEB_GH_V    ?= $(GH_VERSION)
 
 gh-setup: setup
@@ -31,10 +31,7 @@ endif
 gh-package: gh-stage
 	# gh.mk Package Structure
 	rm -rf $(BUILD_DIST)/gh
-	mkdir -p $(BUILD_DIST)/gh/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)
-
-	# gh.mk Prep gh
-	cp -a $(BUILD_STAGE)/gh/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/{bin,share} $(BUILD_DIST)/gh/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)
+	cp -a $(BUILD_STAGE)/gh $(BUILD_DIST)
 
 	# gh.mk Sign
 	$(call SIGN,gh,general.xml)


### PR DESCRIPTION
This PR updates ``gh`` to the latest released version, 1.11.0. The update was only tested on Linux (specifically, Debian Buster), but (theoretically) it should still build on iOS as well. The commit message has more information about what was changed in this version.

I can't test this myself on iOS, as "clang is brokeish", according to Hayden, and I'm not waiting 2+ weeks to re-compile ``llvm``; this (overall) impacts the ability for ``libiosexec`` to linked to the package, which causes the manpages of ``gh`` to not build.