### PR TITLE
Update youtube-dl to 2021.06.06

### DIFF
--- a/makefiles/youtube-dl.mk
+++ b/makefiles/youtube-dl.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS        += youtube-dl
-YOUTUBE-DL_VERSION := 2021.05.16
+YOUTUBE-DL_VERSION := 2021.06.06
 DEB_YOUTUBE-DL_V   ?= $(YOUTUBE-DL_VERSION)
 
 youtube-dl-setup: setup
@@ -28,10 +28,10 @@ endif
 youtube-dl-package: youtube-dl-stage
 	# youtube-dl.mk Package Structure
 	rm -rf $(BUILD_DIST)/youtube-dl
-	mkdir -p $(BUILD_DIST)/youtube-dl
-
-	# youtube-dl.mk Prep youtube-dl
 	cp -a $(BUILD_STAGE)/youtube-dl $(BUILD_DIST)
+
+	# youtube-dl.mk Sign
+	$(call SIGN,youtube-dl,general.xml)
 
 	# youtube-dl.mk Make .debs
 	$(call PACK,youtube-dl,DEB_YOUTUBE-DL_V)


### PR DESCRIPTION
This PR updates ``youtube-dl`` to v2021.06.06. Specific changes are listed in the commit message.