### PR TITLE
Full WebAssembly toolchain

### DIFF
--- a/build_info/binaryen.control
+++ b/build_info/binaryen.control
@@ -4,7 +4,8 @@ Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
 Section: Development
 Priority: optional
-Description: Binaryen is a compiler and toolchain infrastructure library for WebAssembly, written in C++. 
- It aims to make compiling to WebAssembly easy, fast, and effective.
+Description: compiler and toolchain infrastructure for WebAssembly.
+ Binaryen is a compiler and toolchain infrastructure library for WebAssembly,
+ written in C++. It aims to make compiling to WebAssembly easy, fast, and
+ effective.
 Homepage: https://webassembly.org
-Tag: purpose::console, role::developer

--- a/build_info/binaryen.control
+++ b/build_info/binaryen.control
@@ -1,0 +1,10 @@
+Package: binaryen
+Version: @DEB_BINARYEN_V@
+Architecture: @DEB_ARCH@
+Maintainer: @DEB_MAINTAINER@
+Section: Development
+Priority: optional
+Description: Binaryen is a compiler and toolchain infrastructure library for WebAssembly, written in C++. 
+ It aims to make compiling to WebAssembly easy, fast, and effective.
+Homepage: https://webassembly.org
+Tag: purpose::console, role::developer

--- a/build_info/build-essential-wasi.control
+++ b/build_info/build-essential-wasi.control
@@ -1,0 +1,7 @@
+Package: build-essential-wasi
+Version: @DEB_WASI_V@
+Architecture: @DEB_ARCH@
+Maintainer: @DEB_MAINTAINER@
+Section: Development
+Priority: optional
+Description: Contains an SDK for the wasm32-wasi platform.

--- a/build_info/libwasmer-dev.control
+++ b/build_info/libwasmer-dev.control
@@ -1,0 +1,9 @@
+Package: libwasmer-dev
+Version: @DEB_WASMER_V@
+Architecture: @DEB_ARCH@
+Maintainer: @DEB_MAINTAINER@
+Section: Development
+Priority: optional
+Depends: libwasmer (= @DEB_WASMER_V@)
+Homepage: https://wasmer.io/
+Description: An open-source runtime for executing WebAssembly.

--- a/build_info/libwasmer.control
+++ b/build_info/libwasmer.control
@@ -1,0 +1,8 @@
+Package: libwasmer
+Version: @DEB_WASMER_V@
+Architecture: @DEB_ARCH@
+Maintainer: @DEB_MAINTAINER@
+Section: Libraries
+Priority: optional
+Homepage: https://wasmer.io/
+Description: An open-source runtime for executing WebAssembly.

--- a/build_info/wabt.control
+++ b/build_info/wabt.control
@@ -7,4 +7,3 @@ Priority: optional
 Description: A suite of tools for WebAssembly.
 Homepage: https://webassembly.org
 Name: Web Assembly Binary Toolkit
-Tag: purpose::console, role::developer

--- a/build_info/wabt.control
+++ b/build_info/wabt.control
@@ -1,0 +1,10 @@
+Package: wabt
+Version: @DEB_WABT_V@
+Architecture: @DEB_ARCH@
+Maintainer: @DEB_MAINTAINER@
+Section: Development
+Priority: optional
+Description: A suite of tools for WebAssembly.
+Homepage: https://webassembly.org
+Name: Web Assembly Binary Toolkit
+Tag: purpose::console, role::developer

--- a/build_info/wapm.control
+++ b/build_info/wapm.control
@@ -1,0 +1,9 @@
+Package: wapm
+Version: @DEB_WAPM_V@
+Architecture: @DEB_ARCH@
+Maintainer: @DEB_MAINTAINER@
+Section: Development
+Priority: optional
+Description: This tool enables installing, managing, and publishing wasm packages on the wapm.io registry.
+Homepage: https://github.com/wasmerio/wapm-cli
+Name: WebAssembly Package Manager CLI

--- a/build_info/wasmer.control
+++ b/build_info/wasmer.control
@@ -1,0 +1,9 @@
+Package: wasmer
+Version: @DEB_WASMER_V@
+Architecture: @DEB_ARCH@
+Maintainer: @DEB_MAINTAINER@
+Section: Scripting
+Priority: optional
+Homepage: https://wasmer.io/
+Description: An open-source runtime for executing WebAssembly.
+Tag: purpose::console, role::hacker

--- a/build_info/wasmer.control
+++ b/build_info/wasmer.control
@@ -6,4 +6,3 @@ Section: Scripting
 Priority: optional
 Homepage: https://wasmer.io/
 Description: An open-source runtime for executing WebAssembly.
-Tag: purpose::console, role::hacker

--- a/build_misc/wasmer/wasmer.pc
+++ b/build_misc/wasmer/wasmer.pc
@@ -1,0 +1,10 @@
+prefix=
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: wasmer
+Description: The Wasmer library for running WebAssembly
+Version:
+Cflags: -I${includedir}
+Libs: -L${libdir} -lwasmer

