### PR TITLE
Auto assign PRs to project board

### DIFF
--- a/.github/workflows/assign-project.yml
+++ b/.github/workflows/assign-project.yml
@@ -3,7 +3,7 @@ name: Auto Assign PRs/Issues to Project
 on:
   issues:
     types: [opened]
-  pull_request_type:
+  pull_request_target:
     types: [opened]
 env:
   MY_GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}

--- a/.github/workflows/assign-project.yml
+++ b/.github/workflows/assign-project.yml
@@ -6,7 +6,7 @@ on:
   pull_request_target:
     types: [opened]
 env:
-  MY_GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
+  MY_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   assign_project:

--- a/.github/workflows/assign-project.yml
+++ b/.github/workflows/assign-project.yml
@@ -1,0 +1,20 @@
+name: Auto Assign PRs/Issues to Project
+
+on:
+  issues:
+    types: [opened]
+  pull_request_type:
+    types: [opened]
+env:
+  MY_GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
+
+jobs:
+  assign_project:
+    runs-on: ubuntu-latest
+    name: Assign to Procursus Project
+    steps:
+      - name: Assign new Issues/PRs to Project
+        uses: srggrs/assign-one-project-github-action@1.2.1
+        if: github.event.action == 'opened'
+        with:
+          project: https://github.com/orgs/ProcursusTeam/projects/1


### PR DESCRIPTION
This PR adds a workflow that automatically assigns PRs to the project board of ProcursusTeam. I'm unsure as to how I'm supposed to test this, but it's likely that will work once this is merged and someone opens either an issue or PR (since it also works with issues). 

Not much handling to be done, since the project board that these things are being assigned are already automated; this just removes the hassle of one of the team members adding new PRs and issues to their corresponding places.