### PR TITLE
new_package.sh: Migrate to DOWNLOAD_FILE(S)

### DIFF
--- a/build_tools/new_package.sh
+++ b/build_tools/new_package.sh
@@ -38,11 +38,9 @@ downloadlink() {
 		echo -e "\t$\(call GITHUB_ARCHIVE,$(${SED} 's|^.*://||' <<<"${1}" | cut -d'/' -f2),$(${SED} 's|^.*://||' <<<"${1}" | cut -d'/' -f3),$\(${4}_VERSION\),$\(${4}_VERSION\)\)"
 	else
 		if echo "${1##*/}" | ${SED} 's/-//g' | ${SED} 's/\.tar.*//g' | ${SED} "s/${2}//g" | grep "${3}" &>/dev/null; then
-			echo -e "\tcurl --silent -L -Z --create-dirs -C - --remote-name-all --output-dir\$(BUILD_SOURCE) $(${SED} "s/${2}/\$(${4}_VERSION)/g" <<<"$1")"
+			echo -e "\t$\(call DOWNLOAD_FILES,\$(BUILD_SOURCE),$(${SED} 's/${2}/\$(${4}_VERSION)/g' <<<"$1"))"
 		else
-			echo -e "\t-[ ! -f "$\(BUILD_SOURCE\)/${3}-$\(${4}_VERSION\).tar.${download##*.}" ] \&\& \\
-\t	\twget -q -nc -O\$(BUILD_SOURCE)/${3}-\$(${4}_VERSION).tar.${download##*.}) \\
-\t	\t\t$(${SED} "s/${2}/\$(${4}_VERSION)/g" <<<"$1")"
+		    echo -e "\t$\(call DOWNLOAD_FILE,\$(BUILD_SOURCE)/${3}-\$(${4}_VERSION).tar.${download##*.},$(${SED} 's/${2}/\$(${4}_VERSION)/g' <<<"$1"))"
 		fi
 	fi
 }

--- a/build_tools/new_package.sh
+++ b/build_tools/new_package.sh
@@ -94,7 +94,8 @@ main_dialog() {
 	count=1
 	for i in ./build_misc/templates/*.mk; do
 		if ! [ "$(basename "$i" .mk)" = "keyring" ]; then
-			buildsystems+=("$count $(basename "$i" .mk)")
+		    # shellcheck disable=SC2086,SC2207,SC2206
+			buildsystems+=($count $(basename $i .mk))
 			count=$((count + 1))
 		fi
 	done

--- a/build_tools/new_package.sh
+++ b/build_tools/new_package.sh
@@ -1,132 +1,132 @@
 #!/usr/bin/env bash
 
 ask() {
-	[ -z ${1+x} ] && exit 1
-	if [ -z ${2+x} ]; then
-		read -rp "${1}: " rc
-	else
-		rc=$2
-	fi
-	echo "$rc"
+    [ -z ${1+x} ] && exit 1
+    if [ -z ${2+x} ]; then
+        read -rp "${1}: " rc
+    else
+        rc=$2
+    fi
+    echo "$rc"
 }
 
 dialog_inputbox() {
-	dialog \
-		--colors --no-cancel --title "$1" \
-		--inputbox "$2" "${3:-15}" "${4:-40}" 3>&1 1>&2 2>&3 3>&-
+    dialog \
+        --colors --no-cancel --title "$1" \
+        --inputbox "$2" "${3:-15}" "${4:-40}" 3>&1 1>&2 2>&3 3>&-
 }
 
 checkpkg() {
-	if [ -f makefiles/"$1".mk ]; then
-		echo "$1.mk already exists."
-		return 1
-	elif grep -R "^$pkg:" makefiles/*.mk &>/dev/null; then
-		echo "$1 already exists."
-		return 1
-	fi
+    if [ -f makefiles/"$1".mk ]; then
+        echo "$1.mk already exists."
+        return 1
+    elif grep -R "^$pkg:" makefiles/*.mk &>/dev/null; then
+        echo "$1 already exists."
+        return 1
+    fi
 }
 
 checkbuild() {
-	if [ ! -f build_misc/templates/"$1".mk ]; then
-		echo "$1 is not a valid buildsystem"
-		return 1
-	fi
+    if [ ! -f build_misc/templates/"$1".mk ]; then
+    echo "$1 is not a valid buildsystem"
+        return 1
+    fi
 }
 
 downloadlink() {
-	if [ "$(${SED} 's|^.*://||' <<<"${1}" | cut -d'/' -f1)" = "github.com" ]; then
-		echo -e "\t$\(call GITHUB_ARCHIVE,$(${SED} 's|^.*://||' <<<"${1}" | cut -d'/' -f2),$(${SED} 's|^.*://||' <<<"${1}" | cut -d'/' -f3),$\(${4}_VERSION\),$\(${4}_VERSION\)\)"
-	else
-		if echo "${1##*/}" | ${SED} 's/-//g' | ${SED} 's/\.tar.*//g' | ${SED} "s/${2}//g" | grep "${3}" &>/dev/null; then
-			echo -e "\t$\(call DOWNLOAD_FILES,\$(BUILD_SOURCE),$(${SED} "s/${2}/\$(${4}_VERSION)/g" <<< "$1"))"
-		else
-		    echo -e "\t$\(call DOWNLOAD_FILE,\$(BUILD_SOURCE)/${3}-\$(${4}_VERSION).tar.${download##*.},$(${SED} "s/${2}/\$(${4}_VERSION)/g" <<< "$1"))"
-		fi
-	fi
+    if [ "$(${SED} 's|^.*://||' <<<"${1}" | cut -d'/' -f1)" = "github.com" ]; then
+        echo -e "\t$\(call GITHUB_ARCHIVE,$(${SED} 's|^.*://||' <<<"${1}" | cut -d'/' -f2),$(${SED} 's|^.*://||' <<<"${1}" | cut -d'/' -f3),$\(${4}_VERSION\),$\(${4}_VERSION\)\)"
+    else
+        if echo "${1##*/}" | ${SED} 's/-//g' | ${SED} 's/\.tar.*//g' | ${SED} "s/${2}//g" | grep "${3}" &>/dev/null; then
+            echo -e "\t$\(call DOWNLOAD_FILES,\$(BUILD_SOURCE),$(${SED} "s/${2}/\$(${4}_VERSION)/g" <<< "$1"))"
+        else
+            echo -e "\t$\(call DOWNLOAD_FILE,\$(BUILD_SOURCE)/${3}-\$(${4}_VERSION).tar.${download##*.},$(${SED} "s/${2}/\$(${4}_VERSION)/g" <<< "$1"))"
+        fi
+    fi
 }
 
 main() {
     # shellcheck disable=SC2086
-	pkg="$(ask "Package Name" $1)"
-	checkpkg "$pkg" || exit 1
-	formatpkg="$(${SED} -e 's|-|_|g' -e "s|\(.\)|\u\1|g" <<<"${pkg}")"
+    pkg="$(ask "Package Name" $1)"
+    checkpkg "$pkg" || exit 1
+    formatpkg="$(${SED} -e 's|-|_|g' -e "s|\(.\)|\u\1|g" <<<"${pkg}")"
 
-	while true; do
+    while true; do
         # shellcheck disable=SC2086
-		build="$(ask "Build System (type ? to list all build systems)" $2)"
-		if [ "$build" = "?" ]; then
-			echo "Available build systems:"
-			find build_misc/templates -name '*.mk' -not -name 'keyring.mk' -exec basename '{}' .mk \; | $SED 's/^/- /g'
-		else
-			if checkbuild "$build"; then
-				break
-			elif [ -n "$2" ]; then
-				exit 1
-			fi
-		fi
-	done
+        build="$(ask "Build System (type ? to list all build systems)" $2)"
+        if [ "$build" = "?" ]; then
+            echo "Available build systems:"
+            find build_misc/templates -name '*.mk' -not -name 'keyring.mk' -exec basename '{}' .mk \; | $SED 's/^/- /g'
+        else
+            if checkbuild "$build"; then
+                break
+            elif [ -n "$2" ]; then
+                exit 1
+            fi
+        fi
+    done
 
     # shellcheck disable=SC2086
-	ver="$(ask "Package Version" $3)"
+    ver="$(ask "Package Version" $3)"
     # shellcheck disable=SC2086
-	download="$(ask "Tarball Download Link" $4)"
-	${SED} -e "s/@pkg@/${pkg}/g" \
-		-e "s/@PKG@/${formatpkg}/g" \
-		-e "s/@PKG_VERSION@/${ver}/g" \
-		-e "s|@download@|$(downloadlink "$download" "$ver" "$pkg" "$formatpkg")|g" \
-		-e "s|@compression@|${download##*.}|g" \
-		"build_misc/templates/${build}.mk" > "makefiles/${pkg}.mk"
-	${SED} -e "s/@pkg@/${pkg}/g" \
-		-e "s/@PKG@/${formatpkg}/g" \
-		"build_misc/templates/package.control" > "build_info/${pkg}.control"
+    download="$(ask "Tarball Download Link" $4)"
+    ${SED} -e "s/@pkg@/${pkg}/g" \
+        -e "s/@PKG@/${formatpkg}/g" \
+        -e "s/@PKG_VERSION@/${ver}/g" \
+        -e "s|@download@|$(downloadlink "$download" "$ver" "$pkg" "$formatpkg")|g" \
+        -e "s|@compression@|${download##*.}|g" \
+        "build_misc/templates/${build}.mk" > "makefiles/${pkg}.mk"
+    ${SED} -e "s/@pkg@/${pkg}/g" \
+        -e "s/@PKG@/${formatpkg}/g" \
+        "build_misc/templates/package.control" > "build_info/${pkg}.control"
 }
 
 main_dialog() {
-	pkg=$(dialog_inputbox "New package" "Package name")
-	if ! checkpkg "$pkg"; then
-		dialog --msgbox "$pkg already exists" 15 40
-		clear
-		exit 1
-	fi
-	formatpkg="$(${SED} -e 's|-|_|g' -e "s|\(.\)|\u\1|g" <<<"${pkg}")"
+    pkg=$(dialog_inputbox "New package" "Package name")
+    if ! checkpkg "$pkg"; then
+        dialog --msgbox "$pkg already exists" 15 40
+        clear
+        exit 1
+    fi
+    formatpkg="$(${SED} -e 's|-|_|g' -e "s|\(.\)|\u\1|g" <<<"${pkg}")"
 
-	buildsystems=()
-	count=1
-	for i in ./build_misc/templates/*.mk; do
-		if ! [ "$(basename "$i" .mk)" = "keyring" ]; then
-		    # shellcheck disable=SC2086,SC2207,SC2206
-			buildsystems+=($count $(basename $i .mk))
-			count=$((count + 1))
-		fi
-	done
-	build=$(dialog \
-		--colors --no-cancel --title 'New package' \
-		--menu 'Build System' 15 40 $count "${buildsystems[@]}" 3>&1 1>&2 2>&3 3>&-)
-	build=${buildsystems[(( build*2-1 ))]}
+    buildsystems=()
+    count=1
+    for i in ./build_misc/templates/*.mk; do
+        if ! [ "$(basename "$i" .mk)" = "keyring" ]; then
+            # shellcheck disable=SC2086,SC2207,SC2206
+            buildsystems+=($count $(basename $i .mk))
+            count=$((count + 1))
+        fi
+    done
+    build=$(dialog \
+        --colors --no-cancel --title 'New package' \
+        --menu 'Build System' 15 40 $count "${buildsystems[@]}" 3>&1 1>&2 2>&3 3>&-)
+    build=${buildsystems[(( build*2-1 ))]}
 
-	ver=$(dialog_inputbox "New package" "Package version")
-	download=$(dialog_inputbox "New package" "Tarball download link")
-	${SED} -e "s/@pkg@/${pkg}/g" \
-		-e "s/@PKG@/${formatpkg}/g" \
-		-e "s/@PKG_VERSION@/${ver}/g" \
-		-e "s|@download@|$(downloadlink "$download" "$ver" "$pkg" "$formatpkg")|g" \
-		-e "s|@compression@|${download##*.}|g" \
-		"build_misc/templates/${build}.mk" > "makefiles/${pkg}.mk"
-	${SED} -e "s/@pkg@/${pkg}/g" \
-		-e "s/@PKG@/${formatpkg}/g" \
-		"build_misc/templates/package.control" > "build_info/${pkg}.control"
-	clear
+    ver=$(dialog_inputbox "New package" "Package version")
+    download=$(dialog_inputbox "New package" "Tarball download link")
+    ${SED} -e "s/@pkg@/${pkg}/g" \
+        -e "s/@PKG@/${formatpkg}/g" \
+        -e "s/@PKG_VERSION@/${ver}/g" \
+        -e "s|@download@|$(downloadlink "$download" "$ver" "$pkg" "$formatpkg")|g" \
+        -e "s|@compression@|${download##*.}|g" \
+        "build_misc/templates/${build}.mk" > "makefiles/${pkg}.mk"
+    ${SED} -e "s/@pkg@/${pkg}/g" \
+        -e "s/@PKG@/${formatpkg}/g" \
+        "build_misc/templates/package.control" > "build_info/${pkg}.control"
+    clear
 }
 
 if command -v gsed &>/dev/null; then
-	SED=gsed
+    SED=gsed
 else
-	# shellcheck disable=SC2209
-	SED=sed
+    # shellcheck disable=SC2209
+    SED=sed
 fi
 
 if command -v dialog &>/dev/null && [ -z "$1" ]; then
-	main_dialog
+    main_dialog
 else
-	main "$@"
+    main "$@"
 fi


### PR DESCRIPTION
This PR migrates `new_package.sh` to `DOWNLOAD_FILE(S)`, which was recently (as in probably months now) introduced by Hayden. This forces newly generated Makefiles to use these functions. Documentation on both of these functions can be found in the links below.

- [DOWNLOAD_FILE](https://github.com/ProcursusTeam/Procursus/wiki/Makefile-functions#download_file)
- [DOWNLOAD_FILES](https://github.com/ProcursusTeam/Procursus/wiki/Makefile-functions#download_files)