### PR TITLE
Auto-generated DEBIAN/conffiles for all files in /etc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -824,7 +824,7 @@ PACK = \
 			fi; \
 		done; \
 	done; \
-	(cd $(BUILD_DIST)/$(1)/; find .$(MEMO_PREFIX)/etc -type f) | cut -d. -f2- >> $(BUILD_DIST)/$(1)/DEBIAN/conffiles; \
+	find $(BUILD_DIST)/$(1)/$(MEMO_PREFIX)/etc -type f -printf '$(MEMO_PREFIX)/etc/%P\n' | LC_ALL=C sort >> $(BUILD_DIST)/$(1)/DEBIAN/conffiles; \
 	[ -s $(BUILD_DIST)/$(1)/DEBIAN/conffiles ] || rm $(BUILD_DIST)/$(1)/DEBIAN/conffiles; \
 	sed -i '$$a\' $(BUILD_DIST)/$(1)/DEBIAN/control; \
 	cd $(BUILD_DIST)/$(1) && find . -type f ! -regex '.*.hg.*' ! -regex '.*?debian-binary.*' ! -regex '.*?DEBIAN.*' -printf '"%P" ' | xargs md5sum > $(BUILD_DIST)/$(1)/DEBIAN/md5sums; \

--- a/Makefile
+++ b/Makefile
@@ -824,6 +824,8 @@ PACK = \
 			fi; \
 		done; \
 	done; \
+	(cd $(BUILD_DIST)/$(1)/; find .$(MEMO_PREFIX)/etc -type f) | cut -d. -f2- >> $(BUILD_DIST)/$(1)/DEBIAN/conffiles; \
+	[ -s $(BUILD_DIST)/$(1)/DEBIAN/conffiles ] || rm $(BUILD_DIST)/$(1)/DEBIAN/conffiles; \
 	sed -i '$$a\' $(BUILD_DIST)/$(1)/DEBIAN/control; \
 	cd $(BUILD_DIST)/$(1) && find . -type f ! -regex '.*.hg.*' ! -regex '.*?debian-binary.*' ! -regex '.*?DEBIAN.*' -printf '"%P" ' | xargs md5sum > $(BUILD_DIST)/$(1)/DEBIAN/md5sums; \
 	$(FAKEROOT) chmod 0755 $(BUILD_DIST)/$(1)/DEBIAN/*; \

--- a/build_info/base.conffiles
+++ b/build_info/base.conffiles
@@ -1,3 +1,0 @@
-@MEMO_PREFIX@/etc/passwd
-@MEMO_PREFIX@/etc/master.passwd
-@MEMO_PREFIX@/etc/group

--- a/build_info/doas.conffiles
+++ b/build_info/doas.conffiles
@@ -1,1 +1,0 @@
-@MEMO_PREFIX@/etc/doas.conf

--- a/build_misc/pam/doas
+++ b/build_misc/pam/doas
@@ -1,4 +1,4 @@
-# sudo: auth account password session
+# doas: auth account password session
 auth       required       pam_unix.so
 account    required       pam_permit.so
 password   required       pam_deny.so


### PR DESCRIPTION
build_info/*.conffiles should be reserved for files not in /etc that
need to be tracked in the conffiles.

We need to confirm Sileo, Zebra and Cydia will not choke on conffiles. Sileo and Zebra should work but the bundled versions in most jailbreaks is likely too old. Cydia will almost definitely need an update.
