### PR TITLE
dist: update apple tarball to github tarball

### DIFF
--- a/makefiles/adv-cmds.mk
+++ b/makefiles/adv-cmds.mk
@@ -9,7 +9,7 @@ ADV-CMDS_VERSION := 176
 DEB_ADV-CMDS_V   ?= $(ADV-CMDS_VERSION)-1
 
 adv-cmds-setup: setup
-	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://opensource.apple.com/tarballs/adv_cmds/adv_cmds-$(ADV-CMDS_VERSION).tar.gz)
+	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://github.com/apple-oss-distributions/adv_cmds/archive/refs/tags/adv_cmds-$(ADV-CMDS_VERSION).tar.gz)
 	$(call EXTRACT_TAR,adv_cmds-$(ADV-CMDS_VERSION).tar.gz,adv_cmds-$(ADV-CMDS_VERSION),adv-cmds)
 	mkdir -p $(BUILD_STAGE)/adv-cmds/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/{bin,share/man/man{1,5}/}
 

--- a/makefiles/basic-cmds.mk
+++ b/makefiles/basic-cmds.mk
@@ -7,7 +7,7 @@ BASIC-CMDS_VERSION := 55
 DEB_BASIC-CMDS_V   ?= $(BASIC-CMDS_VERSION)-2
 
 basic-cmds-setup: setup
-	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://opensource.apple.com/tarballs/basic_cmds/basic_cmds-$(BASIC-CMDS_VERSION).tar.gz)
+	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://github.com/apple-oss-distributions/basic_cmds/archive/refs/tags/basic_cmds-$(BASIC-CMDS_VERSION).tar.gz)
 	$(call EXTRACT_TAR,basic_cmds-$(BASIC-CMDS_VERSION).tar.gz,basic_cmds-$(BASIC-CMDS_VERSION),basic-cmds)
 	mkdir -p $(BUILD_STAGE)/basic-cmds/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin
 

--- a/makefiles/bootstrap-cmds.mk
+++ b/makefiles/bootstrap-cmds.mk
@@ -9,7 +9,7 @@ BOOTSTRAP-CMDS_VERSION := 121
 DEB_BOOTSTRAP-CMDS_V   ?= $(BOOTSTRAP-CMDS_VERSION)-1
 
 bootstrap-cmds-setup: setup
-	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://opensource.apple.com/tarballs/bootstrap_cmds/bootstrap_cmds-$(BOOTSTRAP-CMDS_VERSION).tar.gz)
+	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://github.com/apple-oss-distributions/bootstrap_cmds/archive/refs/tags/bootstrap_cmds-$(BOOTSTRAP-CMDS_VERSION).tar.gz)
 	$(call EXTRACT_TAR,bootstrap_cmds-$(BOOTSTRAP-CMDS_VERSION).tar.gz,bootstrap_cmds-$(BOOTSTRAP-CMDS_VERSION),bootstrap-cmds)
 	mkdir -p $(BUILD_STAGE)/bootstrap-cmds/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/{bin,libexec,share/man/man1/}
 

--- a/makefiles/developer-cmds.mk
+++ b/makefiles/developer-cmds.mk
@@ -9,7 +9,7 @@ DEVELOPER-CMDS_VERSION := 66
 DEB_DEVELOPER-CMDS_V   ?= $(DEVELOPER-CMDS_VERSION)-1
 
 developer-cmds-setup: setup
-	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://opensource.apple.com/tarballs/developer_cmds/developer_cmds-$(DEVELOPER-CMDS_VERSION).tar.gz)
+	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://github.com/apple-oss-distributions/developer_cmds/archive/refs/tags/developer_cmds-$(DEVELOPER-CMDS_VERSION).tar.gz)
 	$(call EXTRACT_TAR,developer_cmds-$(DEVELOPER-CMDS_VERSION).tar.gz,developer_cmds-$(DEVELOPER-CMDS_VERSION),developer-cmds)
 	mkdir -p $(BUILD_STAGE)/developer-cmds/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/{bin,share/man/man1/}
 

--- a/makefiles/diskdev-cmds.mk
+++ b/makefiles/diskdev-cmds.mk
@@ -11,7 +11,7 @@ DISKDEV-CMDS_VERSION := 667.40.1
 DEB_DISKDEV-CMDS_V   ?= $(DISKDEV-CMDS_VERSION)
 
 diskdev-cmds-setup: setup
