### PR TITLE
ktool: Update to 1.0.0

### DIFF
--- a/build_info/ktool.control
+++ b/build_info/ktool.control
@@ -8,5 +8,5 @@ Section: Python
 Priority: optional
 Homepage: https://github.com/cxnder/ktool
 Description: Static MachO/ObjC reverse engineering toolkit.
- ktool is a fully cross-platform toolkit (and library)
- for MachO editing and analysis.
+ ktool is a fully cross-platform toolkit, TUI, and library
+ for MachO binary editing and analysis.

--- a/build_patch/ktool/legacy_setup.patch
+++ b/build_patch/ktool/legacy_setup.patch
@@ -1,0 +1,33 @@
+From 52d60b94589c4a9fd38370deea5c1c5bff730166 Mon Sep 17 00:00:00 2001
+From: TheRealKeto <therealketo@gmail.com>
+Date: Wed, 2 Mar 2022 15:30:40 -0500
+Subject: [PATCH] legacy(setup): Use entry_points/console_scripts to specify
+ scripts
+
+Signed-off-by: TheRealKeto <therealketo@gmail.com>
+---
+ .legacy_setup.py | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/.legacy_setup.py b/.legacy_setup.py
+index b2fa875..165676f 100644
+--- a/.legacy_setup.py
++++ b/.legacy_setup.py
+@@ -5,7 +5,7 @@
+ long_description = (this_directory / "README.md").read_text()
+ 
+ setup(name='k2l',
+-      version='1.0.0rc0',
++      version='1.0.0',
+       description='Static MachO/ObjC Reverse Engineering Toolkit',
+       long_description=long_description,
+       long_description_content_type='text/markdown',
+@@ -24,5 +24,7 @@
+             'License :: OSI Approved :: MIT License',
+             'Operating System :: OS Independent'
+       ],
+-      scripts=['bin/ktool']
++      entry_points = {"console_scripts": [
++        "ktool=ktool.ktool_script:main"
++      ]}
+       )

--- a/makefiles/ktool.mk
+++ b/makefiles/ktool.mk
@@ -16,8 +16,7 @@ ktool:
 	@echo "Using previously built ktool."
 else
 ktool: ktool-setup python3-kimg4 python3-pyaes pygments python3
-	mv $(BUILD_WORK)/ktool/.legacy_setup.py $(BUILD_WORK)/ktool/setup.py
-	cd $(BUILD_WORK)/ktool && $(DEFAULT_SETUP_PY_ENV) python3 ./setup.py \
+	cd $(BUILD_WORK)/ktool && $(DEFAULT_SETUP_PY_ENV) python3 ./.legacy_setup.py \
 		build \
 		--executable="$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/python3" \
 		install \

--- a/makefiles/ktool.mk
+++ b/makefiles/ktool.mk
@@ -3,20 +3,20 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS    += ktool
-# Get rid of this variable at some point
-KTOOL_TVERSION := 1.0.0rc0
-KTOOL_VERSION  := 1.0.0~rc0
+KTOOL_VERSION  := 1.0.0
 DEB_KTOOL_V    ?= $(KTOOL_VERSION)
 
 ktool-setup: setup
-	$(call GITHUB_ARCHIVE,cxnder,ktool,$(KTOOL_VERSION),$(KTOOL_TVERSION))
-	$(call EXTRACT_TAR,ktool-$(KTOOL_VERSION).tar.gz,ktool-$(KTOOL_TVERSION),ktool)
+	$(call GITHUB_ARCHIVE,cxnder,ktool,$(KTOOL_VERSION),$(KTOOL_VERSION))
+	$(call EXTRACT_TAR,ktool-$(KTOOL_VERSION).tar.gz,ktool-$(KTOOL_VERSION),ktool)
+	$(call DO_PATCH,ktool,ktool,-p1)
 
 ifneq ($(wildcard $(BUILD_WORK)/ktool/.build_complete),)
 ktool:
 	@echo "Using previously built ktool."
 else
 ktool: ktool-setup python3-kimg4 python3-pyaes pygments python3
+	mv $(BUILD_WORK)/ktool/.legacy_setup.py $(BUILD_WORK)/ktool/setup.py
 	cd $(BUILD_WORK)/ktool && $(DEFAULT_SETUP_PY_ENV) python3 ./setup.py \
 		build \
 		--executable="$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/python3" \

--- a/makefiles/pygments.mk
+++ b/makefiles/pygments.mk
@@ -16,7 +16,7 @@ ifneq ($(wildcard $(BUILD_WORK)/pygments/.build_complete),)
 pygments:
 	@echo "Using previously built pygments."
 else
-pygments: pygments-setup
+pygments: pygments-setup python3
 	cd $(BUILD_WORK)/pygments && $(DEFAULT_SETUP_PY_ENV) python3 ./setup.py \
 		build \
 		--executable="$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/python3" \

--- a/makefiles/python3-kimg4.mk
+++ b/makefiles/python3-kimg4.mk
@@ -11,9 +11,9 @@ python3-kimg4-setup: setup
 	$(call GITHUB_ARCHIVE,cxnder,kimg4,$(PYTHON3_KIMG4_VERSION),$(PYTHON3_KIMG4_COMMIT))
 	$(call EXTRACT_TAR,kimg4-$(PYTHON3_KIMG4_VERSION).tar.gz,kimg4-$(PYTHON3_KIMG4_COMMIT),python3-kimg4)
 
-ifneq ($(wildcard $(BUILD_WORK)/kimg4/.build_complete),)
+ifneq ($(wildcard $(BUILD_WORK)/python3-kimg4/.build_complete),)
 python3-kimg4:
-	@echo "Using previously built kimg4."
+	@echo "Using previously built python3-kimg4."
 else
 python3-kimg4: python3-kimg4-setup python3-pyaes python3
 	cd $(BUILD_WORK)/python3-kimg4 && $(DEFAULT_SETUP_PY_ENV) python3 ./setup.py \

--- a/makefiles/python3-pyaes.mk
+++ b/makefiles/python3-pyaes.mk
@@ -10,9 +10,9 @@ python3-pyaes-setup: setup
 	$(call GITHUB_ARCHIVE,ricmoo,pyaes,$(PYTHON3_PYAES_VERSION),v$(PYTHON3_PYAES_VERSION))
 	$(call EXTRACT_TAR,pyaes-$(PYTHON3_PYAES_VERSION).tar.gz,pyaes-$(PYTHON3_PYAES_VERSION),python3-pyaes)
 
-ifneq ($(wildcard $(BUILD_WORK)/pyaes/.build_complete),)
+ifneq ($(wildcard $(BUILD_WORK)/python3-pyaes/.build_complete),)
 python3-pyaes:
-	@echo "Using previously built pyaes."
+	@echo "Using previously built python3-pyaes."
 else
 python3-pyaes: python3-pyaes-setup python3
 	cd $(BUILD_WORK)/python3-pyaes && $(DEFAULT_SETUP_PY_ENV) python3 ./setup.py \


### PR DESCRIPTION
This PR updates ``ktool`` to its latest release (v1.0.0); some patches were required to add in order for the package to build on all architectures. All other changes have been documented under the commit message.