### PR TITLE
xkeyboard-config: Add missing build dependencies

### DIFF
--- a/makefiles/xkeyboard-config.mk
+++ b/makefiles/xkeyboard-config.mk
@@ -19,7 +19,7 @@ xkeyboard-config: xkeyboard-config-setup xorgproto libx11 libxcb libxau libpthre
 		$(DEFAULT_CONFIGURE_FLAGS)
 	+$(MAKE) -C $(BUILD_WORK)/xkeyboard-config
 	+$(MAKE) -C $(BUILD_WORK)/xkeyboard-config install \
-		DESTDIR=$(BUILD_STAGE)/xkeyboard-config
+		DESTDIR="$(BUILD_STAGE)/xkeyboard-config"
 	$(call AFTER_BUILD)
 endif
 

--- a/makefiles/xkeyboard-config.mk
+++ b/makefiles/xkeyboard-config.mk
@@ -14,7 +14,7 @@ ifneq ($(wildcard $(BUILD_WORK)/xkeyboard-config/.build_complete),)
 xkeyboard-config:
 	@echo "Using previously built xkeyboard-config."
 else
-xkeyboard-config: xkeyboard-config-setup xorgproto
+xkeyboard-config: xkeyboard-config-setup xorgproto libx11 libxcb libxau libpthread-stubs libxdmcp
 	cd $(BUILD_WORK)/xkeyboard-config && ./configure \
 		$(DEFAULT_CONFIGURE_FLAGS)
 	+$(MAKE) -C $(BUILD_WORK)/xkeyboard-config


### PR DESCRIPTION
This small PR adds missing build dependencies for `xkeyboard-config`. The package should build now without any missing dependencies.