### PR TITLE
Update zlib-ng and make some modifications

### DIFF
--- a/makefiles/zlib-ng.mk
+++ b/makefiles/zlib-ng.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS      += zlib-ng
-ZLIB-NG_VERSION  := 2.0.3
+ZLIB-NG_VERSION  := 2.0.6
 DEB_ZLIB-NG_V    ?= $(ZLIB-NG_VERSION)
 
 zlib-ng-setup: setup
@@ -17,6 +17,8 @@ else
 zlib-ng: zlib-ng-setup
 	cd $(BUILD_WORK)/zlib-ng && cmake . \
 		$(DEFAULT_CMAKE_FLAGS) \
+		-DZLIB_ENABLE_TESTS=Off \
+		-DZLIB_INSTALL_UTILS=On \
 		.
 	+$(MAKE) -C $(BUILD_WORK)/zlib-ng
 	+$(MAKE) -C $(BUILD_WORK)/zlib-ng install \


### PR DESCRIPTION
As this is a drop in replacement for zlib, perhaps we should be replacing all non-system binaries with this zlib-ng