### PR TITLE
Add USB entitlements to python3

### DIFF
--- a/makefiles/python3.mk
+++ b/makefiles/python3.mk
@@ -83,7 +83,7 @@ python3-package: python3-stage
 
 	# python3.mk Sign
 	$(call SIGN,python$(PYTHON3_MAJOR_V),usb.xml)
-	$(call SIGN,libpython$(PYTHON3_MAJOR_V),usb.xml)
+	$(call SIGN,libpython$(PYTHON3_MAJOR_V),general.xml)
 
 	# python3.mk Make .debs
 	$(call PACK,python$(PYTHON3_MAJOR_V),DEB_PYTHON3_V)

--- a/makefiles/python3.mk
+++ b/makefiles/python3.mk
@@ -82,8 +82,8 @@ python3-package: python3-stage
 	$(LN_S) python$(PYTHON3_MAJOR_V).1$(MEMO_MANPAGE_SUFFIX) $(BUILD_DIST)/python3/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/man/man1/python.1$(MEMO_MANPAGE_SUFFIX)
 
 	# python3.mk Sign
-	$(call SIGN,python$(PYTHON3_MAJOR_V),general.xml)
-	$(call SIGN,libpython$(PYTHON3_MAJOR_V),general.xml)
+	$(call SIGN,python$(PYTHON3_MAJOR_V),usb.xml)
+	$(call SIGN,libpython$(PYTHON3_MAJOR_V),usb.xml)
 
 	# python3.mk Make .debs
 	$(call PACK,python$(PYTHON3_MAJOR_V),DEB_PYTHON3_V)


### PR DESCRIPTION
Without USB entitlements python3 just doesn't see any USB devices

### All Submissions

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [x] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)

### Package Additions/Updates

* [X] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
^ (i've not tested the build, but the entitlements work fine on iOS)
* [ ] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
