### PR TITLE
meson: Update to 0.64.0

### DIFF
--- a/makefiles/meson.mk
+++ b/makefiles/meson.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS   += meson
-MESON_VERSION := 0.61.2
+MESON_VERSION := 0.64.0
 DEB_MESON_V   ?= $(MESON_VERSION)
 
 meson-setup: setup


### PR DESCRIPTION
This small PR updates `meson` to its latest version, 0.64.0.

* [x] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [x] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
