### PR TITLE
libtesseract5: conflicts libtesseract4

### DIFF
--- a/build_info/libtesseract5.control
+++ b/build_info/libtesseract5.control
@@ -3,6 +3,9 @@ Version: @DEB_TESSERACT_V@
 Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
 Depends: liblept5, libarchive13, libcurl4
+Replaces: libtesseract4
+Breaks: libtesseract4
+Conflicts: libtesseract4
 Section: Libraries
 Priority: optional
 Description: Tesseract OCR library


### PR DESCRIPTION
### All Submissions

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [ ] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)

### Package Additions/Updates

* [ ] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [ ] Have you confirmed this builds & works as intended on a macOS device (if applicable)?

```
Unpacking libtesseract5 (5.1.0) ...
dpkg: error processing archive /var/tmp//apt-dpkg-install-9dh5fM/19-libtesseract5_5.1.0_iphoneos-arm.deb (--unpack):
 正要取代 '/usr/share/tessdata/configs/alto'，它也是套件 libtesseract4 4.1.1 的檔案
 ```