### PR TITLE
Rename GET_LOGICAL_CORES and make it configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -947,11 +947,11 @@ MAKEFLAGS += --no-print-directory
 
 ifeq ($(findstring --jobserver-auth=,$(MAKEFLAGS)),)
 ifeq ($(call HAS_COMMAND,nproc),1)
-GET_LOGICAL_CORES := $(shell expr $(shell nproc) / 2)
+CORE_COUNT ?= $(shell nproc)
 else
-GET_LOGICAL_CORES := $(shell expr $(shell sysctl -n hw.ncpu) / 2)
+CORE_COUNT ?= $(shell sysctl -n hw.ncpu)
 endif
-MAKEFLAGS += --jobs=$(GET_LOGICAL_CORES) --load-average=$(GET_LOGICAL_CORES)
+MAKEFLAGS += --jobs=$(CORE_COUNT) --load-average=$(CORE_COUNT)
 endif
 
 PROCURSUS := 1

--- a/makefiles/openjdk.mk
+++ b/makefiles/openjdk.mk
@@ -101,7 +101,7 @@ openjdk: openjdk-setup libx11 libxext libxi libxrender libxrandr libxtst freetyp
 		CPP="$(CPP) -arch arm64" \
 		CXXCPP="$(CXX) -E -arch arm64"
 	make -C $(BUILD_WORK)/openjdk images \
-		JOBS=$(shell $(GET_LOGICAL_CORES))
+		JOBS=$(CORE_COUNT)
 	cp -a $(BUILD_WORK)/openjdk/build/*/images/jdk $(BUILD_STAGE)/openjdk/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/jvm/java-$(OPENJDK_MAJOR_V)-openjdk
 	for dylib in $(BUILD_STAGE)/openjdk/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/jvm/java-$(OPENJDK_MAJOR_V)-openjdk/lib/{,*/}*.dylib; do \
 		$(LN_S) $$(basename $$dylib) $$(echo $$dylib | sed s/.dylib//).so; \


### PR DESCRIPTION
- Not every CPU is using SMT.
- Make this configurable instead of forcing to use all cores/threads.
- Rename variable as it's not a function

Probably a better name than `CORE_COUNT` can be used though.

### All Submissions

* [ ] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [x] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)

### Package Additions/Updates

* [ ] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [ ] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
