### PR TITLE
Automatically insert libiosexec1 depend in PACK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -898,6 +898,17 @@ PACK = \
 			fi; \
 		done; \
 	done; \
+	if ! grep -q "darwin" <<< "$(MEMO_TARGET)"; then \
+		if ! [ "$(1)" = "libiosexec1" ] || ! [ "$(1)" = "libiosexec-dev" ]; then \
+			if find $(BUILD_DIST)/$(1) | xargs file -ib | grep 'x-mach-binary' | head -1 | grep -q 'x-mach-binary'; then \
+				if grep -q '^Depends\:' $(BUILD_DIST)/$(1)/DEBIAN/control; then \
+					sed -i 's/^Depends\:/Depends: libiosexec1 (>= '$${DEB_LIBIOSEXEC_V}'),/' $(BUILD_DIST)/$(1)/DEBIAN/control; \
+				else \
+					echo 'Depends: libiosexec1 (>= '$${DEB_LIBIOSEXEC_V}')' >> $(BUILD_DIST)/$(1)/DEBIAN/control; \
+				fi; \
+			fi; \
+		fi; \
+	fi; \
 	find $(BUILD_DIST)/$(1)/$(MEMO_PREFIX)/etc -type f -printf '$(MEMO_PREFIX)/etc/%P\n' | LC_ALL=C sort >> $(BUILD_DIST)/$(1)/DEBIAN/conffiles; \
 	[ -s $(BUILD_DIST)/$(1)/DEBIAN/conffiles ] || rm $(BUILD_DIST)/$(1)/DEBIAN/conffiles; \
 	sed -i '$$a\' $(BUILD_DIST)/$(1)/DEBIAN/control; \

--- a/build_info/bash.control
+++ b/build_info/bash.control
@@ -3,7 +3,7 @@ Version: @DEB_BASH_V@
 Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
 Pre-Depends: dash (>= 0.5.11.3-1), libreadline8 (>= 8.0), profile.d (>= 0-5), debianutils (>= 4.11.2)
-Depends: grep, libiosexec1 (>= 1.2.1), libncursesw6, libreadline8, sed, debianutils (>= 4.11.2)
+Depends: grep, libncursesw6, libreadline8, sed, debianutils (>= 4.11.2)
 Section: Terminal_Support
 Priority: optional
 Homepage: http://www.gnu.org/software/bash/

--- a/build_info/coreutils.control
+++ b/build_info/coreutils.control
@@ -2,7 +2,7 @@ Package: coreutils
 Version: @DEB_COREUTILS_V@
 Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
-Depends: sh, profile.d, libssl3, libintl8 (>= 0.20.0), libgmp10, libcrypt2, libiosexec1
+Depends: sh, profile.d, libssl3, libintl8 (>= 0.20.0), libgmp10, libcrypt2
 Conflicts: coreutils-bin (<<1:0), shell-cmds (<< 207.40.1), text-cmds (<< 1:0), file-cmds (<< 272.250.1-1), system-cmds (<< 854.40.2-3)
 Replaces: netatalk (<= 2.0.3-6), coreutils-bin, shell-cmds (<< 207.40.1), text-cmds (<< 1:0), file-cmds (<< 272.250.1-1)
 Provides: md5sum, sha1sum, coreutils-bin (=@DEB_COREUTILS_V@), dirname, kill, mktemp, su

--- a/build_info/darwintools.control
+++ b/build_info/darwintools.control
@@ -2,7 +2,6 @@ Package: darwintools
 Version: @DEB_DARWINTOOLS_V@
 Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
-Pre-Depends: libiosexec1
 Depends: grep, coreutils (>= 8.32-12)
 Recommends: uikittools (>= 2.0.0)
 Section: Administration

--- a/build_info/dash.control
+++ b/build_info/dash.control
@@ -4,7 +4,7 @@ Version: @DEB_DASH_V@
 Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
 Pre-Depends: debianutils (>= 4.11.2)
-Depends: libiosexec1 (>= 1.2.1), debianutils (>= 4.11.2), libedit0
+Depends: debianutils (>= 4.11.2), libedit0
 Provides: sh
 Section: Terminal_Support
 Priority: required

--- a/build_info/dpkg.control
+++ b/build_info/dpkg.control
@@ -4,7 +4,7 @@ Architecture: @DEB_ARCH@
 Essential: yes
 Maintainer: @DEB_MAINTAINER@
 Pre-Depends: tar (>= 1.23), libintl8 (>= 0.20)
