### PR TITLE
hexedit: Update to 1.6

### DIFF
--- a/makefiles/hexedit.mk
+++ b/makefiles/hexedit.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS     += hexedit
-HEXEDIT_VERSION := 1.5
+HEXEDIT_VERSION := 1.6
 DEB_HEXEDIT_V   ?= $(HEXEDIT_VERSION)
 
 hexedit-setup: setup


### PR DESCRIPTION
This PR updates `hexedit` to its latest version, 1.6.

* [x] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [x] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
