### PR TITLE
Makefile: codesign with -o kill,hard,expires instead of -o runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -655,7 +655,7 @@ SIGN = 	CODESIGN_FLAGS="--sign $(CODESIGN_IDENTITY) --force --deep "; \
 		if [ "$(CODESIGN_IDENTITY)" != "-" ]; then \
 			CODESIGN_FLAGS+="--timestamp "; \
 			if [ "$(4)" != "nohardened" ]; then \
-				CODESIGN_FLAGS+="-o runtime "; \
+				CODESIGN_FLAGS+="-o kill,hard,expires "; \
 			fi; \
 			if [ -n "$(3)" ]; then \
 				CODESIGN_FLAGS+="--entitlements $(BUILD_MISC)/entitlements/$(3) "; \

--- a/Makefile
+++ b/Makefile
@@ -655,7 +655,7 @@ SIGN = 	CODESIGN_FLAGS="--sign $(CODESIGN_IDENTITY) --force --deep "; \
 		if [ "$(CODESIGN_IDENTITY)" != "-" ]; then \
 			CODESIGN_FLAGS+="--timestamp "; \
 			if [ "$(4)" != "nohardened" ]; then \
-				CODESIGN_FLAGS+="-o kill,hard,expires "; \
+				CODESIGN_FLAGS+="-o kill,hard "; \
 			fi; \
 			if [ -n "$(3)" ]; then \
 				CODESIGN_FLAGS+="--entitlements $(BUILD_MISC)/entitlements/$(3) "; \


### PR DESCRIPTION
runtime includes library validation, which requires any libraries to be
system or signed with the same Team ID in order to be loaded, this means
that anything signed with a valid cert that is not part of Hayden Seay's
team will not work.

\> ldid
dyld: Library not loaded: @rpath/libcrypto.3.dylib
  Referenced from: /opt/procursus/bin/ldid
  Reason: no suitable image found.  Did find:
    /opt/procursus/lib/libcrypto.3.dylib: code signature in (/opt/procursus/lib/libcrypto.3.dylib) not valid for use in process using Library Validation: mapping process and mapped file (non-platform) have different Team IDs
    /opt/procursus/lib/libcrypto.3.dylib: stat() failed with errno=1
[1]    12218 abort      ldid
