### PR TITLE
Adds logcleaner

### DIFF
--- a/build_info/logcleaner.control
+++ b/build_info/logcleaner.control
@@ -1,0 +1,10 @@
+Package: logcleaner
+Version: @DEB_LOGCLEANER_V@
+Architecture: @DEB_ARCH@
+Maintainer: @DEB_MAINTAINER@
+Depends: findutils, launchctl
+Section: Administration
+Priority: standard
+Description: Automatically cleans up old crash reports collected by iOS.
+ Every day, or on boot, this will run a simple script that cleans up .ips
+ reports which are older than 3 days.

--- a/build_info/logcleaner.extrainst_
+++ b/build_info/logcleaner.extrainst_
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -e
+
+case "$1" in
+    (install)
+    /bin/launchctl load -w @MEMO_PREFIX@/Library/LaunchDaemons/moe.absolucy.logcleaner.plist
+    ;;
+	(upgrade)
+	/bin/launchctl unload @MEMO_PREFIX@/Library/LaunchDaemons/moe.absolucy.logcleaner.plist
+    /bin/launchctl load @MEMO_PREFIX@/Library/LaunchDaemons/moe.absolucy.logcleaner.plist
+	;;
+	(*)
+	exit 0
+	;;
+esac
+
+exit 0

--- a/build_info/logcleaner.extrainst_
+++ b/build_info/logcleaner.extrainst_
@@ -3,12 +3,12 @@
 set -e
 
 case "$1" in
-    (install)
-    /bin/launchctl load -w @MEMO_PREFIX@/Library/LaunchDaemons/moe.absolucy.logcleaner.plist
-    ;;
+	(install)
+	/bin/launchctl load -w @MEMO_PREFIX@/Library/LaunchDaemons/moe.absolucy.logcleaner.plist
+	;;
 	(upgrade)
 	/bin/launchctl unload @MEMO_PREFIX@/Library/LaunchDaemons/moe.absolucy.logcleaner.plist
-    /bin/launchctl load @MEMO_PREFIX@/Library/LaunchDaemons/moe.absolucy.logcleaner.plist
+	/bin/launchctl load @MEMO_PREFIX@/Library/LaunchDaemons/moe.absolucy.logcleaner.plist
 	;;
 	(*)
 	exit 0

--- a/build_info/logcleaner.prerm
+++ b/build_info/logcleaner.prerm
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+
+case "$1" in
+	(remove|purge)
+	/bin/launchctl unload @MEMO_PREFIX@/Library/LaunchDaemons/moe.absolucy.logcleaner.plist
+	;;
+	(*)
+	exit 0
+	;;
+esac
+
+exit 0

--- a/build_misc/moe.absolucy.logcleaner.plist
+++ b/build_misc/moe.absolucy.logcleaner.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>moe.absolucy.logcleaner</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>@MEMO_PREFIX@@MEMO_SUB_PREFIX@/bin/find</string>
+		<string>/var/mobile/Library/Logs/CrashReporter</string>
+		<string>-mindepth</string>
+		<string>1</string>
+		<string>-mtime</string>
+		<string>+3</string>
+		<string>-delete</string>
+	</array>
+	<key>RunAtLoad</key>
+    <true/>
+    <key>StartInterval</key>
+    <integer>86400</integer>
+</dict>
+</plist>

--- a/build_misc/moe.absolucy.logcleaner.plist
+++ b/build_misc/moe.absolucy.logcleaner.plist
@@ -15,8 +15,8 @@
 		<string>-delete</string>
 	</array>
 	<key>RunAtLoad</key>
-    <true/>
-    <key>StartInterval</key>
-    <integer>86400</integer>
+	<true/>
+	<key>StartInterval</key>
+	<integer>86400</integer>
 </dict>
 </plist>

--- a/makefiles/logcleaner.mk
+++ b/makefiles/logcleaner.mk
@@ -2,6 +2,8 @@ ifneq ($(PROCURSUS),1)
 $(error Use the main Makefile)
 endif
 
