### PR TITLE
dpkg-repack: Update to 1.50

### DIFF
--- a/makefiles/dpkg-repack.mk
+++ b/makefiles/dpkg-repack.mk
@@ -21,6 +21,8 @@ dpkg-repack: dpkg-repack-setup
 		--release='$(DEB_DPKG_REPACK_V)' \
 		< dpkg-repack.pod > dpkg-repack.1
 	sed -e "s:my \$$VERSION = .*;:my \$$VERSION = '$(DEB_DPKG_REPACK_V)';:" \
+		-e "1s|.*|#!$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/perl|" \
+		-e "s/-pd/-pP/" \
 		< $(BUILD_WORK)/dpkg-repack/dpkg-repack.pl > $(BUILD_WORK)/dpkg-repack/dpkg-repack
 	$(INSTALL) -Dm0755 $(BUILD_WORK)/dpkg-repack/dpkg-repack $(BUILD_STAGE)/dpkg-repack/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/dpkg-repack
 	$(INSTALL) -Dm0644 $(BUILD_WORK)/dpkg-repack/dpkg-repack.1 $(BUILD_STAGE)/dpkg-repack/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/man/man1/dpkg-repack.1

--- a/makefiles/dpkg-repack.mk
+++ b/makefiles/dpkg-repack.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS         += dpkg-repack
-DPKG_REPACK_VERSION := 1.48
+DPKG_REPACK_VERSION := 1.50
 DEB_DPKG_REPACK_V   ?= $(DPKG_REPACK_VERSION)
 
 dpkg-repack-setup: setup
@@ -20,6 +20,8 @@ dpkg-repack: dpkg-repack-setup
 		--center='dpkg suite' \
 		--release='$(DEB_DPKG_REPACK_V)' \
 		< dpkg-repack.pod > dpkg-repack.1
+	sed -e "s:my \$$VERSION = .*;:my \$$VERSION = '$(DEB_DPKG_REPACK_V)';:" \
+		< $(BUILD_WORK)/dpkg-repack/dpkg-repack.pl > $(BUILD_WORK)/dpkg-repack/dpkg-repack
 	$(INSTALL) -Dm0755 $(BUILD_WORK)/dpkg-repack/dpkg-repack $(BUILD_STAGE)/dpkg-repack/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/dpkg-repack
 	$(INSTALL) -Dm0644 $(BUILD_WORK)/dpkg-repack/dpkg-repack.1 $(BUILD_STAGE)/dpkg-repack/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/man/man1/dpkg-repack.1
 	$(call AFTER_BUILD)


### PR DESCRIPTION
### Description

This PR updates `dpkg-repack` to the latest version, as 1.48 no longer exists (for whatever reason)

### All Submissions

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [x] This Pull Request doesn't contain any package additions; it's a small change (e.g README change): Bump version

### Package Additions/Updates

* [x] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [ ] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