-Depends: libiosexec1 (>= 1.2.1), sh, coreutils, diffutils, tar, liblzma5 (>= 5.2.5), libintl8, libz-ng2, libzstd1, libmd0
+Depends: sh, coreutils, diffutils, tar, liblzma5 (>= 5.2.5), libintl8, libz-ng2, libzstd1, libmd0
 Section: Packaging
 Priority: required
 Homepage: http://wiki.debian.org/Teams/Dpkg

--- a/build_info/fish.control
+++ b/build_info/fish.control
@@ -2,7 +2,7 @@ Package: fish
 Version: @DEB_FISH_V@
 Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
-Depends: libiosexec1, libncursesw6, libintl8, libpcre2-32-0, debianutils (>= 4.11.2), awk
+Depends: libncursesw6, libintl8, libpcre2-32-0, debianutils (>= 4.11.2), awk
 Pre-Depends: debianutils (>= 4.11.2)
 Recommends: python3, lynx, man-db
 Section: Terminal_Support

--- a/build_info/git.control
+++ b/build_info/git.control
@@ -2,7 +2,7 @@ Package: git
 Version: @DEB_GIT_V@
 Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
-Depends: libiosexec1, libcurl4, libssl3, libintl8, libpcre2-8-0, libidn2-0, firmware (>= 14.0) | libexpat1, pager
+Depends: libcurl4, libssl3, libintl8, libpcre2-8-0, libidn2-0, firmware (>= 14.0) | libexpat1, pager
 Section: Data_Storage
 Priority: optional
 Description: fast, scalable, distributed revision control system

--- a/build_info/golang-1.18-go.control
+++ b/build_info/golang-1.18-go.control
@@ -2,7 +2,7 @@ Package: golang-1.18-go
 Version: @DEB_GOLANG_V@
 Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
-Depends: golang-1.18-src (>= @DEB_GOLANG_V@), libiosexec1, clang
+Depends: golang-1.18-src (>= @DEB_GOLANG_V@), clang
 Section: Development
 Priority: optional
 Homepage: https://golang.org

--- a/build_info/libapt-pkg6.0.control
+++ b/build_info/libapt-pkg6.0.control
@@ -4,7 +4,7 @@ Section: Libraries
 Maintainer: @DEB_MAINTAINER@
 Architecture: @DEB_ARCH@
 Version: @DEB_APT_V@
-Depends: libiosexec1, libgcrypt20, liblz4-1, liblzma5 (>= 5.2.5), libxxhash0, libzstd1
+Depends: libgcrypt20, liblz4-1, liblzma5 (>= 5.2.5), libxxhash0, libzstd1
 Replaces: apt1.8, apt1.4, libapt, libapt-pkg5.0, apt-lib, apt-key, apt (<< 2.1.10-2)
 Conflicts: apt7 (<<1:0), apt1.4 (<<1:0), apt1.8 (<<1:0), libapt-pkg5.0 (<<1:0), libapt (<<1:0), apt-key (<<1:0), apt (<< 2.1.10-2)
 Provides: libapt-pkg (=@DEB_APT_V@)

--- a/build_info/libpython3.9.control
+++ b/build_info/libpython3.9.control
@@ -4,7 +4,7 @@ Architecture: @DEB_ARCH@
 Version: @DEB_PYTHON3_V@
 Conflicts: python3.9 (<< 3.9.5)
 Replaces: python3.9 (<< 3.9.5)
-Depends: libncursesw6 (>= 6.0), libreadline8 (>= 8.0), libssl3, libffi8, liblzma5 (>= 5.2.5), libgdbm6, libintl8, firmware (>= 14.0) | libexpat1, libcrypt2, libiosexec1
+Depends: libncursesw6 (>= 6.0), libreadline8 (>= 8.0), libssl3, libffi8, liblzma5 (>= 5.2.5), libgdbm6, libintl8, firmware (>= 14.0) | libexpat1, libcrypt2
 Section: Libraries
 Priority: optional
 Description: Interpreted, interactive, object-oriented programming language. Contains the standard library and other shared libraries.

--- a/build_info/make.control
+++ b/build_info/make.control
@@ -2,7 +2,7 @@ Package: make
 Maintainer: @DEB_MAINTAINER@
 Architecture: @DEB_ARCH@
 Version: @DEB_MAKE_V@
-Depends: libiosexec1 (>> 1.0.16), libintl8
+Depends: libintl8
 Section: Development
 Priority: important
 Description: utility for directing compilation

--- a/build_info/misc-cmds.control
+++ b/build_info/misc-cmds.control
@@ -2,7 +2,7 @@ Package: misc-cmds
 Section: Utilities
 Version: @DEB_MISC-CMDS_V@
 Architecture: @DEB_ARCH@