--- a/build_patch/binaryen/0001-Fix-uint64_t-truncation-when-compiling-for-iOS.patch
+++ b/build_patch/binaryen/0001-Fix-uint64_t-truncation-when-compiling-for-iOS.patch
@@ -1,0 +1,22 @@
+From 389e5ffcdf1d24221cbc317096f20ff4c655fc0b Mon Sep 17 00:00:00 2001
+From: Lucy <lucy@absolucy.moe>
+Date: Sat, 31 Jul 2021 14:51:41 -0400
+Subject: [PATCH] Fix `uint64_t` truncation when compiling for iOS.
+
+---
+ src/wasm/literal.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/wasm/literal.cpp b/src/wasm/literal.cpp
+index c7a9ca8446..7cb99f2140 100644
+--- a/src/wasm/literal.cpp
++++ b/src/wasm/literal.cpp
+@@ -815,7 +815,7 @@ Literal Literal::abs() const {
+     case Type::i32:
+       return Literal(std::abs(i32));
+     case Type::i64:
+-      return Literal(std::abs(i64));
++      return Literal(std::llabs(i64));
+     case Type::f32:
+       return Literal(i32 & 0x7fffffff).castToF32();
+     case Type::f64:

--- a/build_patch/wasmer/0001-Use-target_vendor-apple-over-target_os-macos.patch
+++ b/build_patch/wasmer/0001-Use-target_vendor-apple-over-target_os-macos.patch
@@ -1,0 +1,269 @@
+From 2564a5c8075a1bb07205e6d38fb22c34e4080dc0 Mon Sep 17 00:00:00 2001
+From: Lucy <lucy@absolucy.moe>
+Date: Sat, 31 Jul 2021 12:46:22 -0400
+Subject: [PATCH] Use `target_vendor = "apple"` over `target_os = "macos"`
+
+---
+ examples/engine_cross_compilation.rs         |  2 +-
+ lib/c-api/build.rs                           |  2 +-
+ lib/compiler-llvm/src/translator/stackmap.rs |  2 +-
+ lib/emscripten/src/syscalls/unix.rs          | 32 ++++++++++----------
+ lib/emscripten/src/time.rs                   |  6 ++--
+ lib/vm/src/libcalls.rs                       |  4 +--
+ lib/vm/src/trap/traphandlers.rs              | 10 +++---
+ lib/wasi/src/syscalls/mod.rs                 |  4 +--
+ 8 files changed, 31 insertions(+), 31 deletions(-)
+
+diff --git a/examples/engine_cross_compilation.rs b/examples/engine_cross_compilation.rs
+index 618d24d..150e5c2 100644
+--- a/examples/engine_cross_compilation.rs
++++ b/examples/engine_cross_compilation.rs
+@@ -103,7 +103,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
+ #[cfg(not(any(
+     windows,
+     // We don't support yet crosscompilation in macOS with Apple Silicon
+-    all(target_os = "macos", target_arch = "aarch64"),
++    all(target_vendor = "apple", target_arch = "aarch64"),
+     target_env = "musl",
+ )))]
+ fn test_cross_compilation() -> Result<(), Box<dyn std::error::Error>> {
+diff --git a/lib/c-api/build.rs b/lib/c-api/build.rs
+index 01ec70e..3bd4e64 100644
+--- a/lib/c-api/build.rs
++++ b/lib/c-api/build.rs
+@@ -281,7 +281,7 @@ fn build_inline_c_env_vars() {
+         shared_object_dir = shared_object_dir,
+         lib = if cfg!(target_os = "windows") {
+             "wasmer_c_api.dll".to_string()
+-        } else if cfg!(target_os = "macos") {
++        } else if cfg!(target_vendor = "apple") {
+             "libwasmer_c_api.dylib".to_string()
+         } else {
+             let path = format!(
+diff --git a/lib/compiler-llvm/src/translator/stackmap.rs b/lib/compiler-llvm/src/translator/stackmap.rs
+index d23ebd1..cb6abc4 100644
+--- a/lib/compiler-llvm/src/translator/stackmap.rs
++++ b/lib/compiler-llvm/src/translator/stackmap.rs
+@@ -54,7 +54,7 @@ pub enum StackmapEntryKind {
+ 
+ impl StackmapEntry {
+     #[cfg(all(
+-        any(target_os = "freebsd", target_os = "linux", target_os = "macos"),
++        any(target_os = "freebsd", target_os = "linux", target_vendor = "apple"),
+         target_arch = "x86_64"
+     ))]
+     pub fn populate_msm(
+diff --git a/lib/emscripten/src/syscalls/unix.rs b/lib/emscripten/src/syscalls/unix.rs
+index 69ac5a2..2444329 100644
+--- a/lib/emscripten/src/syscalls/unix.rs
++++ b/lib/emscripten/src/syscalls/unix.rs
+@@ -1,5 +1,5 @@
+ use crate::{ptr::WasmPtr, varargs::VarArgs, LibcDirWrapper};
+-#[cfg(target_os = "macos")]
++#[cfg(target_vendor = "apple")]
+ use libc::size_t;
+ /// NOTE: TODO: These syscalls only support wasm_32 for now because they assume offsets are u32
+ /// Syscall list: https://www.cs.utexas.edu/~bismith/test/syscalls/syscalls32.html
+@@ -121,7 +121,7 @@ use std::io::Error;
+ use std::mem;
+ 
+ // Linking to functions that are not provided by rust libc
+-#[cfg(target_os = "macos")]
++#[cfg(target_vendor = "apple")]
+ #[link(name = "c")]
+ extern "C" {
+     pub fn wait4(pid: pid_t, status: *mut c_int, options: c_int, rusage: *mut rusage) -> pid_t;
+@@ -140,19 +140,19 @@ extern "C" {
+     pub fn lstat(path: *const libc::c_char, buf: *mut stat) -> c_int;
+ }
+ 
+-#[cfg(not(any(target_os = "freebsd", target_os = "macos", target_os = "android")))]
++#[cfg(not(any(target_os = "freebsd", target_vendor = "apple", target_os = "android")))]
+ use libc::fallocate;
+ #[cfg(target_os = "freebsd")]
+ use libc::madvise;
+-#[cfg(not(any(target_os = "freebsd", target_os = "macos")))]
++#[cfg(not(any(target_os = "freebsd", target_vendor = "apple")))]
+ use libc::{fdatasync, ftruncate64, lstat, madvise, wait4};
+ 
+ // Another conditional constant for name resolution: Macos et iOS use
+ // SO_NOSIGPIPE as a setsockopt flag to disable SIGPIPE emission on socket.
+ // Other platforms do otherwise.
+-#[cfg(target_os = "macos")]
++#[cfg(target_vendor = "apple")]
+ use libc::SO_NOSIGPIPE;
+-#[cfg(not(target_os = "macos"))]
++#[cfg(not(target_vendor = "apple"))]
+ const SO_NOSIGPIPE: c_int = 0;
+ 
+ /// open
+@@ -269,7 +269,7 @@ pub fn ___syscall194(ctx: &EmEnv, _which: c_int, mut varargs: VarArgs) -> c_int
+     debug!("emscripten::___syscall194 (ftruncate64) {}", _which);
+     let _fd: c_int = varargs.get(ctx);
+     let _length: i64 = varargs.get(ctx);
+-    #[cfg(not(any(target_os = "freebsd", target_os = "macos")))]
++    #[cfg(not(any(target_os = "freebsd", target_vendor = "apple")))]
+     unsafe {
+         ftruncate64(_fd, _length)
+     }
+@@ -277,7 +277,7 @@ pub fn ___syscall194(ctx: &EmEnv, _which: c_int, mut varargs: VarArgs) -> c_int
+     unsafe {
+         ftruncate(_fd, _length)
+     }
+-    #[cfg(target_os = "macos")]
++    #[cfg(target_vendor = "apple")]
+     unimplemented!("emscripten::___syscall194 (ftruncate64) {}", _which)
+ }
+ 
+@@ -639,7 +639,7 @@ pub fn ___syscall102(ctx: &EmEnv, _which: c_int, mut varargs: VarArgs) -> c_int
+             let mut host_address: sockaddr = sockaddr {
+                 sa_family: Default::default(),
+                 sa_data: Default::default(),
+-                #[cfg(any(target_os = "freebsd", target_os = "macos"))]
++                #[cfg(any(target_os = "freebsd", target_vendor = "apple"))]
+                 sa_len: Default::default(),
+             };
+             let fd = unsafe { accept(socket, &mut host_address, address_len_addr) };
+@@ -672,7 +672,7 @@ pub fn ___syscall102(ctx: &EmEnv, _which: c_int, mut varargs: VarArgs) -> c_int
+             let mut sock_addr_host: sockaddr = sockaddr {
+                 sa_family: Default::default(),
+                 sa_data: Default::default(),
+-                #[cfg(any(target_os = "freebsd", target_os = "macos"))]
++                #[cfg(any(target_os = "freebsd", target_vendor = "apple"))]
+                 sa_len: Default::default(),
+             };
+             let ret = unsafe {
+@@ -1013,14 +1013,14 @@ pub fn ___syscall196(ctx: &EmEnv, _which: i32, mut varargs: VarArgs) -> i32 {
+     unsafe {
+         let mut stat: stat = std::mem::zeroed();
+ 
+-        #[cfg(target_os = "macos")]
++        #[cfg(target_vendor = "apple")]
+         let stat_ptr = &mut stat as *mut stat as *mut c_void;
+-        #[cfg(not(target_os = "macos"))]
++        #[cfg(not(target_vendor = "apple"))]
+         let stat_ptr = &mut stat as *mut stat;
+ 
+-        #[cfg(target_os = "macos")]
++        #[cfg(target_vendor = "apple")]
+         let ret = lstat64(real_path, stat_ptr);
+-        #[cfg(not(target_os = "macos"))]
++        #[cfg(not(target_vendor = "apple"))]
+         let ret = lstat(real_path, stat_ptr);
+ 
+         debug!("ret: {}", ret);
+@@ -1131,11 +1131,11 @@ pub fn ___syscall324(ctx: &EmEnv, _which: c_int, mut varargs: VarArgs) -> c_int
+     let _mode: c_int = varargs.get(ctx);
+     let _offset: off_t = varargs.get(ctx);
+     let _len: off_t = varargs.get(ctx);
+-    #[cfg(not(any(target_os = "freebsd", target_os = "macos", target_os = "android")))]
++    #[cfg(not(any(target_os = "freebsd", target_vendor = "apple", target_os = "android")))]
+     unsafe {
+         fallocate(_fd, _mode, _offset, _len)
+     }
+-    #[cfg(any(target_os = "freebsd", target_os = "macos", target_os = "android"))]
++    #[cfg(any(target_os = "freebsd", target_vendor = "apple", target_os = "android"))]
+     {
+         unimplemented!("emscripten::___syscall324 (fallocate) {}", _which)
+     }
+diff --git a/lib/emscripten/src/time.rs b/lib/emscripten/src/time.rs
+index 1827b89..7bb57e6 100644
+--- a/lib/emscripten/src/time.rs
++++ b/lib/emscripten/src/time.rs
+@@ -35,11 +35,11 @@ use libc::{CLOCK_MONOTONIC, CLOCK_REALTIME};
+ #[cfg(target_os = "freebsd")]
+ const CLOCK_MONOTONIC_COARSE: clockid_t = 6;
+ 
+-#[cfg(target_os = "macos")]
++#[cfg(target_vendor = "apple")]
+ use libc::CLOCK_REALTIME;
+-#[cfg(target_os = "macos")]
++#[cfg(target_vendor = "apple")]
+ const CLOCK_MONOTONIC: clockid_t = 1;
+-#[cfg(target_os = "macos")]
++#[cfg(target_vendor = "apple")]
+ const CLOCK_MONOTONIC_COARSE: clockid_t = 6;
+ 
+ // some assumptions about the constants when targeting windows
+diff --git a/lib/vm/src/libcalls.rs b/lib/vm/src/libcalls.rs
+index e60704d..301568e 100644
+--- a/lib/vm/src/libcalls.rs
++++ b/lib/vm/src/libcalls.rs
+@@ -858,9 +858,9 @@ impl LibCall {
+             Self::RaiseTrap => "wasmer_vm_raise_trap",
+             // We have to do this because macOS requires a leading `_` and it's not
+             // a normal function, it's a static variable, so we have to do it manually.
+-            #[cfg(target_os = "macos")]
++            #[cfg(target_vendor = "apple")]
+             Self::Probestack => "_wasmer_vm_probestack",
+-            #[cfg(not(target_os = "macos"))]
++            #[cfg(not(target_vendor = "apple"))]
+             Self::Probestack => "wasmer_vm_probestack",
+         }
+     }
+diff --git a/lib/vm/src/trap/traphandlers.rs b/lib/vm/src/trap/traphandlers.rs
+index aff2b44..4a4c7a0 100644
+--- a/lib/vm/src/trap/traphandlers.rs
++++ b/lib/vm/src/trap/traphandlers.rs
+@@ -82,12 +82,12 @@ cfg_if::cfg_if! {
+ 
+             // On ARM, handle Unaligned Accesses.
+             // On Darwin, guard page accesses are raised as SIGBUS.
+-            if cfg!(target_arch = "arm") || cfg!(target_os = "macos") {
++            if cfg!(target_arch = "arm") || cfg!(target_vendor = "apple") {
+                 register(&mut PREV_SIGBUS, libc::SIGBUS);
+             }
+         }
+ 
+-        #[cfg(target_os = "macos")]
++        #[cfg(target_vendor = "apple")]
+         unsafe fn thread_stack() -> (usize, usize) {
+             let this_thread = libc::pthread_self();
+             let stackaddr = libc::pthread_get_stackaddr_np(this_thread);
+@@ -95,7 +95,7 @@ cfg_if::cfg_if! {
+             (stackaddr as usize - stacksize, stacksize)
+         }
+ 
+-        #[cfg(not(target_os = "macos"))]
++        #[cfg(not(target_vendor = "apple"))]
+         unsafe fn thread_stack() -> (usize, usize) {
+             let this_thread = libc::pthread_self();
+             let mut thread_attrs: libc::pthread_attr_t = mem::zeroed();
+@@ -219,10 +219,10 @@ cfg_if::cfg_if! {
+                 } else if #[cfg(all(target_os = "android", target_arch = "aarch64"))] {
+                     let cx = &*(cx as *const libc::ucontext_t);
+                     cx.uc_mcontext.pc as *const u8
+-                } else if #[cfg(all(target_os = "macos", target_arch = "x86_64"))] {
++                } else if #[cfg(all(target_vendor = "apple", target_arch = "x86_64"))] {
+                     let cx = &*(cx as *const libc::ucontext_t);
+                     (*cx.uc_mcontext).__ss.__rip as *const u8
+-                } else if #[cfg(all(target_os = "macos", target_arch = "aarch64"))] {
++                } else if #[cfg(all(target_vendor = "apple", target_arch = "aarch64"))] {
+                     use std::mem;
+                     // TODO: This should be integrated into rust/libc
+                     // Related issue: https://github.com/rust-lang/libc/issues/1977
+diff --git a/lib/wasi/src/syscalls/mod.rs b/lib/wasi/src/syscalls/mod.rs
+index 58413a6..59a39bf 100644
+--- a/lib/wasi/src/syscalls/mod.rs
++++ b/lib/wasi/src/syscalls/mod.rs
+@@ -8,7 +8,7 @@ pub mod types {
+     target_os = "freebsd",
+     target_os = "linux",
+     target_os = "android",
+-    target_os = "macos"
++    target_vendor = "apple"
+ ))]
+ pub mod unix;
+ #[cfg(any(target_os = "windows"))]
+@@ -37,7 +37,7 @@ use wasmer::{Memory, RuntimeError, Value};
+     target_os = "freebsd",
+     target_os = "linux",
+     target_os = "android",
+-    target_os = "macos"
++    target_vendor = "apple"
+ ))]
+ pub use unix::*;
+ 
+-- 
+2.32.0
+

