### PR TITLE
Supersedes #895: Add Discord server reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <p align="center">
     <h1 align="center">Procursus</h1>
     <p align="center">
-        <a href="https://github.com/ProcursusTeam/Procursus/wiki">Documentation</a> •
-        <a href="https://procursus.creator-spring.com/">Merchandise</a> •
-        <a href="https://github.com/ProcursusTeam/Procursus/graphs/contributors">Contributors</a>
+        <a href="https://github.com/ProcursusTeam/Procursus/wiki">Documentation</a> —
+        <a href="https://procursus.creator-spring.com/">Merchandise</a> —
+        <a href="https://diatr.us/discord">Discord</a>
     </p>
 </p>
 


### PR DESCRIPTION
This PR supersedes and closes [#895](https://github.com/ProcursusTeam/Procursus/pull/895), adding a Discord server reference to the README, making it easier to find on the project's "homepage". 