-Depends: libncursesw6, libiosexec1
+Depends: libncursesw6
 Maintainer: @DEB_MAINTAINER@
 Priority: optional
 Description: calendar, leave, ncal, units

--- a/build_info/perl.control
+++ b/build_info/perl.control
@@ -2,7 +2,6 @@ Package: perl
 Version: @DEB_PERL_V@
 Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
-Depends: libiosexec1
 Priority: optional
 Section: Scripting
 Homepage: http://dev.perl.org/perl5/

--- a/build_info/rc.control
+++ b/build_info/rc.control
@@ -2,7 +2,7 @@ Package: rc
 Version: @DEB_RC_V@
 Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
-Depends: libiosexec1, libreadline8, libncursesw6
+Depends: libreadline8, libncursesw6
 Section: Terminal_Support
 Priority: optional
 Homepage: http://tobold.org/article/rc

--- a/build_info/sudo.control
+++ b/build_info/sudo.control
@@ -3,7 +3,7 @@ Essential: yes
 Maintainer: @DEB_MAINTAINER@
 Architecture: @DEB_ARCH@
 Version: @DEB_SUDO_V@
-Depends: libintl8, libpam2, libiosexec1
+Depends: libintl8, libpam2
 Section: Administration
 Priority: required
 Description: temporarily assume root priviledges

--- a/build_info/system-cmds.control
+++ b/build_info/system-cmds.control
@@ -3,7 +3,6 @@ Version: @DEB_SYSTEM-CMDS_V@
 Architecture: @DEB_ARCH@
 Essential: yes
 Maintainer: @DEB_MAINTAINER@
-Pre-Depends: libiosexec1
 Depends: firmware-sbin, file-cmds, libcrypt2, libpam2
 Recommends: vi
 Provides: login, passwd, reboot

--- a/build_info/system-cmds.control.rootless
+++ b/build_info/system-cmds.control.rootless
@@ -3,7 +3,6 @@ Version: @DEB_SYSTEM-CMDS_V@
 Architecture: @DEB_ARCH@
 Essential: yes
 Maintainer: @DEB_MAINTAINER@
-Pre-Depends: libiosexec1
 Depends: file-cmds, libcrypt2, libpam2
 Recommends: vi
 Provides: login, passwd, reboot

--- a/build_info/tcsh.control
+++ b/build_info/tcsh.control
@@ -2,7 +2,7 @@ Package: tcsh
 Version: @DEB_TCSH_V@
 Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
-Depends: libiosexec1, libncursesw6
+Depends: libncursesw6
 Section: Terminal_Support
 Priority: optional
 Homepage: http://www.tcsh.org/

--- a/build_info/toybox.control
+++ b/build_info/toybox.control
@@ -2,7 +2,7 @@ Package: toybox
 Version: @DEB_TOYBOX_V@
 Author: Rob Landley <rob@landley.net>
 Maintainer: @DEB_MAINTAINER@
-Depends: libcrypt2, libssl3, libiosexec1
+Depends: libcrypt2, libssl3
 Section: Utilities
 Architecture: @DEB_ARCH@
 Description: all-in-one Darwin command line

--- a/build_info/zsh.control
+++ b/build_info/zsh.control
@@ -3,7 +3,7 @@ Essential: yes
 Version: @DEB_ZSH_V@
 Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
-Depends: libiosexec1 (>= 1.2.1), libncursesw6, libpcre1, debianutils (>= 4.11.2)
+Depends: libncursesw6, libpcre1, debianutils (>= 4.11.2)
 Pre-Depends: debianutils (>= 4.11.2)
 Section: Terminal_Support
 Priority: required

--- a/makefiles/libiosexec.mk
+++ b/makefiles/libiosexec.mk
@@ -7,6 +7,7 @@ ifeq (,$(findstring darwin,$(MEMO_TARGET)))
 STRAPPROJECTS      += libiosexec
 LIBIOSEXEC_VERSION := 1.2.2
 DEB_LIBIOSEXEC_V   ?= $(LIBIOSEXEC_VERSION)
+export DEB_LIBIOSEXEC_V
 
 ifneq (,$(findstring rootless,$(MEMO_TARGET)))
 LIBIOSEXEC_FLAGS   := SHEBANG_REDIRECT_PATH="$(MEMO_PREFIX)" \


### PR DESCRIPTION
### All Submissions

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [x] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)

Fixes #1274
This PR makes it so that when all of the following conditions are met, a `libiosexec1` depend is auto-inserted into the control file.
- `darwin` is not in `$(MEMO_TARGET)`
- The package name is not `libiosexec1` or `libiosexec-dev`
- The package contains at least one Mach-O binary