### PR TITLE
chore: Actually use OTOOL variable

### DIFF
--- a/build_tools/find_deps.sh
+++ b/build_tools/find_deps.sh
@@ -30,6 +30,6 @@ if [ -z ${1+x} ]; then
 fi
 
 find ${1} -type f -exec sh -c "file -ib '{}' | grep -q 'x-mach-binary; charset=binary'" \; \
-	-exec otool -L {} \; | \
+	-exec ${OTOOL} -L {} \; | \
 	${GREP} -o -P '((?<=lib\/)|(?<=@rpath\/))(.*).*dylib(?!:)' | \
 	sort -u


### PR DESCRIPTION
### Description
Hotfix for ``find_deps.sh``, making it use the ``OTOOL`` variable that the script checks for. Otherwise, why the hell check for it?

### All Submissions

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [x] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)