-	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://opensource.apple.com/tarballs/diskdev_cmds/diskdev_cmds-$(DISKDEV-CMDS_VERSION).tar.gz)
+	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://github.com/apple-oss-distributions/diskdev_cmds/archive/refs/tags/diskdev_cmds-$(DISKDEV-CMDS_VERSION).tar.gz)
 	$(call EXTRACT_TAR,diskdev_cmds-$(DISKDEV-CMDS_VERSION).tar.gz,diskdev_cmds-$(DISKDEV-CMDS_VERSION),diskdev-cmds)
 ifeq ($(shell [ "$(CFVER_WHOLE)" -lt 1300 ] && echo 1),1)
 	sed -i -e 's+#include <sys/mount.h>+#include <sys/mount.h>\n#ifndef MNT_STRICTATIME\n#define MNT_STRICTATIME 0x80\n#endif+g' $(BUILD_WORK)/diskdev-cmds/mount_flags_dir/mount_flags.c

--- a/makefiles/disklabel.mk
+++ b/makefiles/disklabel.mk
@@ -7,7 +7,7 @@ DISKLABEL_VERSION := 7
 DEB_DISKLABEL_V   ?= $(DISKLABEL_VERSION)
 
 disklabel-setup: setup
-	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://opensource.apple.com/tarballs/disklabel/disklabel-$(DISKLABEL_VERSION).tar.gz)
+	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://github.com/apple-oss-distributions/disklabel/archive/refs/tags/disklabel-$(DISKLABEL_VERSION).tar.gz)
 	$(call EXTRACT_TAR,disklabel-$(DISKLABEL_VERSION).tar.gz,disklabel-$(DISKLABEL_VERSION),disklabel)
 	sed -i 's|#include <Kernel/libkern/OSByteOrder.h>|#include <libkern/OSByteOrder.h>|g' $(BUILD_WORK)/disklabel/util.c
 	mkdir -p $(BUILD_STAGE)/disklabel/$(MEMO_PREFIX)/{sbin,$(MEMO_SUB_PREFIX)/share/man/man8}
@@ -26,16 +26,16 @@ endif
 disklabel-package: disklabel-stage
 	# disklabel.mk Package Structure
 	rm -rf $(BUILD_DIST)/disklabel
-	
+
 	# disklabel.mk Prep disklabel
 	cp -a $(BUILD_STAGE)/disklabel $(BUILD_DIST)
-	
+
 	# disklabel.mk Sign
 	$(call SIGN,disklabel,dd.xml)
-	
+
 	# disklabel.mk Make .debs
 	$(call PACK,disklabel,DEB_DISKLABEL_V)
-	
+
 	# disklabel.mk Build cleanup
 	rm -rf $(BUILD_DIST)/disklabel
 

--- a/makefiles/file-cmds.mk
+++ b/makefiles/file-cmds.mk
@@ -14,7 +14,7 @@ endif
 DEB_FILE-CMDS_V   ?= $(FILE-CMDS_VERSION)-3
 
 file-cmds-setup: setup
-	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://opensource.apple.com/tarballs/file_cmds/file_cmds-$(FILE-CMDS_VERSION).tar.gz)
+	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://github.com/apple-oss-distributions/file_cmds/archive/refs/tags/file_cmds-$(FILE-CMDS_VERSION).tar.gz)
 	$(call EXTRACT_TAR,file_cmds-$(FILE-CMDS_VERSION).tar.gz,file_cmds-$(FILE-CMDS_VERSION),file-cmds)
 	mkdir -p $(BUILD_STAGE)/file-cmds/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/{bin,share/man/man1}
 	mkdir -p $(BUILD_WORK)/file-cmds/ipcs/sys

--- a/makefiles/iokittools.mk
+++ b/makefiles/iokittools.mk
@@ -7,7 +7,7 @@ IOKITTOOLS_VERSION := 91
 DEB_IOKITTOOLS_V   ?= $(IOKITTOOLS_VERSION)
 
 iokittools-setup: setup
-	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://opensource.apple.com/tarballs/IOKitTools/IOKitTools-$(IOKITTOOLS_VERSION).tar.gz)
+	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://github.com/apple-oss-distributions/IOKitTools/archive/refs/tags/IOKitTools-$(IOKITTOOLS_VERSION).tar.gz)
 	$(call EXTRACT_TAR,IOKitTools-$(IOKITTOOLS_VERSION).tar.gz,IOKitTools-$(IOKITTOOLS_VERSION),iokittools)
 	mkdir -p $(BUILD_STAGE)/iokittools/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/sbin
 

--- a/makefiles/lsof.mk
+++ b/makefiles/lsof.mk
@@ -9,7 +9,7 @@ LSOF_VERSION := 62
 DEB_LSOF_V   ?= $(LSOF_VERSION)
 
 lsof-setup: setup
