### PR TITLE
Update darwintools with newest firmware commit and bump version

### DIFF
--- a/makefiles/darwintools.mk
+++ b/makefiles/darwintools.mk
@@ -3,8 +3,8 @@ $(error Use the main Makefile)
 endif
 
 STRAPPROJECTS       += darwintools
-DARWINTOOLS_VERSION := 1.5
-ZBRFIRMWARE_COMMIT  := 0d12840783e08cbb4a3148222d88cc0eaabceec6
+DARWINTOOLS_VERSION := 1.6
+ZBRFIRMWARE_COMMIT  := c6c0485c8f575a1e470767e3cb29fdf8e2de0e5e
 DEB_DARWINTOOLS_V   ?= $(DARWINTOOLS_VERSION)
 
 darwintools-setup: setup
@@ -18,8 +18,7 @@ else
 darwintools: darwintools-setup
 	+$(MAKE) -C $(BUILD_WORK)/darwintools all \
 		FIRMWARE_MAINTAINER="$(DEB_MAINTAINER)" \
-		PREFIX=$(MEMO_PREFIX) \
-		EXECPREFIX=$(MEMO_SUB_PREFIX) \
+		PREFIX=$(MEMO_PREFIX)$(MEMO_SUB_PREFIX) \
 		CFLAGS="$(CFLAGS)" \
 		LDFLAGS="$(LDFLAGS)"
 	$(INSTALL) -Dm 0755 $(BUILD_WORK)/darwintools/build/firmware $(BUILD_STAGE)/darwintools/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/libexec/firmware


### PR DESCRIPTION
Updates to firmware:
- Query MobileGestalt directly instead of parsing gssc
- Minor performance improvements
- Ensure all paths use `PREFIX` (please check the [firmware](https://github.com/zbrateam/Firmware) source code merging this pr)