### PR TITLE
Makefile: Clear tarballs with extreme-clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1102,6 +1102,6 @@ clean::
 	rm -rf $(BUILD_ROOT)/build_{base,stage,work}
 
 extreme-clean: clean
-	rm -rf $(BUILD_ROOT)/build_dist
+	rm -rf $(BUILD_ROOT)/build_{source,strap,dist}
 
 .PHONY: clean setup


### PR DESCRIPTION
This PR changes ``extreme-clean`` so that old downloaded project tarballs are cleared out when using the Makefile function. You can use this in case ``rebuild-(tool)`` fails with outdated tarballs you have on your build system setup.