### PR TITLE
python3-glances: Update to 3.3.0

### DIFF
--- a/build_info/python3-defusedxml.control
+++ b/build_info/python3-defusedxml.control
@@ -1,0 +1,10 @@
+Package: python3-defusedxml
+Version: @DEB_PYTHON3_DEFUSEDXML_V@
+Architecture: @DEB_ARCH@
+Maintainer: @DEB_MAINTAINER@
+Author: Christian Heimes <christian@python.org>
+Depends: python3
+Section: Python
+Priority: optional
+Homepage: https://github.com/tiran/defusedxml
+Description: XML bomb protection for Python stdlib modules

--- a/build_info/python3-glances.control
+++ b/build_info/python3-glances.control
@@ -3,7 +3,7 @@ Version: @DEB_PYTHON3_GLANCES_V@
 Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
 Author: Nicolas Hennion <nicolas@nicolargo.com>
-Depends: python3, python3-psutil (>= 5.3.0)
+Depends: python3, python3-psutil (>= 5.3.0), python3-defusedxml
 Section: Python
 Priority: optional
 Homepage: https://nicolargo.github.io/glances/

--- a/build_info/python3-psutil.control
+++ b/build_info/python3-psutil.control
@@ -1,5 +1,5 @@
 Package: python3-psutil
-Version: @DEB_PYTHON3-PSUTIL_V@
+Version: @DEB_PYTHON3_PSUTIL_V@
 Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
 Section: Python

--- a/makefiles/python3-defusedxml.mk
+++ b/makefiles/python3-defusedxml.mk
@@ -1,0 +1,42 @@
+ifneq ($(PROCURSUS),1)
+$(error Use the main Makefile)
+endif
+
+SUBPROJECTS                += python3-defusedxml
+PYTHON3_DEFUSEDXML_VERSION := 0.7.1
+DEB_PYTHON3_DEFUSEDXML_V   ?= $(PYTHON3_DEFUSEDXML_VERSION)
+
+python3-defusedxml-setup: setup
+	$(call GITHUB_ARCHIVE,tiran,defusedxml,$(PYTHON3_DEFUSEDXML_VERSION),v$(PYTHON3_DEFUSEDXML_VERSION),python3-defusedxml)
+	$(call EXTRACT_TAR,python3-defusedxml-$(PYTHON3_DEFUSEDXML_VERSION).tar.gz,defusedxml-$(PYTHON3_DEFUSEDXML_VERSION),python3-defusedxml)
+
+ifneq ($(wildcard $(BUILD_WORK)/python3-defusedxml/.build_complete),)
+python3-defusedxml:
+	@echo "Using previously built python3-defusedxml."
+else
+python3-defusedxml: python3-defusedxml-setup python3
+	cd $(BUILD_WORK)/python3-defusedxml && $(DEFAULT_SETUP_PY_ENV) python3 ./setup.py \
+		build \
+		--executable="$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/python3" \
+		install \
+		--install-layout=deb \
+		--root="$(BUILD_STAGE)/python3-defusedxml" \
+		--prefix="$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)"
+	find $(BUILD_STAGE)/python3-defusedxml -name __pycache__ -prune -exec rm -rf {} \;
+	$(call AFTER_BUILD)
+endif
+
+python3-defusedxml-package: python3-defusedxml-stage
+	# python3-defusedxml.mk Package Structure
+	rm -rf $(BUILD_DIST)/python3-defusedxml
+
+	# python3-defusedxml.mk Prep python3-defusedxml
+	cp -a $(BUILD_STAGE)/python3-defusedxml $(BUILD_DIST)
+
+	#python3-defusedxml.mk Make .debs
+	$(call PACK,python3-defusedxml,DEB_PYTHON3_DEFUSEDXML_V)
+
+	# python3-defusedxml.mk Build cleanup
+	rm -rf $(BUILD_DIST)/python3-defusedxml
+
+.PHONY: python3-defusedxml python3-defusedxml-package

--- a/makefiles/python3-glances.mk
+++ b/makefiles/python3-glances.mk
@@ -3,12 +3,12 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS             += python3-glances
-PYTHON3_GLANCES_VERSION := 3.2.4.2
+PYTHON3_GLANCES_VERSION := 3.3.0
 DEB_PYTHON3_GLANCES_V   ?= $(PYTHON3_GLANCES_VERSION)
 
 python3-glances-setup: setup
