### PR TITLE
libintl: Only call cfprefsd from mobile.

### DIFF
--- a/build_patch/gettext/fix-getting-locale.diff
+++ b/build_patch/gettext/fix-getting-locale.diff
@@ -1,0 +1,24 @@
+diff -urN gettext-0.21/gettext-runtime/intl/localename.c gettext/gettext-runtime/intl/localename.c
+--- gettext-0.21/gettext-runtime/intl/localename.c	2020-06-26 22:05:43.000000000 +0000
++++ gettext/gettext-runtime/intl/localename.c	2021-09-04 03:58:18.000000000 +0000
+@@ -3404,7 +3404,7 @@
+     /* Cache the locale name, since CoreFoundation calls are expensive.  */
+     static const char *cached_localename;
+ 
+-    if (cached_localename == NULL)
++    if (cached_localename == NULL && getuid() == 501)
+       {
+         char namebuf[256];
+         CFTypeRef value =
+@@ -3421,9 +3421,9 @@
+                 cached_localename = strdup (namebuf);
+               }
+           }
+-        if (cached_localename == NULL)
+-          cached_localename = "C";
+       }
++    if (cached_localename == NULL)
++      cached_localename = "C";
+     return cached_localename;
+   }
+ 

--- a/makefiles/gettext.mk
+++ b/makefiles/gettext.mk
@@ -4,12 +4,15 @@ endif
 
 STRAPPROJECTS   += gettext
 GETTEXT_VERSION := 0.21
-DEB_GETTEXT_V   ?= $(GETTEXT_VERSION)-4
+DEB_GETTEXT_V   ?= $(GETTEXT_VERSION)-5
 
 gettext-setup: setup
 	wget -q -nc -P $(BUILD_SOURCE) https://ftpmirror.gnu.org/gettext/gettext-$(GETTEXT_VERSION).tar.xz{,.sig}
 	$(call PGP_VERIFY,gettext-$(GETTEXT_VERSION).tar.xz)
 	$(call EXTRACT_TAR,gettext-$(GETTEXT_VERSION).tar.xz,gettext-$(GETTEXT_VERSION),gettext)
+ifeq (,$(findstring darwin,$(MEMO_TARGET)))
+	$(call DO_PATCH,gettext,gettext,-p1)
+endif
 
 ifneq ($(wildcard $(BUILD_WORK)/gettext/.build_complete),)
 gettext:


### PR DESCRIPTION
Should fix an issue reported by CoolStar.