+ifeq (,$(findstring darwin,$(MEMO_TARGET)))
+
 SUBPROJECTS        += logcleaner
 LOGCLEANER_VERSION := 1.0.0
 DEB_LOGCLEANER_V   ?= $(LOGCLEANER_VERSION)
@@ -33,3 +35,5 @@ logcleaner-package: logcleaner-stage
 	rm -rf $(BUILD_DIST)/logcleaner
 
 .PHONY: logcleaner logcleaner-package
+
+endif

--- a/makefiles/logcleaner.mk
+++ b/makefiles/logcleaner.mk
@@ -2,8 +2,6 @@ ifneq ($(PROCURSUS),1)
 $(error Use the main Makefile)
 endif
 
-ifneq (,$(findstring darwin,$(MEMO_TARGET)))
-
 SUBPROJECTS        += logcleaner
 LOGCLEANER_VERSION := 1.0.0
 DEB_LOGCLEANER_V   ?= $(LOGCLEANER_VERSION)
@@ -35,5 +33,3 @@ logcleaner-package: logcleaner-stage
 	rm -rf $(BUILD_DIST)/logcleaner
 
 .PHONY: logcleaner logcleaner-package
-
-endif

--- a/makefiles/logcleaner.mk
+++ b/makefiles/logcleaner.mk
@@ -1,0 +1,39 @@
+ifneq ($(PROCURSUS),1)
+$(error Use the main Makefile)
+endif
+
+ifeq (,$(findstring darwin,$(MEMO_TARGET)))
+
+STRAPPROJECTS += logcleaner
+LOGCLEANER_VERSION := 1.0.0
+DEB_LOGCLEANER_V   ?= $(LOGCLEANER_VERSION)
+
+logcleaner-setup: setup
+	mkdir -p $(BUILD_STAGE)/logcleaner/$(MEMO_PREFIX)/Library/LaunchDaemons
+
+ifneq ($(wildcard $(BUILD_WORK)/logcleaner/.build_complete),)
+logcleaner:
+	@echo "Using previously built logcleaner."
+else
+logcleaner: logcleaner-setup
+	$(SED) -e 's|@MEMO_PREFIX@|$(MEMO_PREFIX)|g' -e 's|@MEMO_SUB_PREFIX@|$(MEMO_SUB_PREFIX)|g' < $(BUILD_MISC)/moe.absolucy.logcleaner.plist > $(BUILD_STAGE)/logcleaner/$(MEMO_PREFIX)/Library/LaunchDaemons/moe.absolucy.logcleaner.plist
+	mkdir -p $(BUILD_WORK)/logcleaner
+	touch $(BUILD_WORK)/logcleaner/.build_complete
+endif
+
+logcleaner-package: logcleaner-stage
+	# logcleaner.mk Package Structure
+	rm -rf $(BUILD_DIST)/logcleaner
+
+	# logcleaner.mk Prep logcleaner
+	cp -a $(BUILD_STAGE)/logcleaner $(BUILD_DIST)
+
+	# logcleaner.mk Make .debs
+	$(call PACK,logcleaner,DEB_LOGCLEANER_V)
+
+	# logcleaner.mk Build cleanup
+	rm -rf $(BUILD_DIST)/logcleaner
+
+.PHONY: logcleaner logcleaner-package
+
+endif

--- a/makefiles/logcleaner.mk
+++ b/makefiles/logcleaner.mk
@@ -2,9 +2,9 @@ ifneq ($(PROCURSUS),1)
 $(error Use the main Makefile)
 endif
 
-ifeq (,$(findstring darwin,$(MEMO_TARGET)))
+ifneq (,$(findstring darwin,$(MEMO_TARGET)))
 
-STRAPPROJECTS += logcleaner
+SUBPROJECTS        += logcleaner
 LOGCLEANER_VERSION := 1.0.0
 DEB_LOGCLEANER_V   ?= $(LOGCLEANER_VERSION)
 


### PR DESCRIPTION
simple launchctl script that runs `find /var/mobile/Library/Logs/CrashReporter -mindepth 1 -mtime +3 -delete` every 6 hours / on boot, which deletes crash logs older than 3 days.

originally i had some dumb program that did it, but turns out it can be done with just `find` (thanks @elihwyma)