### PR TITLE
diskdev-cmds: Do not build dirs_cleaner on CFVER 1800+

### DIFF
--- a/makefiles/diskdev-cmds.mk
+++ b/makefiles/diskdev-cmds.mk
@@ -71,7 +71,11 @@ diskdev-cmds: diskdev-cmds-setup
 		bin=../$$(basename $$c .c); \
 		$(CC) $(CFLAGS) $(LDFLAGS) -isystem ../include -o $$bin $$c; \
 	done
+ifneq ($(shell [ "$(CFVER_WHOLE)" -ge 1800 ] && echo 1),1)
 	$(CC) $(CFLAGS) $(LDFLAGS) $(BUILD_WORK)/diskdev-cmds/dirs_cleaner/dirs_cleaner.c -o $(BUILD_STAGE)/diskdev-cmds/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/libexec/dirs_cleaner
+else
+	rmdir $(BUILD_STAGE)/diskdev-cmds/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/libexec
+endif
 	cd $(BUILD_WORK)/diskdev-cmds; \
 	cp -a quota $(BUILD_STAGE)/diskdev-cmds/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin; \
 	cp -a dev_mkdb edquota fdisk quotaon repquota vsdbutil $(BUILD_STAGE)/diskdev-cmds/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/sbin; \


### PR DESCRIPTION
On these versions, this file exists in stock. The package version is not bumped since there is no offical repositories that supports 1800+

### All Submissions

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [x] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)

### Package Additions/Updates

* [x] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
