### PR TITLE
chezmoi: slightly fix makefile and bump to 2.12.1

### DIFF
--- a/makefiles/chezmoi.mk
+++ b/makefiles/chezmoi.mk
@@ -3,12 +3,13 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS     += chezmoi
-CHEZMOI_VERSION := 2.0.10
+CHEZMOI_COMMIT  := 8714b95999fcfc7247a3ee70e4232f438b610c82 
+CHEZMOI_VERSION := 2.12.1
 DEB_CHEZMOI_V   ?= $(CHEZMOI_VERSION)
 
 chezmoi-setup: setup
 	$(call GITHUB_ARCHIVE,twpayne,chezmoi,$(CHEZMOI_VERSION),v$(CHEZMOI_VERSION))
-	$(call EXTRACT_TAR,chezmoi-v$(CHEZMOI_VERSION).tar.gz,chezmoi-$(CHEZMOI_VERSION),chezmoi)
+	$(call EXTRACT_TAR,chezmoi-$(CHEZMOI_VERSION).tar.gz,chezmoi-$(CHEZMOI_VERSION),chezmoi)
 	mkdir -p $(BUILD_STAGE)/chezmoi/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin
 
 ifneq ($(wildcard $(BUILD_WORK)/chezmoi/.build_complete),)
@@ -23,7 +24,10 @@ endif
 	cd $(BUILD_WORK)/chezmoi && go get -d -v .
 	cd $(BUILD_WORK)/chezmoi && \
 		$(DEFAULT_GOLANG_FLAGS) \
-		go build
+		go build -ldflags "-X main.version=$(CHEZMOI_VERSION) \
+			-X main.commit=$(CHEZMOI_COMMIT) \
+			-X main.builtBy=Procursus \
+			-X main.date=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)"
 	cp -a $(BUILD_WORK)/chezmoi/chezmoi $(BUILD_STAGE)/chezmoi/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin
 	$(call AFTER_BUILD)
 endif

--- a/makefiles/chezmoi.mk
+++ b/makefiles/chezmoi.mk
@@ -10,7 +10,7 @@ DEB_CHEZMOI_V   ?= $(CHEZMOI_VERSION)
 chezmoi-setup: setup
 	$(call GITHUB_ARCHIVE,twpayne,chezmoi,$(CHEZMOI_VERSION),v$(CHEZMOI_VERSION))
 	$(call EXTRACT_TAR,chezmoi-$(CHEZMOI_VERSION).tar.gz,chezmoi-$(CHEZMOI_VERSION),chezmoi)
-	mkdir -p $(BUILD_STAGE)/chezmoi/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin
+	mkdir -p $(BUILD_STAGE)/chezmoi/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/{bin,share/{zsh/site-functions,bash-completion/completions,fish/vendor_completions.d}}
 
 ifneq ($(wildcard $(BUILD_WORK)/chezmoi/.build_complete),)
 chezmoi:
@@ -28,6 +28,13 @@ endif
 			-X main.commit=$(CHEZMOI_COMMIT) \
 			-X main.builtBy=Procursus \
 			-X main.date=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)"
+	cd $(BUILD_WORK)/chezmoi && \
+		CGO_CC="$(CC_FOR_BUILD)" CGO_CFLAGS="$(CFLAGS_FOR_BUILD)" CGO_CPPFLAGS="$(CPPFLAGS_FOR_BUILD)" CGO_LDFLAGS="$(LDFLAGS_FOR_BUILD)" \
+		go build -o chezmoi-host
+
+	$(BUILD_WORK)/chezmoi/chezmoi-host completion zsh > $(BUILD_STAGE)/chezmoi/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/zsh/site-functions/_chezmoi
+	$(BUILD_WORK)/chezmoi/chezmoi-host completion bash > $(BUILD_STAGE)/chezmoi/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/bash-completion/completions/chezmoi
+	$(BUILD_WORK)/chezmoi/chezmoi-host completion fish > $(BUILD_STAGE)/chezmoi/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/fish/vendor_completions.d/chezmoi.fish
 	cp -a $(BUILD_WORK)/chezmoi/chezmoi $(BUILD_STAGE)/chezmoi/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin
 	$(call AFTER_BUILD)
 endif


### PR DESCRIPTION
### All Submissions

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [x] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)

### Package Additions/Updates

* [ ] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [x] Have you confirmed this builds & works as intended on a macOS device (if applicable)?

----
- Bump chezmoi to 2.12.1
- Fixes filename in EXTRACT_TAR
- Provides version number, commit hash and build time in the binary as per chezmoi's [packaging guide.](https://www.chezmoi.io/developer/packaging/)