### PR TITLE
xz-utils: Update to 5.2.8

### DIFF
--- a/makefiles/xz.mk
+++ b/makefiles/xz.mk
@@ -3,8 +3,8 @@ $(error Use the main Makefile)
 endif
 
 STRAPPROJECTS += xz
-XZ_VERSION    := 5.2.5
-DEB_XZ_V      ?= $(XZ_VERSION)-3
+XZ_VERSION    := 5.2.8
+DEB_XZ_V      ?= $(XZ_VERSION)
 
 xz-setup: setup
 	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://tukaani.org/xz/xz-$(XZ_VERSION).tar.xz{$(comma).sig})
@@ -18,13 +18,12 @@ else
 xz: xz-setup gettext
 	cd $(BUILD_WORK)/xz && ./configure -C \
 		$(DEFAULT_CONFIGURE_FLAGS) \
-		--libdir=$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)$(MEMO_ALT_PREFIX)/lib \
+		--libdir="$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)$(MEMO_ALT_PREFIX)/lib" \
 		--enable-threads \
 		--disable-xzdec \
 		--disable-lzmadec
 	+$(MAKE) -C $(BUILD_WORK)/xz install \
-		DESTDIR=$(BUILD_STAGE)/xz
-
+		DESTDIR="$(BUILD_STAGE)/xz"
 	cd $(BUILD_WORK)/xz && ./configure -C \
 		$(DEFAULT_CONFIGURE_FLAGS) \
 		--disable-shared \
@@ -38,7 +37,7 @@ xz: xz-setup gettext
 		--disable-xz \
 		--disable-lzma-links
 	+$(MAKE) -C $(BUILD_WORK)/xz install \
-		DESTDIR=$(BUILD_STAGE)/xz
+		DESTDIR="$(BUILD_STAGE)/xz"
 	$(call AFTER_BUILD,copy)
 endif
 


### PR DESCRIPTION
This PR updates `xz` to the latest version, 5.2.8.

* [x] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [ ] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