--- a/makefiles/binaryen.mk
+++ b/makefiles/binaryen.mk
@@ -1,0 +1,44 @@
+ifneq ($(PROCURSUS),1)
+$(error Use the main Makefile)
+endif
+
+SUBPROJECTS      += binaryen
+BINARYEN_VERSION := 101
+DEB_BINARYEN_V   ?= $(BINARYEN_VERSION)
+
+binaryen-setup: setup
+	$(call GITHUB_ARCHIVE,WebAssembly,binaryen,version_$(BINARYEN_VERSION),version_$(BINARYEN_VERSION))
+	$(call EXTRACT_TAR,binaryen-version_$(BINARYEN_VERSION).tar.gz,binaryen-version_$(BINARYEN_VERSION),binaryen)
+	mkdir -p $(BUILD_WORK)/binaryen/build
+
+ifneq ($(wildcard $(BUILD_WORK)/binaryen/.build_complete),)
+binaryen:
+	@echo "Using previously built binaryen."
+else
+binaryen: binaryen-setup
+	cd $(BUILD_WORK)/binaryen/build && cmake . \
+		$(DEFAULT_CMAKE_FLAGS) \
+		..
+	+$(MAKE) -C $(BUILD_WORK)/binaryen/build
+	+$(MAKE) -C $(BUILD_WORK)/binaryen/build install \
+		DESTDIR="$(BUILD_STAGE)/binaryen"
+	touch $(BUILD_WORK)/binaryen/.build_complete
+endif
+
+binaryen-package: binaryen-stage
+	# binaryen.mk Package Structure
+	rm -rf $(BUILD_DIST)/binaryen
+	
+	# binaryen.mk Prep binaryen
+	cp -a $(BUILD_STAGE)/binaryen $(BUILD_DIST)
+	
+	# binaryen.mk Sign
+	$(call SIGN,binaryen,general.xml)
+	
+	# binaryen.mk Make .debs
+	$(call PACK,binaryen,DEB_BINARYEN_V)
+	
+	# binaryen.mk Build cleanup
+	rm -rf $(BUILD_DIST)/binaryen
+
+.PHONY: binaryen binaryen-package

