### PR TITLE
xonsh: Add extra dependencies

### DIFF
--- a/build_info/python3-prompt-toolkit.control
+++ b/build_info/python3-prompt-toolkit.control
@@ -2,7 +2,7 @@ Package: python3-prompt-toolkit
 Version: @DEB_PYTHON3-PROMPT-TOOLKIT_V@
 Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
-Depends: python3
+Depends: python3, python3-wcwidth
 Section: Python
 Priority: optional
 Homepage: https://github.com/prompt-toolkit/python-prompt-toolkit

--- a/makefiles/python3-prompt-toolkit.mk
+++ b/makefiles/python3-prompt-toolkit.mk
@@ -4,7 +4,7 @@ endif
 
 SUBPROJECTS                    += python3-prompt-toolkit
 PYTHON3-PROMPT-TOOLKIT_VERSION := 3.0.18
-DEB_PYTHON3-PROMPT-TOOLKIT_V   ?= $(PYTHON3-PROMPT-TOOLKIT_VERSION)
+DEB_PYTHON3-PROMPT-TOOLKIT_V   ?= $(PYTHON3-PROMPT-TOOLKIT_VERSION)-1
 
 python3-prompt-toolkit-setup: setup
 	$(call GITHUB_ARCHIVE,prompt-toolkit,python-prompt-toolkit,$(PYTHON3-PROMPT-TOOLKIT_VERSION),$(PYTHON3-PROMPT-TOOLKIT_VERSION))
@@ -14,7 +14,7 @@ ifneq ($(wildcard $(BUILD_WORK)/python3-prompt-toolkit/.build_complete),)
 python3-prompt-toolkit:
 	@echo "Using previously built python-prompt-toolkit."
 else
-python3-prompt-toolkit: python3-prompt-toolkit-setup python3
+python3-prompt-toolkit: python3-prompt-toolkit-setup python3-wcwidth
 	cd $(BUILD_WORK)/python3-prompt-toolkit && $(DEFAULT_SETUP_PY_ENV) python3 ./setup.py install \
 		--install-layout=deb \
 		--prefix=$(MEMO_PREFIX)$(MEMO_SUB_PREFIX) \

--- a/makefiles/xonsh.mk
+++ b/makefiles/xonsh.mk
@@ -4,7 +4,7 @@ endif
 
 SUBPROJECTS   += xonsh
 XONSH_VERSION := 0.9.27
-DEB_XONSH_V   ?= $(XONSH_VERSION)-1
+DEB_XONSH_V   ?= $(XONSH_VERSION)-2
 
 xonsh-setup: setup
 	# Download main branch instead of tag for 0.9.27
@@ -16,7 +16,7 @@ ifneq ($(wildcard $(BUILD_WORK)/xonsh/.build_complete),)
 xonsh:
 	@echo "Using previously built xonsh."
 else
-xonsh: xonsh-setup python3
+xonsh: xonsh-setup python3-prompt-toolkit
 	cd $(BUILD_WORK)/xonsh && $(DEFAULT_SETUP_PY_ENV) python3 ./setup.py install \
 		--install-layout=deb \
 		--root=$(BUILD_STAGE)/xonsh \


### PR DESCRIPTION
This PR is a small update to ``xonsh`` to include a new dependency, [``python3-wcwidth``](https://github.com/jquast/wcwidth), which is provided by [#839](https://github.com/ProcursusTeam/Procursus/pull/839). Other changes made are listed in the commit message.