### PR TITLE
nano: Update to 6.4

### DIFF
--- a/makefiles/nano.mk
+++ b/makefiles/nano.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS  += nano
-NANO_VERSION := 6.3
+NANO_VERSION := 6.4
 DEB_NANO_V   ?= $(NANO_VERSION)
 
 nano-setup: setup


### PR DESCRIPTION
This PR updates `nano` to its latest release, that being 6.4. No issues while compiling on macOS, for iOS 14.