### PR TITLE
Remove all rev references from package generator

### DIFF
--- a/build_tools/new_package.sh
+++ b/build_tools/new_package.sh
@@ -29,13 +29,13 @@ checkbuild() {
 
 downloadlink() {
 	if [ "$(${SED} 's|^.*://||' <<< "${1}" | cut -d'/' -f1)" = "github.com" ]; then
-		echo -e "\t$\(call GITHUB_ARCHIVE,$(${SED} 's|^.*://||' <<< "${1}" | cut -d'/' -f2),$(${SED} 's|^.*://||' <<< "${1}" | cut -d'/' -f3),$\(${4}_VERSION\),$(echo "${1}" | rev | cut -d'/' -f1 | rev | ${SED} 's/\.tar.*//g' | ${SED} "s/${2}//g")$\(${4}_VERSION\)\)"
+		echo -e "\t$\(call GITHUB_ARCHIVE,$(${SED} 's|^.*://||' <<< "${1}" | cut -d'/' -f2),$(${SED} 's|^.*://||' <<< "${1}" | cut -d'/' -f3),$\(${4}_VERSION\),$(echo "${1}" | cut -d'/' -f1 | ${SED} 's/\.tar.*//g' | ${SED} "s/${2}//g")$\(${4}_VERSION\)\)"
 	else
-		if echo "${1}" | rev | cut -d'/' -f1 | rev | ${SED} 's/\.tar.*//g' | ${SED} "s/${2}//g" | grep "${3}" &>/dev/null; then
+		if echo "${1}" | cut -d'/' -f1 | ${SED} 's/\.tar.*//g' | ${SED} "s/${2}//g" | grep "${3}" &>/dev/null; then
 			echo -e "\twget -q -nc -P\$(BUILD_SOURCE) $(${SED} "s/${2}/\$(${4}_VERSION)/g" <<< "$1")"
 		else
-			echo -e "\t-[ ! -f "$\(BUILD_SOURCE\)/${3}-$\(${4}_VERSION\).tar.$(rev <<< "$download" | cut -d'.' -f1 | rev)" ] \&\& \\
-\t	\twget -q -nc -O\$(BUILD_SOURCE)/${3}-\$(${4}_VERSION).tar.$(rev <<< "$download" | cut -d'.' -f1 | rev) \\
+			echo -e "\t-[ ! -f "$\(BUILD_SOURCE\)/${3}-$\(${4}_VERSION\).tar.$("$download" | cut -d'.' -f1)" ] \&\& \\
+\t	\twget -q -nc -O\$(BUILD_SOURCE)/${3}-\$(${4}_VERSION).tar.$("$download" | cut -d'.' -f1) \\
 \t	\t\t$(${SED} "s/${2}/\$(${4}_VERSION)/g" <<< "$1")"
 		fi
 	fi
@@ -53,7 +53,7 @@ main() {
 		-e "s/@PKG@/${formatpkg}/g" \
 		-e "s/@PKG_VERSION@/${ver}/g" \
 		-e "s|@download@|$(downloadlink "$download" "$ver" "$pkg" "$formatpkg")|g" \
-		-e "s|@compression@|$(rev <<< "$download" | cut -d'.' -f1 | rev)|g" \
+		-e "s|@compression@|$("$download" | cut -d'.' -f1)|g" \
 		build_misc/templates/${build}.mk > makefiles/${pkg}.mk
 }
 


### PR DESCRIPTION
This PR removes all references of ``rev``, which is unnecessary, from the Makefile package generator.