--- a/makefiles/binaryen.mk
+++ b/makefiles/binaryen.mk
@@ -9,6 +9,7 @@ DEB_BINARYEN_V   ?= $(BINARYEN_VERSION)
 binaryen-setup: setup
 	$(call GITHUB_ARCHIVE,WebAssembly,binaryen,version_$(BINARYEN_VERSION),version_$(BINARYEN_VERSION))
 	$(call EXTRACT_TAR,binaryen-version_$(BINARYEN_VERSION).tar.gz,binaryen-version_$(BINARYEN_VERSION),binaryen)
+	$(call DO_PATCH,binaryen,binaryen,-p1)
 	mkdir -p $(BUILD_WORK)/binaryen/build
 
 ifneq ($(wildcard $(BUILD_WORK)/binaryen/.build_complete),)

--- a/makefiles/build-essential-wasi.mk
+++ b/makefiles/build-essential-wasi.mk
@@ -1,0 +1,36 @@
+ifneq ($(PROCURSUS),1)
+$(error Use the main Makefile)
+endif
+
+SUBPROJECTS  += build-essential-wasi
+WASI_VERSION := 12
+DEB_WASI_V   ?= $(WASI_VERSION)
+
+build-essential-wasi-setup: setup
+	wget -q -nc -P $(BUILD_SOURCE) https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$(WASI_VERSION)/wasi-sysroot-$(WASI_VERSION).0.tar.gz
+	$(call EXTRACT_TAR,wasi-sysroot-$(WASI_VERSION).0.tar.gz,wasi-sysroot,build-essential-wasi)
+
+ifneq ($(wildcard $(BUILD_WORK)/build-essential-wasi/.build_complete),)
+build-essential-wasi:
+	@echo "Using previously built build-essential-wasi."
+else
+build-essential-wasi: build-essential-wasi-setup
+	mkdir -p $(BUILD_STAGE)/build-essential-wasi/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/SDKs/WASI.sdk
+	cp -a $(BUILD_WORK)/build-essential-wasi/* $(BUILD_STAGE)/build-essential-wasi/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/SDKs/WASI.sdk
+	touch $(BUILD_WORK)/build-essential-wasi/.build_complete
+endif
+
+build-essential-wasi-package: build-essential-wasi-stage
+	# build-essential-wasi.mk Package Structure
+	rm -rf $(BUILD_DIST)/build-essential-wasi
+
+	# build-essential-wasi.mk Prep build-essential-wasi
+	cp -a $(BUILD_STAGE)/build-essential-wasi $(BUILD_DIST)
+
+	# build-essential-wasi.mk Make .debs
+	$(call PACK,build-essential-wasi,DEB_WASI_V)
+
+	# build-essential-wasi.mk Build cleanup
+	rm -rf $(BUILD_DIST)/build-essential-wasi
+
+.PHONY: build-essential-wasi build-essential-wasi-package

--- a/makefiles/llvm.mk
+++ b/makefiles/llvm.mk
@@ -46,7 +46,7 @@ ifeq ($(wildcard $(BUILD_WORK)/../../native/llvm/.*),)
 		-DCMAKE_OSX_SYSROOT="$(MACOSX_SYSROOT)" \
 		-DSWIFT_INCLUDE_TESTS=OFF \
 		-DSWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER=ON \
-		-DLLVM_TARGETS_TO_BUILD="X86;AArch64" \
+		-DLLVM_TARGETS_TO_BUILD="X86;AArch64;WebAssembly" \
 		-DLLVM_ENABLE_PROJECTS="clang;libcxx;libcxxabi;lldb" \
 		-DLLVM_EXTERNAL_PROJECTS="cmark;swift" \
 		-DLLVM_EXTERNAL_SWIFT_SOURCE_DIR="$(BUILD_WORK)/llvm/swift" \

--- a/makefiles/wabt.mk
+++ b/makefiles/wabt.mk
@@ -1,0 +1,43 @@
+ifneq ($(PROCURSUS),1)
+$(error Use the main Makefile)
+endif
+
+SUBPROJECTS  += wabt
+WABT_VERSION := 1.0.23
+DEB_WABT_V   ?= $(WABT_VERSION)
+
+wabt-setup: setup
+	$(call GIT_CLONE,https://github.com/WebAssembly/wabt.git,$(WABT_VERSION),wabt)
+	mkdir -p $(BUILD_WORK)/wabt/build
+
+ifneq ($(wildcard $(BUILD_WORK)/wabt/.build_complete),)
+wabt:
+	@echo "Using previously built wabt."
+else
+wabt: wabt-setup
+	cd $(BUILD_WORK)/wabt/build && cmake \
+		-DBUILD_TESTS=OFF $(DEFAULT_CMAKE_FLAGS) \
+		..
+	+$(MAKE) -C $(BUILD_WORK)/wabt/build
+	+$(MAKE) -C $(BUILD_WORK)/wabt/build install \
+		DESTDIR="$(BUILD_STAGE)/wabt"
+	touch $(BUILD_WORK)/wabt/.build_complete
+endif
+
+wabt-package: wabt-stage
+	# wabt.mk Package Structure
+	rm -rf $(BUILD_DIST)/wabt
+	
+	# wabt.mk Prep wabt
+	cp -a $(BUILD_STAGE)/wabt $(BUILD_DIST)
+	
+	# wabt.mk Sign
+	$(call SIGN,wabt,general.xml)
+	
+	# wabt.mk Make .debs
+	$(call PACK,wabt,DEB_WABT_V)
+	
+	# wabt.mk Build cleanup
+	rm -rf $(BUILD_DIST)/wabt
+
+.PHONY: wabt wabt-package

--- a/makefiles/wabt.mk
+++ b/makefiles/wabt.mk
@@ -16,7 +16,8 @@ wabt:
 else
 wabt: wabt-setup
 	cd $(BUILD_WORK)/wabt/build && cmake \
-		-DBUILD_TESTS=OFF $(DEFAULT_CMAKE_FLAGS) \
+		$(DEFAULT_CMAKE_FLAGS) \
+		-DBUILD_TESTS=OFF \
 		..
 	+$(MAKE) -C $(BUILD_WORK)/wabt/build
 	+$(MAKE) -C $(BUILD_WORK)/wabt/build install \

--- a/makefiles/wapm.mk
+++ b/makefiles/wapm.mk
@@ -1,0 +1,41 @@
+ifneq ($(PROCURSUS),1)
+$(error Use the main Makefile)
+endif
+
+SUBPROJECTS  += wapm
+WAPM_VERSION := 0.5.1
+DEB_WAPM_V   ?= $(WAPM_VERSION)
+
+wapm-setup: setup
+	$(call GITHUB_ARCHIVE,wasmerio,wapm-cli,$(WAPM_VERSION),v$(WAPM_VERSION))
+	$(call EXTRACT_TAR,wapm-cli-$(WAPM_VERSION).tar.gz,wapm-cli-$(WAPM_VERSION),wapm)
+
+ifneq ($(wildcard $(BUILD_WORK)/wapm/.build_complete),)
+wapm:
+	@echo "Using previously built wapm."
+else
+wapm: wapm-setup
+	cd $(BUILD_WORK)/wapm && unset CFLAGS && $(DEFAULT_RUST_FLAGS) cargo build \
+		--release \
+		--target=$(RUST_TARGET)
+	$(INSTALL) -Dm755 $(BUILD_WORK)/wapm/target/$(RUST_TARGET)/release/wapm $(BUILD_STAGE)/wapm/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/wapm
+	touch $(BUILD_WORK)/wapm/.build_complete
+endif
+
+wapm-package: wapm-stage
+	# wapm.mk Package Structure
+	rm -rf $(BUILD_DIST)/wapm
+
+	# wapm.mk Prep wapm
+	cp -a $(BUILD_STAGE)/wapm $(BUILD_DIST)
+
+	# wapm.mk Sign
+	$(call SIGN,wapm,general.xml)
+
+	# wapm.mk Make .debs
+	$(call PACK,wapm,DEB_WAPM_V)
+
+	# wapm.mk Build cleanup
+	rm -rf $(BUILD_DIST)/wapm
+
+.PHONY: wapm wapm-package

--- a/makefiles/wasmer.mk
+++ b/makefiles/wasmer.mk
@@ -2,6 +2,8 @@ ifneq ($(PROCURSUS),1)
 $(error Use the main Makefile)
 endif
 
+ifneq (,$(findstring darwin,$(MEMO_TARGET)))
+
 SUBPROJECTS    += wasmer
 WASMER_VERSION := 2.0.0
 DEB_WASMER_V   ?= $(WASMER_VERSION)
@@ -68,3 +70,5 @@ wasmer-package: wasmer-stage
 	rm -rf $(BUILD_DIST)/wasmer
 
 .PHONY: wasmer wasmer-package
+
+endif

--- a/makefiles/wasmer.mk
+++ b/makefiles/wasmer.mk
@@ -10,6 +10,7 @@ wasmer-setup: setup
 	$(call GITHUB_ARCHIVE,wasmerio,wasmer,$(WASMER_VERSION),v$(WASMER_VERSION))
 	$(call EXTRACT_TAR,wasmer-$(WASMER_VERSION).tar.gz,wasmer-$(WASMER_VERSION),wasmer)
 	$(call DO_PATCH,wasmer,wasmer,-p1)
+	mkdir -p $(BUILD_STAGE)/libwasmer-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/{include,lib/pkgconfig}
 
 ifneq ($(wildcard $(BUILD_WORK)/wasmer/.build_complete),)
 wasmer:
@@ -27,8 +28,6 @@ wasmer: wasmer-setup
 		--release \
 		--target=$(RUST_TARGET) \
 		--features="cranelift,dylib,staticlib"
-	mkdir -p $(BUILD_STAGE)/libwasmer/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
-	mkdir -p $(BUILD_STAGE)/libwasmer-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/{include,lib/pkgconfig}
 	$(INSTALL) -Dm755 $(BUILD_WORK)/wasmer/target/$(RUST_TARGET)/release/wasmer $(BUILD_STAGE)/wasmer/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/wasmer
 	$(INSTALL) -Dm755 $(BUILD_WORK)/wasmer/target/$(RUST_TARGET)/release/libwasmer_c_api.dylib $(BUILD_STAGE)/libwasmer/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/libwasmer.dylib
 	$(I_N_T) -id $(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/libwasmer.dylib $(BUILD_STAGE)/libwasmer/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/libwasmer.dylib
@@ -51,7 +50,7 @@ wasmer-package: wasmer-stage
 	cp -a $(BUILD_STAGE)/wasmer $(BUILD_DIST)
 
 	# wasmer.mk Prep libwasmer
-	$(INSTALL) -Dm755 $(BUILD_STAGE)/libwasmer/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/libwasmer.dylib $(BUILD_DIST)/libwasmer/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/libwasmer.dylib
+	cp -a $(BUILD_STAGE)/libwasmer/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/libwasmer.dylib $(BUILD_DIST)/libwasmer/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/libwasmer.dylib
 
 	# wasmer.mk Prep libwasmer-dev
 	cp -a $(BUILD_STAGE)/libwasmer-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/{include,lib} $(BUILD_DIST)/libwasmer-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)

--- a/makefiles/wasmer.mk
+++ b/makefiles/wasmer.mk
@@ -9,6 +9,7 @@ DEB_WASMER_V   ?= $(WASMER_VERSION)
 wasmer-setup: setup
 	$(call GITHUB_ARCHIVE,wasmerio,wasmer,$(WASMER_VERSION),v$(WASMER_VERSION))
 	$(call EXTRACT_TAR,wasmer-$(WASMER_VERSION).tar.gz,wasmer-$(WASMER_VERSION),wasmer)
+	$(call DO_PATCH,wasmer,wasmer,-p1)
 
 ifneq ($(wildcard $(BUILD_WORK)/wasmer/.build_complete),)
 wasmer:

--- a/makefiles/wasmer.mk
+++ b/makefiles/wasmer.mk
@@ -1,0 +1,70 @@
+ifneq ($(PROCURSUS),1)
+$(error Use the main Makefile)
+endif
+
+SUBPROJECTS    += wasmer
+WASMER_VERSION := 2.0.0
+DEB_WASMER_V   ?= $(WASMER_VERSION)
+
+wasmer-setup: setup
+	$(call GITHUB_ARCHIVE,wasmerio,wasmer,$(WASMER_VERSION),v$(WASMER_VERSION))
+	$(call EXTRACT_TAR,wasmer-$(WASMER_VERSION).tar.gz,wasmer-$(WASMER_VERSION),wasmer)
+
+ifneq ($(wildcard $(BUILD_WORK)/wasmer/.build_complete),)
+wasmer:
+	@echo "Using previously built wasmer."
+else
+wasmer: wasmer-setup
+	unset CFLAGS && $(DEFAULT_RUST_FLAGS) cargo build \
+		--manifest-path="$(BUILD_WORK)/wasmer/lib/cli/Cargo.toml" \
+		--release \
+		--target=$(RUST_TARGET) \
+		--features="cranelift" \
+		--bin wasmer
+	unset CFLAGS && $(DEFAULT_RUST_FLAGS) cargo build \
+		--manifest-path="$(BUILD_WORK)/wasmer/lib/c-api/Cargo.toml" \
+		--release \
+		--target=$(RUST_TARGET) \
+		--features="cranelift,dylib,staticlib"
+	mkdir -p $(BUILD_STAGE)/libwasmer/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
+	mkdir -p $(BUILD_STAGE)/libwasmer-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/{include,lib/pkgconfig}
+	$(INSTALL) -Dm755 $(BUILD_WORK)/wasmer/target/$(RUST_TARGET)/release/wasmer $(BUILD_STAGE)/wasmer/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/wasmer
+	$(INSTALL) -Dm755 $(BUILD_WORK)/wasmer/target/$(RUST_TARGET)/release/libwasmer_c_api.dylib $(BUILD_STAGE)/libwasmer/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/libwasmer.dylib
+	$(I_N_T) -id $(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/libwasmer.dylib $(BUILD_STAGE)/libwasmer/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/libwasmer.dylib
+	$(INSTALL) -Dm644 $(BUILD_WORK)/wasmer/lib/c-api/*.h $(BUILD_STAGE)/libwasmer-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include
+	$(INSTALL) -Dm755 $(BUILD_WORK)/wasmer/target/$(RUST_TARGET)/release/libwasmer_c_api.a $(BUILD_STAGE)/libwasmer-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/libwasmer.a
+	$(INSTALL) -Dm644 $(BUILD_MISC)/wasmer/wasmer.pc $(BUILD_STAGE)/libwasmer-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/pkgconfig/wasmer.pc
+	$(SED) -i 's|prefix=|prefix=$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)|g' \
+		$(BUILD_STAGE)/libwasmer-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/pkgconfig/wasmer.pc
+	$(SED) -i 's/Version:/Version: $(WASMER_VERSION)/g' \
+		$(BUILD_STAGE)/libwasmer-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/pkgconfig/wasmer.pc
+	touch $(BUILD_WORK)/wasmer/.build_complete
+endif
+
+wasmer-package: wasmer-stage
+	# wasmer.mk Package Structure
+	rm -rf $(BUILD_DIST)/wasmer $(BUILD_DIST)/libwasmer{,-dev}
+	mkdir -p $(BUILD_DIST)/wasmer $(BUILD_DIST)/libwasmer{,-dev}/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)
+
+	# wasmer.mk Prep wasmer
+	cp -a $(BUILD_STAGE)/wasmer $(BUILD_DIST)
+
+	# wasmer.mk Prep libwasmer
+	$(INSTALL) -Dm755 $(BUILD_STAGE)/libwasmer/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/libwasmer.dylib $(BUILD_DIST)/libwasmer/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/libwasmer.dylib
+
+	# wasmer.mk Prep libwasmer-dev
+	cp -a $(BUILD_STAGE)/libwasmer-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/{include,lib} $(BUILD_DIST)/libwasmer-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)
+
+	# wasmer.mk Sign
+	$(call SIGN,wasmer,general.xml)
+	$(call SIGN,libwasmer,general.xml)
+
+	# wasmer.mk Make .debs
+	$(call PACK,wasmer,DEB_WASMER_V)
+	$(call PACK,libwasmer,DEB_WASMER_V)
+	$(call PACK,libwasmer-dev,DEB_WASMER_V)
+
+	# wasmer.mk Build cleanup
+	rm -rf $(BUILD_DIST)/wasmer
+
+.PHONY: wasmer wasmer-package


### PR DESCRIPTION
This is a *full WebAssembly toolchain* for Procursus.  
It includes:
 - `build-essential-wasi`: A wasm32-wasi SDK/sysroot.
 - `binaryen`: A WebAssembly optimizer
 - `wabt`: Various WebAssembly tools
 - `wasmer`: A WebAssembly runtime (+ C API in `libwasmer`)
 	- Note: the Cranelift backend is used, rather than the LLVM backend. If anyone wants the LLVM backend, I could add support for it (just add `llvm` to the --features flag and add some environmental variable). tbh I just don't feel like running `make llvm` while away from home.
  - `wapm`: like npm but for WebAssembly

In addition, `llvm` was updated to compile with support for WebAssembly.