### PR TITLE
ktool: Update to 1.1.1

### DIFF
--- a/build_patch/ktool/legacy_setup.patch
+++ b/build_patch/ktool/legacy_setup.patch
@@ -1,33 +1,21 @@
-From 52d60b94589c4a9fd38370deea5c1c5bff730166 Mon Sep 17 00:00:00 2001
+From 464260413c09fa7c33d07c9b7d0b72f75127224e Mon Sep 17 00:00:00 2001
 From: TheRealKeto <therealketo@gmail.com>
-Date: Wed, 2 Mar 2022 15:30:40 -0500
-Subject: [PATCH] legacy(setup): Use entry_points/console_scripts to specify
- scripts
+Date: Sat, 5 Mar 2022 14:24:50 -0500
+Subject: [PATCH] legacy(setup): Let's handle this ourselves...
 
-Signed-off-by: TheRealKeto <therealketo@gmail.com>
 ---
- .legacy_setup.py | 6 ++++--
- 1 file changed, 4 insertions(+), 2 deletions(-)
+ .legacy_setup.py | 1 +
+ 1 file changed, 1 insertion(+)
 
 diff --git a/.legacy_setup.py b/.legacy_setup.py
-index b2fa875..165676f 100644
+index 4207d43..6eed624 100644
 --- a/.legacy_setup.py
 +++ b/.legacy_setup.py
-@@ -5,7 +5,7 @@
- long_description = (this_directory / "README.md").read_text()
+@@ -6,6 +6,7 @@
  
- setup(name='k2l',
--      version='1.0.0rc0',
-+      version='1.0.0',
-       description='Static MachO/ObjC Reverse Engineering Toolkit',
-       long_description=long_description,
-       long_description_content_type='text/markdown',
-@@ -24,5 +24,7 @@
-             'License :: OSI Approved :: MIT License',
-             'Operating System :: OS Independent'
-       ],
--      scripts=['bin/ktool']
-+      entry_points = {"console_scripts": [
-+        "ktool=ktool.ktool_script:main"
-+      ]}
-       )
+ setup(
+     name = 'k2l',
++    version = "@DEB_KTOOL_V@",
+     description = 'Static MacO/ObjC Reverse Engineering Toolkit',
+     long_description = long_description,
+     long_description_content_type = 'text/markdown',

--- a/build_patch/ktool/no_update.patch
+++ b/build_patch/ktool/no_update.patch
@@ -1,0 +1,46 @@
+From 00cfd0782d7199033c7a23c45d219d315a37ea02 Mon Sep 17 00:00:00 2001
+From: TheRealKeto <therealketo@gmail.com>
+Date: Sat, 5 Mar 2022 14:35:45 -0500
+Subject: [PATCH] ktool(update): Change instructions on updating
+
+Originally, the message would prompt the user to
+use pip in order to install latest updates. However,
+the user should instead use apt(8) over pip on Procursus.
+
+This also adds contact information for the Procursus Team.
+---
+ src/ktool/ktool_script.py | 7 ++++---
+ src/ktool/window.py       | 2 +-
+ 2 files changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/src/ktool/ktool_script.py b/src/ktool/ktool_script.py
+index c2f4adf..e7dd7d4 100644
+--- a/src/ktool/ktool_script.py
++++ b/src/ktool/ktool_script.py
+@@ -393,9 +393,10 @@ def main():
+                             f'Malformed MachO. Pass -f to force loading whatever possible')
+ 
+     if UPDATE_AVAILABLE:
+-        print(f'\n\nUpdate Available ---')
+-        print(f'run `pip3 install --upgrade k2l` to fetch the latest update')
+-        print(f'set the envar KTOOL_NO_UPDATE_CHECK to disable update checks')
++        print('\n\nUpdate Available ---')
++        print('Run `sudo apt install ktool` to fetch the latest update')
++        print('or set the envar KTOOL_NO_UPDATE_CHECK to disable update checks\n')
++        print('For more information, contact the Procursus Team <support@procurs.us>.')
+ 
+     exit(0)
+ 
+diff --git a/src/ktool/window.py b/src/ktool/window.py
+index 0fde961..0927ba0 100644
+--- a/src/ktool/window.py
++++ b/src/ktool/window.py
+@@ -61,7 +61,7 @@
+ 
+ This is a *very* pre-release version of the GUI Tool, and it has a long ways to go. 
+ 
+-Stay Updated with `python3 -m pip install --upgrade k2l` !
++Stay Updated with `sudo apt install ktool` !
+ 
+ Mouse support is a WIP; quite a few things support mouse interaction already.
+ 

--- a/makefiles/ktool.mk
+++ b/makefiles/ktool.mk
@@ -3,19 +3,21 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS    += ktool
-KTOOL_VERSION  := 1.0.0
+KTOOL_VERSION  := 1.1.1
 DEB_KTOOL_V    ?= $(KTOOL_VERSION)
 
 ktool-setup: setup
 	$(call GITHUB_ARCHIVE,cxnder,ktool,$(KTOOL_VERSION),$(KTOOL_VERSION))
 	$(call EXTRACT_TAR,ktool-$(KTOOL_VERSION).tar.gz,ktool-$(KTOOL_VERSION),ktool)
 	$(call DO_PATCH,ktool,ktool,-p1)
+	mkdir -p $(BUILD_STAGE)/ktool/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/man/man1
 
 ifneq ($(wildcard $(BUILD_WORK)/ktool/.build_complete),)
 ktool:
 	@echo "Using previously built ktool."
 else
 ktool: ktool-setup python3-kimg4 python3-pyaes pygments python3
+	sed -i 's|@DEB_KTOOL_V@|$(DEB_KTOOL_V)|g' $(BUILD_WORK)/ktool/.legacy_setup.py
 	cd $(BUILD_WORK)/ktool && $(DEFAULT_SETUP_PY_ENV) python3 ./.legacy_setup.py \
 		build \
 		--executable="$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/python3" \
@@ -23,6 +25,7 @@ ktool: ktool-setup python3-kimg4 python3-pyaes pygments python3
 		--install-layout=deb \
 		--root="$(BUILD_STAGE)/ktool" \
 		--prefix="$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)"
+	cp -a $(BUILD_WORK)/ktool/docs/ktool.1 $(BUILD_STAGE)/ktool/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/man/man1
 	find $(BUILD_STAGE)/ktool -name __pycache__ -prune -exec rm -rf {} \;
 	$(call AFTER_BUILD)
 endif


### PR DESCRIPTION
This PR updates `ktool` to its latest version, 1.1.1. All changes made were documented under the commit message; this built just fine on my 2015 iPod touch 6th gen running iOS 12.4.1
