### PR TITLE
Makefile: Install expat.pc during setup on CFVER 1700+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1432,6 +1432,10 @@ setup:
 
 	@cp -a $(BUILD_MISC)/{libxml-2.0,zlib}.pc $(BUILD_BASE)/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/pkgconfig
 
+ifeq ($(shell [ "$(CFVER_WHOLE)" -ge 1700 ] && echo 1),1)
+	@cp -a $(BUILD_MISC)/expat.pc $(BUILD_BASE)/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/pkgconfig
+endif
+
 ifeq ($(UNAME),FreeBSD)
 	@# FreeBSD's LLVM does not have stdbool.h, stdatomic.h, and stdarg.h
 	@cp -af $(MACOSX_SYSROOT)/System/Library/Frameworks/Kernel.framework/Headers/{stdbool,stdatomic,stdarg}.h $(BUILD_BASE)/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include

--- a/build_misc/expat.pc
+++ b/build_misc/expat.pc
@@ -1,0 +1,11 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: expat
+Version: 2.2.1
+Description: expat XML parser
+URL: http://www.libexpat.org
+Libs: -L${libdir} -lexpat
+Cflags: -I${includedir}


### PR DESCRIPTION
### All Submissions

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [x] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)

makes #1005 buildable for CFVER 1700+