### PR TITLE
chore: bump various packages

### DIFF
--- a/build_info/duf.control
+++ b/build_info/duf.control
@@ -2,6 +2,7 @@ Package: duf
 Version: @DEB_DUF_V@
 Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
+Author: Christian Muehlhaeuser <muesli@gmail.com>
 Section: Utilities
 Priority: optional
 Description:  Disk Usage/Free Utility - a better 'df' alternative 

--- a/makefiles/curlie.mk
+++ b/makefiles/curlie.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS     += curlie
-CURLIE_VERSION  := 1.6.0
+CURLIE_VERSION  := 1.6.7
 DEB_CURLIE_V    ?= $(CURLIE_VERSION)
 
 curlie-setup: setup

--- a/makefiles/duf.mk
+++ b/makefiles/duf.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS  += duf
-DUF_VERSION  := 0.6.2
+DUF_VERSION  := 0.8.1
 DEB_DUF_V    ?= $(DUF_VERSION)
 
 duf-setup: setup

--- a/makefiles/duf.mk
+++ b/makefiles/duf.mk
@@ -9,7 +9,7 @@ DEB_DUF_V    ?= $(DUF_VERSION)
 duf-setup: setup
 	$(call GITHUB_ARCHIVE,muesli,duf,$(DUF_VERSION),v$(DUF_VERSION))
 	$(call EXTRACT_TAR,duf-$(DUF_VERSION).tar.gz,duf-$(DUF_VERSION),duf)
-	mkdir -p $(BUILD_STAGE)/duf/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin
+	mkdir -p $(BUILD_STAGE)/duf/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/{bin,share/man/man1}
 
 ifneq ($(wildcard $(BUILD_WORK)/duf/.build_complete),)
 duf:
@@ -19,6 +19,7 @@ duf: duf-setup
 	cd $(BUILD_WORK)/duf && $(DEFAULT_GOLANG_FLAGS) go build \
 			-o $(BUILD_WORK)/duf/duf
 	$(INSTALL) -Dm755 $(BUILD_WORK)/duf/duf $(BUILD_STAGE)/duf/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/
+	$(INSTALL) -Dm644 $(BUILD_WORK)/duf/duf.1 $(BUILD_STAGE)/duf/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/man/man1/duf.1
 	$(call AFTER_BUILD)
 endif
 

--- a/makefiles/fzf.mk
+++ b/makefiles/fzf.mk
@@ -9,7 +9,7 @@ DEB_FZF_V    ?= $(FZF_VERSION)
 fzf-setup: setup
 	$(call GITHUB_ARCHIVE,junegunn,fzf,$(FZF_VERSION),$(FZF_VERSION))
 	$(call EXTRACT_TAR,fzf-$(FZF_VERSION).tar.gz,fzf-$(FZF_VERSION),fzf)
-	mkdir -p $(BUILD_STAGE)/fzf/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX){/share,/bin}
+	mkdir -p $(BUILD_STAGE)/fzf/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX){/share/doc/fzf/examples,/bin}
 
 ifneq ($(wildcard $(BUILD_WORK)/fzf/.build_complete),)
 fzf:
@@ -18,7 +18,13 @@ else
 fzf: fzf-setup
 	cd $(BUILD_WORK)/fzf && $(DEFAULT_GOLANG_FLAGS) go build \
 			-ldflags "-s -w -X main.version=$(FZF_VERSION) -X main.revision=Procursus"
+	
 	$(INSTALL) -Dm755 $(BUILD_WORK)/fzf/{/fzf,/bin/fzf-tmux} $(BUILD_STAGE)/fzf/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/
+	$(INSTALL) -Dm644 $(BUILD_WORK)/fzf/shell/completion.bash  $(BUILD_STAGE)/fzf/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/bash-completion/completions/fzf
+	$(INSTALL) -Dm644 $(BUILD_WORK)/fzf/shell/completion.zsh $(BUILD_STAGE)/fzf/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/zsh/site-functions/_fzf
+	$(INSTALL) -Dm644 $(BUILD_WORK)/fzf/shell/key-bindings.{bash,zsh,fish} $(BUILD_STAGE)/fzf/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/doc/fzf/examples/
+	$(INSTALL) -Dm644 $(BUILD_WORK)/fzf/plugin/fzf.vim $(BUILD_STAGE)/fzf/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/doc/fzf/plugins/fzf.vim
+	
 	cp -a $(BUILD_WORK)/fzf/man $(BUILD_STAGE)/fzf/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share
 	$(call AFTER_BUILD)
 endif

--- a/makefiles/fzf.mk
+++ b/makefiles/fzf.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS  += fzf
-FZF_VERSION  := 0.25.0
+FZF_VERSION  := 0.29.0
 DEB_FZF_V    ?= $(FZF_VERSION)
 
 fzf-setup: setup

--- a/makefiles/mtr.mk
+++ b/makefiles/mtr.mk
@@ -32,7 +32,7 @@ mtr-package: mtr-stage
 	mkdir -p $(BUILD_DIST)/mtr
 
 	# mtr.mk Prep mtr
-	cp -a $(BUILD_STAGE)/mtr/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX) $(BUILD_DIST)/mtr
+	cp -a $(BUILD_STAGE)/mtr $(BUILD_DIST)
 
 	# mtr.mk Sign
 	$(call SIGN,mtr,general.xml)

--- a/makefiles/mtr.mk
+++ b/makefiles/mtr.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS  += mtr
-MTR_VERSION := 0.94
+MTR_VERSION := 0.95
 DEB_MTR_V   ?= $(MTR_VERSION)
 
 mtr-setup: setup


### PR DESCRIPTION
### Description
- Bumps mtr, fzf, duf, curlie to upstream versions
- Add duf's author
- Add shell completions for fzf, as well as shell keybindings (in `@MEMO_PREFIX@@MEMO_SUB_PREFIX@/share/doc/fzf`

### Building
- Build environment: darwin-amd64, macOS 12.2.1
- Tested building on: darwin-amd64, darwin-arm64, iphoneos-arm64
- Tested working on: darwin-amd64

### All Submissions

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [x] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)

### Package Additions/Updates

* [ ] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [x] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