-	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://opensource.apple.com/tarballs/lsof/lsof-$(LSOF_VERSION).tar.gz)
+	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://github.com/apple-oss-distributions/lsof/archive/refs/tags/lsof-$(LSOF_VERSION).tar.gz)
 	$(call EXTRACT_TAR,lsof-$(LSOF_VERSION).tar.gz,lsof-$(LSOF_VERSION),lsof)
 	mkdir -p $(BUILD_STAGE)/lsof/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/{sbin,share/man/man8}
 	sed -i 's/lcurses/lncursesw/' $(BUILD_WORK)/lsof/lsof/Configure

--- a/makefiles/misc-cmds.mk
+++ b/makefiles/misc-cmds.mk
@@ -7,7 +7,7 @@ MISC-CMDS_VERSION := 34
 DEB_MISC-CMDS_V   ?= $(MISC-CMDS_VERSION)
 
 misc-cmds-setup: setup
-	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://opensource.apple.com/tarballs/misc_cmds/misc_cmds-$(MISC-CMDS_VERSION).tar.gz)
+	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://github.com/apple-oss-distributions/misc_cmds/archive/refs/tags/misc_cmds-$(MISC-CMDS_VERSION).tar.gz)
 	$(call EXTRACT_TAR,misc_cmds-$(MISC-CMDS_VERSION).tar.gz,misc_cmds-$(MISC-CMDS_VERSION),misc-cmds)
 	mkdir -p $(BUILD_STAGE)/misc-cmds/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/{bin,share/{man/man1,misc}}
 	sed -i 's|#include <calendar.h>|#include "calendar.h"|g' $(BUILD_WORK)/misc-cmds/ncal/ncal.c

--- a/makefiles/network-cmds.mk
+++ b/makefiles/network-cmds.mk
@@ -9,7 +9,7 @@ NETWORK-CMDS_VERSION := 596
 DEB_NETWORK-CMDS_V   ?= $(NETWORK-CMDS_VERSION)
 
 network-cmds-setup: setup
-	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://opensource.apple.com/tarballs/network_cmds/network_cmds-$(NETWORK-CMDS_VERSION).tar.gz)
+	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://github.com/apple-oss-distributions/network_cmds/archive/refs/tags/network_cmds-$(NETWORK-CMDS_VERSION).tar.gz)
 	$(call EXTRACT_TAR,network_cmds-$(NETWORK-CMDS_VERSION).tar.gz,network_cmds-$(NETWORK-CMDS_VERSION),network-cmds)
 	mkdir -p $(BUILD_STAGE)/network-cmds/{{s,}bin,usr/{{s,}bin,libexec}}
 

--- a/makefiles/notifyutil.mk
+++ b/makefiles/notifyutil.mk
@@ -9,7 +9,7 @@ NOTIFYUTIL_VERSION := 279.40.4
 DEB_NOTIFYUTIL_V   ?= $(NOTIFYUTIL_VERSION)
 
 notifyutil-setup: setup
-	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://opensource.apple.com/tarballs/Libnotify/Libnotify-$(NOTIFYUTIL_VERSION).tar.gz)
+	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://github.com/apple-oss-distributions/Libnotify/archive/refs/tags/Libnotify-$(NOTIFYUTIL_VERSION).tar.gz)
 	$(call EXTRACT_TAR,Libnotify-$(NOTIFYUTIL_VERSION).tar.gz,Libnotify-$(NOTIFYUTIL_VERSION),notifyutil)
 	$(call DO_PATCH,notifyutil,notifyutil,-p1)
 	mkdir -p $(BUILD_STAGE)/notifyutil/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/{bin,share/man/man1}

--- a/makefiles/pam-modules.mk
+++ b/makefiles/pam-modules.mk
@@ -13,7 +13,7 @@ DEB_PAM-MODULES_V   ?= $(PAM-MODULES_VERSION)-1
 ###
 
 pam-modules-setup: setup
-	-$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://opensource.apple.com/tarballs/pam_modules/pam_modules-$(PAM-MODULES_VERSION).tar.gz)
+	-$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://github.com/apple-oss-distributions/pam_modules/archive/refs/tags/pam_modules-$(PAM-MODULES_VERSION).tar.gz)
 	$(call EXTRACT_TAR,pam_modules-$(PAM-MODULES_VERSION).tar.gz,pam_modules-$(PAM-MODULES_VERSION),pam-modules)
 	sed -i 's/__APPLE__/NOTDEFINED/' $(BUILD_WORK)/pam-modules/modules/pam_group/pam_group.c
 	mkdir -p $(BUILD_STAGE)/pam-modules/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/{lib/pam,share/man/man8}

--- a/makefiles/shell-cmds.mk
+++ b/makefiles/shell-cmds.mk
@@ -9,7 +9,7 @@ SHELL-CMDS_VERSION := 207.40.1
 DEB_SHELL-CMDS_V   ?= $(SHELL-CMDS_VERSION)-2
 
 shell-cmds-setup: setup
