### PR TITLE
apt: update to 2.5

### DIFF
--- a/build_patch/apt/path.diff
+++ b/build_patch/apt/path.diff
@@ -6,7 +6,7 @@ diff -urN apt-2.2.0/apt-pkg/init.cc apt/apt-pkg/init.cc
 
 
 -   Cnf.CndSet("DPkg::Path", "/usr/sbin:/usr/bin:/sbin:/bin");
-+   Cnf.CndSet("DPkg::Path", "/opt/procursus/sbin:/opt/procursus/bin:/usr/sbin:/usr/bin:/sbin:/bin");
++   Cnf.CndSet("DPkg::Path", "@MEMO_PREFIX@@MEMO_SUB_PREFIX@/sbin:@MEMO_PREFIX@@MEMO_SUB_PREFIX@/bin:@MEMO_PREFIX@/sbin:@MEMO_PREFIX@/bin:/usr/sbin:/usr/bin:/sbin:/bin");
 
     // Read an alternate config file
     _error->PushToStack();

--- a/makefiles/apt.mk
+++ b/makefiles/apt.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 STRAPPROJECTS += apt
-APT_VERSION   := 2.4.5
+APT_VERSION   := 2.5.0
 DEB_APT_V     ?= $(APT_VERSION)
 
 ifeq ($(shell [ "$(CFVER_WHOLE)" -lt 1500 ] && echo 1),1)


### PR DESCRIPTION
### All Submissions

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [ ] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)

### Package Additions/Updates

* [x] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [x] Have you confirmed this builds & works as intended on a macOS device (if applicable)?

builds fine for iphoneos-arm64/1{5..7}00 and darwin-a{md,rm}64/1700.
Appears to install and work fine for iphoneos-arm64/1700 and darwin-amd64/1700 (actually 1800 with 1700 bootstrap)

iphoneos-arm64 note: you may encounter issues with libiosexec-dev dependencies. If you do, please build and install libiosexec debs from the GitHub repo.