### PR TITLE
Add kakoune

### DIFF
--- a/build_info/kakoune.control
+++ b/build_info/kakoune.control
@@ -1,0 +1,21 @@
+Package: kakoune
+Version: @DEB_KAKOUNE_V@
+Architecture: @DEB_ARCH@
+Maintainer: @DEB_MAINTAINER@
+Author: Maxime Coste <mawww@kakoune.org>
+Section: Text_Editors
+Priority: optional
+Homepage: http://kakoune.org/
+Description: Vim-inspired, selection-oriented code editor
+ Kakoune is a code editor heavily inspired by Vim; as such most of its
+ commands are similar to vi’s ones, and it shares Vi’s "keystrokes as
+ a text editing language" model.  Kakoune can operate in two modes, normal
+ and insertion.  In insertion mode, keys are directly inserted into
+ the current buffer.  In normal mode, keys are used to manipulate
+ the current selection and to enter insertion mode.  Kakoune has a strong
+ focus on interactivity, most commands provide immediate and incremental
+ results, while still being competitive (as in keystroke count) with Vim.
+ Kakoune works on selections, which are oriented, inclusive range of
+ characters; selections have an anchor and a cursor character.
+ Most commands move both of them, except when extending selection where
+ the anchor character stays fixed and the cursor one moves around.

--- a/build_info/kakoune.postinst
+++ b/build_info/kakoune.postinst
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ]; then
+	update-alternatives --install @MEMO_PREFIX@@MEMO_SUB_PREFIX@/bin/editor editor @MEMO_PREFIX@@MEMO_SUB_PREFIX@/bin/kak 40 \
+		--slave @MEMO_PREFIX@@MEMO_SUB_PREFIX@/share/man/man1/editor.1@MEMO_MANPAGE_SUFFIX@ editor.1@MEMO_MANPAGE_SUFFIX@ \
+		@MEMO_PREFIX@@MEMO_SUB_PREFIX@/share/man/man1/kak.1@MEMO_MANPAGE_SUFFIX@
+fi

--- a/build_info/kakoune.prerm
+++ b/build_info/kakoune.prerm
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" != "upgrade" ]; then
+    update-alternatives --remove editor @MEMO_PREFIX@@MEMO_SUB_PREFIX@/bin/kak
+fi

--- a/makefiles/kakoune.mk
+++ b/makefiles/kakoune.mk
@@ -17,8 +17,9 @@ else
 kakoune: kakoune-setup
 	+$(MAKE) -C $(BUILD_WORK)/kakoune \
 		CXX="$(CXX)" \
-		PREFIX="$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)"
+		LDFLAGS="$(patsubst -L/opt/local/lib,,$(LDFLAGS))"
 	+$(MAKE) -C $(BUILD_WORK)/kakoune install \
+		PREFIX="$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)" \
 		DESTDIR="$(BUILD_STAGE)/kakoune"
 	$(call AFTER_BUILD)
 endif

--- a/makefiles/kakoune.mk
+++ b/makefiles/kakoune.mk
@@ -19,6 +19,7 @@ kakoune: kakoune-setup
 		CXX="$(CXX)" \
 		LDFLAGS="$(patsubst -L/opt/local/lib,,$(LDFLAGS))"
 	+$(MAKE) -C $(BUILD_WORK)/kakoune install \
+		gzip_man=no \
 		PREFIX="$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)" \
 		DESTDIR="$(BUILD_STAGE)/kakoune"
 	$(call AFTER_BUILD)

--- a/makefiles/kakoune.mk
+++ b/makefiles/kakoune.mk
@@ -1,0 +1,42 @@
+ifneq ($(PROCURSUS),1)
+$(error Use the main Makefile)
+endif
+
+SUBPROJECTS     += kakoune
+KAKOUNE_VERSION := 2021.11.08
+DEB_KAKOUNE_V   ?= $(KAKOUNE_VERSION)
+
+kakoune-setup: setup
+	$(call GITHUB_ARCHIVE,mawww,kakoune,$(KAKOUNE_VERSION),v$(KAKOUNE_VERSION))
+	$(call EXTRACT_TAR,kakoune-$(KAKOUNE_VERSION).tar.gz,kakoune-$(KAKOUNE_VERSION),kakoune)
+
+ifneq ($(wildcard $(BUILD_WORK)/kakoune/.build_complete),)
+kakoune:
+	@echo "Using previously built kakoune."
+else
+kakoune: kakoune-setup
+	+$(MAKE) -C $(BUILD_WORK)/kakoune \
+		CXX="$(CXX)" \
+		PREFIX="$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)"
+	+$(MAKE) -C $(BUILD_WORK)/kakoune install \
+		DESTDIR="$(BUILD_STAGE)/kakoune"
+	$(call AFTER_BUILD)
+endif
+
+kakoune-package: kakoune-stage
+	# kakoune.mk Package Structure
+	rm -rf $(BUILD_DIST)/kakoune
+
+	# kakoune.mk Prep kakoune
+	cp -a $(BUILD_STAGE)/kakoune $(BUILD_DIST)
+
+	# kakoune.mk Sign
+	$(call SIGN,kakoune,general.xml)
+
+	# kakoune.mk Make .debs
+	$(call PACK,kakoune,DEB_KAKOUNE_V)
+
+	# kakoune.mk Build cleanup
+	rm -rf $(BUILD_DIST)/kakoune
+
+.PHONY: kakoune kakoune-package


### PR DESCRIPTION
This PR adds [`kakoune`](https://github.com/mawww/kakoune), a vim-like experimental editor. Specific changes were documented under the commit message. Tested on my 2015 iPod touch 6th generation running iOS 12.4.1.