### PR TITLE
Fix #915: Small changes to iDeviceHacked keyring

### DIFF
--- a/build_info/idevicehacked-keyring.control
+++ b/build_info/idevicehacked-keyring.control
@@ -4,5 +4,6 @@ Architecture: all
 Maintainer: @DEB_MAINTAINER@
 Section: Keyrings
 Priority: optional
-Description: GnuPG keys for the iDeviceHacked repositories
+Homepage: https://idevicehacked.com/
+Description: GnuPG keys for the iDeviceHacked repository
 Name: iDeviceHacked APT Keyring


### PR DESCRIPTION
This PR makes the following changes to the iDeviceHacked keyring package
- Adds repo URL under the homepage field
- Fix small typo in control file description field