### PR TITLE
Update python3 to 3.9.9

### DIFF
--- a/build_patch/python3/library-fallback.patch
+++ b/build_patch/python3/library-fallback.patch
@@ -1,0 +1,11 @@
+diff -urN a/Lib/ctypes/macholib/dyld.py b/Lib/ctypes/macholib/dyld.py
+--- a/Lib/ctypes/macholib/dyld.py	2021-06-28 03:26:18.000000000 -0500
++++ b/Lib/ctypes/macholib/dyld.py	2021-11-25 01:36:39.000000000 -0600
+@@ -31,6 +31,7 @@
+     "/usr/local/lib",
+     "/lib",
+     "/usr/lib",
++    "@MEMO_PREFIX@@MEMO_SUB_PREFIX@/lib"
+ ]
+ 
+ def dyld_env(env, var):

--- a/makefiles/python3.mk
+++ b/makefiles/python3.mk
@@ -4,7 +4,7 @@ endif
 
 SUBPROJECTS      += python3
 PYTHON3_MAJOR_V  := 3.9
-PYTHON3_VERSION  := $(PYTHON3_MAJOR_V).6
+PYTHON3_VERSION  := $(PYTHON3_MAJOR_V).9
 DEB_PYTHON3_V    ?= $(PYTHON3_VERSION)
 
 python3-setup: setup


### PR DESCRIPTION
This PR updates to python 3.9.9, and also adds alternate Procursus library paths (e.g. /opt/procursus/lib) to the Python lib search paths.

### All Submissions

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [ ] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)

### Package Additions/Updates

* [x] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [x] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
