### PR TITLE
unzip: Update to 6.0-27

### DIFF
--- a/makefiles/unzip.mk
+++ b/makefiles/unzip.mk
@@ -11,8 +11,7 @@ unzip-setup: setup
 	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://deb.debian.org/debian/pool/main/u/unzip/{unzip_$(UNZIP_VERSION).orig.tar.gz$(comma)unzip_$(DEBIAN_UNZIP_V).debian.tar.xz})
 	$(call EXTRACT_TAR,unzip_$(UNZIP_VERSION).orig.tar.gz,unzip60,unzip)
 	$(call EXTRACT_TAR,unzip_$(DEBIAN_UNZIP_V).debian.tar.xz,debian/patches,$(BUILD_PATCH)/unzip-$(UNZIP_VERSION))
-	rm -rf $(BUILD_WORK)/debian
-	rm -rf $(BUILD_PATCH)/unzip-$(UNZIP_VERSION)/series
+	rm -rf $(BUILD_WORK)/debian $(BUILD_PATCH)/unzip-$(UNZIP_VERSION)/series
 	$(call DO_PATCH,unzip-$(UNZIP_VERSION),unzip,-p1)
 	rm -rf $(BUILD_PATCH)/unzip-$(UNZIP_VERSION)
 
@@ -21,13 +20,13 @@ unzip:
 	@echo "Using previously built unzip."
 else
 unzip: unzip-setup
-	+cd $(BUILD_WORK)/unzip && $(MAKE) -f unix/Makefile unzips \
+	$(MAKE) -C $(BUILD_WORK)/unzip -f unix/Makefile unzips \
 		CC=$(CC) \
 		CF='$(CFLAGS) -Wall -I. -DBSD -DUNIX -DACORN_FTYPE_NFS -DWILD_STOP_AT_DIR \
 		-DLARGE_FILE_SUPPORT -DUNICODE_SUPPORT -DUNICODE_WCHAR -DUTF8_MAYBE_NATIVE \
 		-DNO_LCHMOD -DDATE_FORMAT=DF_YMD -DUSE_BZIP2 -DIZ_HAVE_UXUIDGID ' \
 		LF2="$(CFLAGS)" L_BZ2=-lbz2
-	+cd $(BUILD_WORK)/unzip && $(MAKE) -f unix/Makefile install \
+	$(MAKE) -C $(BUILD_WORK)/unzip -f unix/Makefile install \
 		prefix=$(BUILD_STAGE)/unzip/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX) \
 		MANDIR="$(BUILD_STAGE)/unzip/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/man/man1/"
 	$(call AFTER_BUILD)

--- a/makefiles/unzip.mk
+++ b/makefiles/unzip.mk
@@ -4,12 +4,11 @@ endif
 
 SUBPROJECTS    += unzip
 UNZIP_VERSION  := 6.0
-DEBIAN_UNZIP_V := $(UNZIP_VERSION)-26
+DEBIAN_UNZIP_V := $(UNZIP_VERSION)-27
 DEB_UNZIP_V    ?= $(DEBIAN_UNZIP_V)
 
 unzip-setup: setup
-	$(call DOWNLOAD_FILES,$(BUILD_SOURCE) https://deb.debian.org/debian/pool/main/u/unzip/unzip_$(UNZIP_VERSION).orig.tar.gz, \
-		https://deb.debian.org/debian/pool/main/u/unzip/unzip_$(DEBIAN_UNZIP_V).debian.tar.xz)
+	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://deb.debian.org/debian/pool/main/u/unzip/{unzip_$(UNZIP_VERSION).orig.tar.gz$(comma)unzip_$(DEBIAN_UNZIP_V).debian.tar.xz})
 	$(call EXTRACT_TAR,unzip_$(UNZIP_VERSION).orig.tar.gz,unzip60,unzip)
 	$(call EXTRACT_TAR,unzip_$(DEBIAN_UNZIP_V).debian.tar.xz,debian/patches,$(BUILD_PATCH)/unzip-$(UNZIP_VERSION))
 	rm -rf $(BUILD_WORK)/debian


### PR DESCRIPTION
This PR updates unzip to 6.0-27, while correctly downloading source tarballs (which did not work when Hayden migrated over to `DOWNLOAD_FILES`)