### PR TITLE
use openssh for ramdisk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1046,7 +1046,7 @@ env:
 
 include makefiles/*.mk
 
-RAMDISK_PROJECTS := bash coreutils diskdev-cmds dropbear findutils grep gzip ncurses profile.d readline tar
+RAMDISK_PROJECTS := bash coreutils diskdev-cmds findutils grep gzip ncurses profile.d readline tar openssl libmd openssh
 
 ramdisk:
 	+MEMO_NO_IOSEXEC=1 $(MAKE) $(RAMDISK_PROJECTS:%=%-package)
@@ -1059,8 +1059,6 @@ ramdisk:
 	done
 	ln -s $(MEMO_PREFIX)/bin/bash $(BUILD_DIST)/strap/$(MEMO_PREFIX)/bin/sh
 	echo -e "/bin/sh\n" > $(BUILD_DIST)/strap/$(MEMO_PREFIX)/etc/shells
-	echo -e "#!/bin/sh\n\
-exec dropbear -R -F -E -p \$$@" > $(BUILD_DIST)/strap/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/libexec/dropbear-wrapper
 	rm -rf $(BUILD_DIST)/strap/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/{include,lib/{*.a,pkgconfig},share/{doc,man}}
 	export FAKEROOT='fakeroot -i $(BUILD_DIST)/.fakeroot_bootstrap -s $(BUILD_DIST)/.fakeroot_bootstrap --'; \
 	cd $(BUILD_DIST)/strap && $$FAKEROOT tar -ckpf $(BUILD_DIST)/bootstrap_tools.tar .

--- a/makefiles/openssh.mk
+++ b/makefiles/openssh.mk
@@ -25,14 +25,20 @@ openssh-setup: setup
 ifeq (,$(findstring darwin,$(MEMO_TARGET)))
 	$(call DO_PATCH,openssh,openssh,-p1)
 endif
+ifeq (,$(findstring ramdisk,$(MEMO_TARGET)))
 	sed -i 's/#UsePAM no/UsePAM yes/' $(BUILD_WORK)/openssh/sshd_config
+endif #(,$(findstring ramdisk,$(MEMO_TARGET)))
 
 ifneq ($(wildcard $(BUILD_WORK)/openssh/.build_complete),)
 openssh:
 	@echo "Using previously built openssh."
 else
 ifeq (,$(findstring darwin,$(MEMO_TARGET)))
+ifeq (,$(findstring ramdisk,$(MEMO_TARGET)))
 openssh: openssh-setup openssl libxcrypt openpam libmd
+else #(,$(findstring ramdisk,$(MEMO_TARGET)))
+openssh: openssh-setup openssl libmd
+endif #(,$(findstring ramdisk,$(MEMO_TARGET)))
 else # (,$(findstring darwin,$(MEMO_TARGET)))
 OPENSSH_CONFIGURE_ARGS += --with-keychain=apple
 openssh: openssh-setup openssl libmd
@@ -41,6 +47,7 @@ endif # (,$(findstring darwin,$(MEMO_TARGET)))
 		cd $(BUILD_WORK)/openssh && autoreconf; \
 	fi
 	sed -i '/HAVE_ENDIAN_H/d' $(BUILD_WORK)/openssh/config.h.in
+ifeq (,$(findstring ramdisk,$(MEMO_TARGET)))
 	cd $(BUILD_WORK)/openssh && ./configure -C \
 		$(DEFAULT_CONFIGURE_FLAGS) \
 		--sysconfdir=$(MEMO_PREFIX)/etc/ssh \
@@ -53,9 +60,21 @@ endif # (,$(findstring darwin,$(MEMO_TARGET)))
 		SSHDLIBS="-lcrypt -lsandbox -lpam -ldl"
 	+$(MAKE) -C $(BUILD_WORK)/openssh install \
 		DESTDIR="$(BUILD_STAGE)/openssh"
-	mkdir -p $(BUILD_STAGE)/openssh/$(MEMO_PREFIX)/Library/LaunchDaemons
 	mkdir -p $(BUILD_STAGE)/openssh/$(MEMO_PREFIX)/etc/pam.d
 	cp $(BUILD_MISC)/openssh/sshd $(BUILD_STAGE)/openssh/$(MEMO_PREFIX)/etc/pam.d
+else # (,$(findstring ramdisk,$(MEMO_TARGET)))
+	cd $(BUILD_WORK)/openssh && ./configure -C \
+		$(DEFAULT_CONFIGURE_FLAGS) \
+		--sysconfdir=$(MEMO_PREFIX)/etc/ssh \
+		--with-ssl-engine \
+		check_for_libcrypt_before=1 \
+		$(OPENSSH_CONFIGURE_ARGS)
+	+$(MAKE) -C $(BUILD_WORK)/openssh \
+		SSHDLIBS=""
+	+$(MAKE) -C $(BUILD_WORK)/openssh install \
+		DESTDIR="$(BUILD_STAGE)/openssh"
+endif #(,$(findstring ramdisk,$(MEMO_TARGET)))
+	mkdir -p $(BUILD_STAGE)/openssh/$(MEMO_PREFIX)/Library/LaunchDaemons
 	cp $(BUILD_MISC)/openssh/com.openssh.sshd.plist $(BUILD_STAGE)/openssh/$(MEMO_PREFIX)/Library/LaunchDaemons
 	cp $(BUILD_MISC)/openssh/sshd-keygen-wrapper $(BUILD_STAGE)/openssh/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/libexec
 	cp $(BUILD_WORK)/openssh/contrib/ssh-copy-id $(BUILD_STAGE)/openssh/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin
@@ -66,34 +85,48 @@ endif
 openssh-package: openssh-stage
 	# openssh.mk Package Structure
 	rm -rf $(BUILD_DIST)/openssh{,-sftp-server,-server,-client}
+ifeq (,$(findstring ramdisk,$(MEMO_TARGET)))
 	mkdir -p $(BUILD_DIST)/openssh \
 		$(BUILD_DIST)/openssh-client/{$(MEMO_PREFIX)/var/empty,$(MEMO_PREFIX)/etc/ssh,$(MEMO_PREFIX)/$(MEMO_SUB_PREFIX)/{libexec,share/man/{man1,man5,man8}}} \
 		$(BUILD_DIST)/openssh-server/{$(MEMO_PREFIX)/etc/ssh,$(MEMO_PREFIX)/$(MEMO_SUB_PREFIX)/{libexec,share/man/{man5,man8}}} \
 		$(BUILD_DIST)/openssh-sftp-server/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/{libexec,/share/man/man8}
+else
+	mkdir -p $(BUILD_DIST)/openssh \
+		$(BUILD_DIST)/openssh-client/{$(MEMO_PREFIX)/var/empty,$(MEMO_PREFIX)/etc/ssh,$(MEMO_PREFIX)/$(MEMO_SUB_PREFIX)/libexec} \
+		$(BUILD_DIST)/openssh-server/{$(MEMO_PREFIX)/etc/ssh,$(MEMO_PREFIX)/$(MEMO_SUB_PREFIX)/libexec} \
+		$(BUILD_DIST)/openssh-sftp-server/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/libexec
+endif
 
 	# openssh.mk Prep openssh-client
 	cp -a $(BUILD_STAGE)/openssh/$(MEMO_PREFIX)/etc/ssh/ssh_config $(BUILD_DIST)/openssh-client/$(MEMO_PREFIX)/etc/ssh
 	cp -a $(BUILD_STAGE)/openssh/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin $(BUILD_DIST)/openssh-client/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)
 	cp -a $(BUILD_STAGE)/openssh/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/libexec/{ssh-keysign,ssh-pkcs11-helper,ssh-sk-helper} $(BUILD_DIST)/openssh-client/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/libexec
+ifeq (,$(findstring ramdisk,$(MEMO_TARGET)))
 	cp -a $(BUILD_STAGE)/openssh/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/man/man1 $(BUILD_DIST)/openssh-client/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/man
 	cp -a $(BUILD_STAGE)/openssh/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/man/man5/ssh_config.5$(MEMO_MANPAGE_SUFFIX) $(BUILD_DIST)/openssh-client/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/man/man5
 	cp -a $(BUILD_STAGE)/openssh/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/man/man8/{ssh-keysign.8,ssh-pkcs11-helper.8,ssh-sk-helper.8}$(MEMO_MANPAGE_SUFFIX) $(BUILD_DIST)/openssh-client/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/man/man8
+endif
 
 	# openssh.mk Prep openssh-server
 	cp -a $(BUILD_STAGE)/openssh/$(MEMO_PREFIX)/etc/ssh/{moduli,sshd_config} $(BUILD_DIST)/openssh-server/$(MEMO_PREFIX)/etc/ssh
 ifeq (,$(findstring darwin,$(MEMO_TARGET)))
+ifeq (,$(findstring ramdisk,$(MEMO_TARGET)))
 	cp -a $(BUILD_STAGE)/openssh/$(MEMO_PREFIX)/etc/pam.d $(BUILD_DIST)/openssh-server/$(MEMO_PREFIX)/etc
+endif
 endif
 	cp -a $(BUILD_STAGE)/openssh/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/sbin $(BUILD_DIST)/openssh-server/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)
 	cp -a $(BUILD_STAGE)/openssh/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/libexec/sshd-keygen-wrapper $(BUILD_DIST)/openssh-server/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/libexec
+ifeq (,$(findstring ramdisk,$(MEMO_TARGET)))
 	cp -a $(BUILD_STAGE)/openssh/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/man/man5/{moduli.5,sshd_config.5}$(MEMO_MANPAGE_SUFFIX) $(BUILD_DIST)/openssh-server/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/man/man5
 	cp -a $(BUILD_STAGE)/openssh/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/man/man8/sshd.8$(MEMO_MANPAGE_SUFFIX) $(BUILD_DIST)/openssh-server/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/man/man8
+endif
 	cp -a $(BUILD_STAGE)/openssh/$(MEMO_PREFIX)/Library $(BUILD_DIST)/openssh-server/$(MEMO_PREFIX)
 
 	# openssh.mk Prep openssh-sftp-server
 	cp -a $(BUILD_STAGE)/openssh/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/libexec/sftp-server $(BUILD_DIST)/openssh-sftp-server/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/libexec/
+ifeq (,$(findstring ramdisk,$(MEMO_TARGET)))
 	cp -a $(BUILD_STAGE)/openssh/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/man/man8/sftp-server.8$(MEMO_MANPAGE_SUFFIX) $(BUILD_DIST)/openssh-sftp-server/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/man/man8
-
+endif
 	# openssh.mk Sign
 	$(call SIGN,openssh-client,general.xml)
 	$(call SIGN,openssh-server,pam.xml)


### PR DESCRIPTION
Use openssh in ramdisk instead of dropbear, because dropbear is missing `scp`.

Tested on device.