### PR TITLE
xmlto: Specify gnu-getopt as a build dependency

### DIFF
--- a/makefiles/xmlto.mk
+++ b/makefiles/xmlto.mk
@@ -7,7 +7,7 @@ XMLTO_VERSION := 0.0.28
 DEB_XMLTO_V   ?= $(XMLTO_VERSION)
 
 xmlto-setup: setup
-	$(call DOWNLOAD_FILES,$(BUILD_SOURCE) https://releases.pagure.org/xmlto/xmlto-$(XMLTO_VERSION).tar.bz2,)
+	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://releases.pagure.org/xmlto/xmlto-$(XMLTO_VERSION).tar.bz2)
 	$(call EXTRACT_TAR,xmlto-$(XMLTO_VERSION).tar.bz2,xmlto-$(XMLTO_VERSION),xmlto)
 
 ifneq ($(wildcard $(BUILD_WORK)/xmlto/.build_complete),)

--- a/makefiles/xmlto.mk
+++ b/makefiles/xmlto.mk
@@ -14,9 +14,10 @@ ifneq ($(wildcard $(BUILD_WORK)/xmlto/.build_complete),)
 xmlto:
 	@echo "Using previously built xmlto."
 else
-xmlto: xmlto-setup
+xmlto: xmlto-setup gnu-getopt
 	cd $(BUILD_WORK)/xmlto && GETOPT=ggetopt ./configure -C \
-		$(DEFAULT_CONFIGURE_FLAGS)
+		$(DEFAULT_CONFIGURE_FLAGS) \
+		GETOPT="$(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/ggetopt"
 	+$(MAKE) -C $(BUILD_WORK)/xmlto
 	+$(MAKE) -C $(BUILD_WORK)/xmlto install \
 		DESTDIR=$(BUILD_STAGE)/xmlto

--- a/makefiles/xmlto.mk
+++ b/makefiles/xmlto.mk
@@ -15,7 +15,7 @@ xmlto:
 	@echo "Using previously built xmlto."
 else
 xmlto: xmlto-setup gnu-getopt
-	cd $(BUILD_WORK)/xmlto && GETOPT=ggetopt ./configure -C \
+	cd $(BUILD_WORK)/xmlto && ./configure -C \
 		$(DEFAULT_CONFIGURE_FLAGS) \
 		GETOPT="$(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/ggetopt"
 	+$(MAKE) -C $(BUILD_WORK)/xmlto


### PR DESCRIPTION
This small PR adds `gnu-getopt` to the list of build dependencies of `xmlto`, while correctly downloading the source tarball, which was a breaking change introduced by Hayden after migrating to `DOWNLOAD_FILES`. 

Special thanks to [Nebula](https://github.com/itsnebulalol) for pointing out that `xmlto`'s Makefile was broken, as it would not download the source tarball correctly.