### PR TITLE
xterm: update to 372

### DIFF
--- a/build_info/xterm.control
+++ b/build_info/xterm.control
@@ -3,6 +3,7 @@ Version: @DEB_XTERM_V@
 Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
 Depends: libsixel1, libncursesw6, libpcre2-posix3, libfontconfig1, libfreetype6, libice6, libxaw7, libxext6, libxft2, libxmu6, libxpm4, libxt6, libxinerama1, xbitmaps
+Provides: x-terminal-emulator
 Section: X11
 Priority: optional
 Description: X terminal emulator

--- a/makefiles/xterm.mk
+++ b/makefiles/xterm.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS   += xterm
-XTERM_VERSION := 368
+XTERM_VERSION := 372
 DEB_XTERM_V   ?= $(XTERM_VERSION)
 
 xterm-setup: setup


### PR DESCRIPTION
this also makes xterm provides x-terminal-emulator
works fine on iPadOS 14.3

### All Submissions

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [ ] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)

### Package Additions/Updates

* [x] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [ ] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