-	$(call GITHUB_ARCHIVE,nicolargo,glances,$(PYTHON3_GLANCES_VERSION),v$(PYTHON3_GLANCES_VERSION))
-	$(call EXTRACT_TAR,glances-$(PYTHON3_GLANCES_VERSION).tar.gz,glances-$(PYTHON3_GLANCES_VERSION),python3-glances)
+	$(call GITHUB_ARCHIVE,nicolargo,glances,$(PYTHON3_GLANCES_VERSION),v$(PYTHON3_GLANCES_VERSION),python3-glances)
+	$(call EXTRACT_TAR,python3-glances-$(PYTHON3_GLANCES_VERSION).tar.gz,glances-$(PYTHON3_GLANCES_VERSION),python3-glances)
 
 ifneq ($(wildcard $(BUILD_WORK)/python3-glances/.build_complete),)
 python3-glances:

--- a/makefiles/python3-psutil.mk
+++ b/makefiles/python3-psutil.mk
@@ -3,12 +3,12 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS            += python3-psutil
-PYTHON3-PSUTIL_VERSION := 5.9.4
-DEB_PYTHON3-PSUTIL_V   ?= $(PYTHON3-PSUTIL_VERSION)
+PYTHON3_PSUTIL_VERSION := 5.9.4
+DEB_PYTHON3_PSUTIL_V   ?= $(PYTHON3_PSUTIL_VERSION)
 
 python3-psutil-setup: setup
-	$(call GITHUB_ARCHIVE,giampaolo,psutil,$(PYTHON3-PSUTIL_VERSION),release-$(PYTHON3-PSUTIL_VERSION),python3-psutil)
-	$(call EXTRACT_TAR,python3-psutil-$(PYTHON3-PSUTIL_VERSION).tar.gz,psutil-release-$(PYTHON3-PSUTIL_VERSION),python3-psutil)
+	$(call GITHUB_ARCHIVE,giampaolo,psutil,$(PYTHON3_PSUTIL_VERSION),release-$(PYTHON3_PSUTIL_VERSION),python3-psutil)
+	$(call EXTRACT_TAR,python3-psutil-$(PYTHON3_PSUTIL_VERSION).tar.gz,psutil-release-$(PYTHON3_PSUTIL_VERSION),python3-psutil)
 
 ifneq ($(wildcard $(BUILD_WORK)/python3-psutil/.build_complete),)
 python3-psutil:
@@ -37,7 +37,7 @@ python3-psutil-package: python3-psutil-stage
 	$(call SIGN,python3-psutil,general.xml)
 
 	# python3-psutil.mk Make .debs
-	$(call PACK,python3-psutil,DEB_PYTHON3-PSUTIL_V)
+	$(call PACK,python3-psutil,DEB_PYTHON3_PSUTIL_V)
 
 	# python3-psutil.mk Build cleanup
 	rm -rf $(BUILD_DIST)/python3-psutil

--- a/makefiles/python3-psutil.mk
+++ b/makefiles/python3-psutil.mk
@@ -3,12 +3,12 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS            += python3-psutil
-PYTHON3-PSUTIL_VERSION := 5.8.0
+PYTHON3-PSUTIL_VERSION := 5.9.4
 DEB_PYTHON3-PSUTIL_V   ?= $(PYTHON3-PSUTIL_VERSION)
 
 python3-psutil-setup: setup
-	$(call DOWNLOAD_FILES,$(BUILD_SOURCE) ,https://github.com/giampaolo/psutil/archive/refs/tags/release-$(PYTHON3-PSUTIL_VERSION).tar.gz)
-	$(call EXTRACT_TAR,release-$(PYTHON3-PSUTIL_VERSION).tar.gz,psutil-release-$(PYTHON3-PSUTIL_VERSION),python3-psutil)
+	$(call GITHUB_ARCHIVE,giampaolo,psutil,$(PYTHON3-PSUTIL_VERSION),release-$(PYTHON3-PSUTIL_VERSION),python3-psutil)
+	$(call EXTRACT_TAR,python3-psutil-$(PYTHON3-PSUTIL_VERSION).tar.gz,psutil-release-$(PYTHON3-PSUTIL_VERSION),python3-psutil)
 
 ifneq ($(wildcard $(BUILD_WORK)/python3-psutil/.build_complete),)
 python3-psutil:
@@ -29,10 +29,9 @@ endif
 python3-psutil-package: python3-psutil-stage
 	# python3-psutil.mk Package Structure
 	rm -rf $(BUILD_DIST)/python3-psutil
-	mkdir -p $(BUILD_DIST)/python3-psutil/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)
 
 	# python3-psutil.mk Prep python3-psutil
-	cp -a $(BUILD_STAGE)/python3-psutil$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib $(BUILD_DIST)/python3-psutil/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)
+	cp -a $(BUILD_STAGE)/python3-psutil $(BUILD_DIST)
 
 	# python3-psutil.mk Sign
 	$(call SIGN,python3-psutil,general.xml)


### PR DESCRIPTION
This PR updates `python3-glances` to its latest stable release, 3.3.0. A new dependency, `python3-defusedxml` is introduced, while also updating `python3-psutil` to its latest stable release, 5.9.4.