-	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://opensource.apple.com/tarballs/shell_cmds/shell_cmds-$(SHELL-CMDS_VERSION).tar.gz)
+	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://github.com/apple-oss-distributions/shell_cmds/archive/refs/tags/shell_cmds-$(SHELL-CMDS_VERSION).tar.gz)
 	$(call EXTRACT_TAR,shell_cmds-$(SHELL-CMDS_VERSION).tar.gz,shell_cmds-$(SHELL-CMDS_VERSION),shell-cmds)
 
 ifneq ($(wildcard $(BUILD_WORK)/shell-cmds/.build_complete),)

--- a/makefiles/system-cmds.mk
+++ b/makefiles/system-cmds.mk
@@ -10,7 +10,7 @@ PWDARWIN_COMMIT     := 72ae45ce6c025bc2359035cfb941b177149e88ae
 DEB_SYSTEM-CMDS_V   ?= $(SYSTEM-CMDS_VERSION)-14
 
 system-cmds-setup: setup libxcrypt
-	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://opensource.apple.com/tarballs/system_cmds/system_cmds-$(SYSTEM-CMDS_VERSION).tar.gz)
+	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://github.com/apple-oss-distributions/system_cmds/archive/refs/tags/system_cmds-$(SYSTEM-CMDS_VERSION).tar.gz)
 	$(call EXTRACT_TAR,system_cmds-$(SYSTEM-CMDS_VERSION).tar.gz,system_cmds-$(SYSTEM-CMDS_VERSION),system-cmds)
 	$(call DO_PATCH,system-cmds,system-cmds,-p1)
 	sed -i '/#include <stdio.h>/a #include <crypt.h>' $(BUILD_WORK)/system-cmds/login.tproj/login.c

--- a/makefiles/text-cmds.mk
+++ b/makefiles/text-cmds.mk
@@ -9,7 +9,7 @@ TEXT-CMDS_VERSION := 106
 DEB_TEXT-CMDS_V   ?= 1:$(TEXT-CMDS_VERSION)
 
 text-cmds-setup: setup
-	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://opensource.apple.com/tarballs/text_cmds/text_cmds-$(TEXT-CMDS_VERSION).tar.gz)
+	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://github.com/apple-oss-distributions/text_cmds/archive/refs/tags/text_cmds-$(TEXT-CMDS_VERSION).tar.gz)
 	$(call EXTRACT_TAR,text_cmds-$(TEXT-CMDS_VERSION).tar.gz,text_cmds-$(TEXT-CMDS_VERSION),text-cmds)
 	sed -i 's|/usr|$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)|' $(BUILD_WORK)/text-cmds/ee/ee.c
 	mkdir -p $(BUILD_STAGE)/text-cmds/$(MEMO_PREFIX){/sbin,$(MEMO_SUB_PREFIX)/{bin,share/man/man{1,6}}}

--- a/makefiles/top.mk
+++ b/makefiles/top.mk
@@ -9,7 +9,7 @@ TOP_VERSION   := 125
 DEB_TOP_V     ?= $(TOP_VERSION)
 
 top-setup: setup
-	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://opensource.apple.com/tarballs/top/top-$(TOP_VERSION).tar.gz)
+	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://github.com/apple-oss-distributions/top/archive/refs/tags/top-$(TOP_VERSION).tar.gz)
 	$(call EXTRACT_TAR,top-$(TOP_VERSION).tar.gz,top-$(TOP_VERSION),top)
 	mkdir -p $(BUILD_WORK)/top/include/{IOKit/storage,mach}
 	cp -a $(MACOSX_SYSROOT)/usr/include/libkern $(BUILD_WORK)/top/include


### PR DESCRIPTION
### All Submissions

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [x] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)

### Package Additions/Updates

* [ ] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [ ] Have you confirmed this builds & works as intended on a macOS device (if applicable)?

---

apple oss tarball files are gone, so updating them to the github equivalent ones

e.g.
```
$ curl -I https://opensource.apple.com/tarballs/adv_cmds/adv_cmds-147.tar.gz
HTTP/1.1 404 Not Found
x-amz-error-code: NoSuchKey
x-amz-error-message: The specified key does not exist.
x-amz-error-detail-Key: tarballs/adv_cmds/adv_cmds-147.tar.gz
x-amz-request-id: 2VV0V8PSYSQYZJ2J
x-amz-id-2: yfQ2GTeR6krtbu6tv5At0y0kuUl3ZoqpEVPhORgidG3VrAdG4QxHuqFIT4ocJ/ChHTb9DRKBrgA=
Date: Mon, 07 Nov 2022 17:14:00 GMT
Server: AmazonS3

$ curl -I https://github.com/apple-oss-distributions/adv_cmds/archive/refs/tags/adv_cmds-147.tar.gz
HTTP/2 302
```