### PR TITLE
Update siguza-utils to latest commit

### DIFF
--- a/build_info/siguza-utils.control
+++ b/build_info/siguza-utils.control
@@ -7,8 +7,10 @@ Section: Utilities
 Priority: optional
 Homepage: https://www.github.com/Siguza/misc
 Description: Various C written tools.
- This package provides specific C written tools designed by Siguza that do specific things.
- This software and all its binaries, which are listed below, is provided without any kind of warranty and as-is. Use at your own risk.
+ This package provides specific tools, written in C, created by Siguza
+ that do specific things. This software, and all its binaries, which are
+ listed below, is provided without any kind of warranty and as-is. Use
+ at your own risk
  - bindump: Prints a 64-bit command line arg in binary
  - clz: Clang's __builtin_clz, but for the command line
  - dsc_syms: Prints symbol addresses of a dyld_shared_cache in radare2 format

--- a/makefiles/siguza-utils.mk
+++ b/makefiles/siguza-utils.mk
@@ -4,8 +4,8 @@ endif
 
 SUBPROJECTS             += siguza-utils
 # Don't change the version, just the date and git hash
-SIGUZA-UTILS_COMMIT     := 8ce24f02ec14da12ec264084328c3e9b6c9c7603
-SIGUZA-UTILS_VERSION    := 1.0+git20210501.$(shell echo $(SIGUZA-UTILS_COMMIT) | cut -c -7)
+SIGUZA-UTILS_COMMIT     := fc79d4fa8cd9359b1781201b2b53e63c8f1a7414
+SIGUZA-UTILS_VERSION    := 1.0+git20210917.$(shell echo $(SIGUZA-UTILS_COMMIT) | cut -c -7)
 DEB_SIGUZA-UTILS_V      ?= $(SIGUZA-UTILS_VERSION)
 
 siguza-utils-setup: setup
@@ -18,51 +18,16 @@ siguza-utils:
 	@echo "Using previously built siguza-utils."
 else
 siguza-utils: siguza-utils-setup
+	+$(MAKE) -C $(BUILD_WORK)/siguza-utils install \
+		CFLAGS="$(CFLAGS)" \
+		LDFLAGS="$(LDFLAGS)" \
+		PREFIX="$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)" \
+		DESTDIR="$(BUILD_STAGE)/siguza-utils"
 	# Delete mesu, it's broken afaik
-	rm -rf $(BUILD_WORK)/siguza-utils/mesu.c
-
-	# Compile bindump.c
-	$(CC) $(CFLAGS) \
-		$(BUILD_WORK)/siguza-utils/bindump.c \
-		-o $(BUILD_STAGE)/siguza-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/bindump $(LDFLAGS)
-
-	# Compile clz.c
-	$(CC) $(CFLAGS) \
-		$(BUILD_WORK)/siguza-utils/clz.c \
-		-o $(BUILD_STAGE)/siguza-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/clz $(LDFLAGS)
-
-	# Compile dsc_syms.c
-	$(CC) $(CFLAGS) \
-		$(BUILD_WORK)/siguza-utils/dsc_syms.c \
-		-o $(BUILD_STAGE)/siguza-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/dsc_syms $(LDFLAGS)
-
-	# Compile rand.c
-	$(CC) $(CFLAGS) \
-		$(BUILD_WORK)/siguza-utils/rand.c \
-		-o $(BUILD_STAGE)/siguza-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/rand $(LDFLAGS)
-
-	# Compile strerror.c
-	$(CC) $(CFLAGS) \
-		$(BUILD_WORK)/siguza-utils/strerror.c \
-		-o $(BUILD_STAGE)/siguza-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/strerror $(LDFLAGS) -framework CoreFoundation -framework Security
-
-	# Compile vmacho.c
-	$(CC) $(CFLAGS) \
-		$(BUILD_WORK)/siguza-utils/vmacho.c \
-		-o $(BUILD_STAGE)/siguza-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/vmacho $(LDFLAGS)
-
-	# Compile xref.c
-	$(CC) $(CFLAGS) \
-		$(BUILD_WORK)/siguza-utils/xref.c \
-		-o $(BUILD_STAGE)/siguza-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/xref $(LDFLAGS)
-
-	chmod +x $(BUILD_STAGE)/siguza-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/bindump
-	chmod +x $(BUILD_STAGE)/siguza-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/clz
-	chmod +x $(BUILD_STAGE)/siguza-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/dsc_syms
-	chmod +x $(BUILD_STAGE)/siguza-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/rand
-	chmod +x $(BUILD_STAGE)/siguza-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/strerror
-	chmod +x $(BUILD_STAGE)/siguza-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/vmacho
-	chmod +x $(BUILD_STAGE)/siguza-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/xref
+	rm -rf $(BUILD_STAGE)/siguza-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/mesu
+	for file in $(BUILD_STAGE)/siguza-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/; do \
+		chmod +x $$file; \
+	done
 	$(call AFTER_BUILD)
 endif
 


### PR DESCRIPTION
This PR updates `siguza-utils` to the latest commit. which makes it easier to build with a Makefile. Specific changes have been mentioned under the commit message. 