### PR TITLE
Add VLC media player, usable as an iOS command line audio player

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -539,7 +539,11 @@ endif
 
 CFLAGS              := $(OPTIMIZATION_FLAGS) -arch $(MEMO_ARCH) -isysroot $(TARGET_SYSROOT) $(PLATFORM_VERSION_MIN) -isystem $(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include -isystem $(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)$(MEMO_ALT_PREFIX)/include -F$(BUILD_BASE)$(MEMO_PREFIX)/System/Library/Frameworks -F$(BUILD_BASE)$(MEMO_PREFIX)/Library/Frameworks
 CXXFLAGS            := $(CFLAGS)
+ifneq (,$(findstring x86_64,$(MEMO_ARCH)))
+ASFLAGS             :=
+else
 ASFLAGS             := $(CFLAGS)
+endif
 CPPFLAGS            := -arch $(MEMO_ARCH) $(PLATFORM_VERSION_MIN) -isysroot $(TARGET_SYSROOT) -isystem $(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include -isystem $(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)$(MEMO_ALT_PREFIX)/include -Wno-error-implicit-function-declaration
 LDFLAGS             := $(OPTIMIZATION_FLAGS) -arch $(MEMO_ARCH) -isysroot $(TARGET_SYSROOT) $(PLATFORM_VERSION_MIN) -L$(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib -L$(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)$(MEMO_ALT_PREFIX)/lib -F$(BUILD_BASE)$(MEMO_PREFIX)/System/Library/Frameworks -F$(BUILD_BASE)$(MEMO_PREFIX)/Library/Frameworks -Wl,-not_for_dyld_shared_cache
 PKG_CONFIG_PATH     :=

--- a/build_info/libaacs-dev.control
+++ b/build_info/libaacs-dev.control
@@ -1,0 +1,18 @@
+Package: libaacs-dev
+Version: @DEB_LIBAACS_V@
+Architecture: @DEB_ARCH@
+Priority: optional
+Section: Development
+Maintainer: @DEB_MAINTAINER@
+Depends: libaacs0 (= @DEB_LIBAACS_V@) 
+Homepage: https://www.videolan.org/developers/libaacs.html
+Description: free-and-libre implementation of AACS
+ libaacs is a research project to implement the Advanced Access Content
+ System specification. It provides, through an open-source library, a
+ way to understand how the AACS works.
+ .
+ This package DOES NOT provide any key or certificate that could be used
+ to decode encrypted copyrighted material. It is based on the official
+ public AACS specification only.
+ .
+ This package provides the development files for libaacs0.

--- a/build_info/libaacs0.control
+++ b/build_info/libaacs0.control
@@ -1,0 +1,20 @@
+Package: libaacs0
+Version: @DEB_LIBAACS_V@
+Architecture: @DEB_ARCH@
+Priority: optional
+Section: Libraries
+Maintainer: @DEB_MAINTAINER@
+Depends: libgcrypt20 (>= 1.8.0), libgpg-error0 (>= 1.14)
+Recommends: libbdplus0
+Enhances: libbluray2
+Homepage: https://www.videolan.org/developers/libaacs.html
+Description: free-and-libre implementation of AACS
+ libaacs is a research project to implement the Advanced Access Content
+ System specification. It provides, through an open-source library, a
+ way to understand how the AACS works.
+ .
+ This package DOES NOT provide any key or certificate that could be used
+ to decode encrypted copyrighted material. It is based on the official
+ public AACS specification only.
+ .
+ This package provides the shared library.

--- a/build_info/libbdplus-dev.control
+++ b/build_info/libbdplus-dev.control
@@ -1,0 +1,18 @@
+Package: libbdplus-dev
+Version: @DEB_LIBBDPLUS_V@
+Architecture: @DEB_ARCH@
+Priority: optional
+Section: Development
+Maintainer: @DEB_MAINTAINER@
+Depends: libbdplus0 (= @DEB_LIBBDPLUS_V@)
+Homepage: https://www.videolan.org/developers/libbdplus.html
+Description: implementation of BD+ for reading Blu-ray Discs
+ libbdplus is a research project to implement the BD+ System Specifications.
+ It provides, through an open-source library, a way to understand how the BD+
+ works.
+ .
+ This package DOES NOT provide any key, certificate, configuration
+ file or virtual machine that could be used to decode encrypted
+ copyrighted material.
+ .
+ This package provides the shared library.

--- a/build_info/libbdplus0.control
+++ b/build_info/libbdplus0.control
@@ -1,0 +1,20 @@
+Package: libbdplus0
+Version: @DEB_LIBBDPLUS_V@
+Architecture: @DEB_ARCH@
+Priority: optional
+Section: Libraries
+Maintainer: @DEB_MAINTAINER@
+Depends: libgcrypt20 (>= 1.8.0), libgpg-error0 (>= 1.14)
+Recommends: libaacs0
+Enhances: libbluray2
+Homepage: https://www.videolan.org/developers/libbdplus.html
+Description: implementation of BD+ for reading Blu-ray Discs
+ libbdplus is a research project to implement the BD+ System Specifications.
+ It provides, through an open-source library, a way to understand how the BD+
+ works.
+ .
+ This package DOES NOT provide any key, certificate, configuration
+ file or virtual machine that could be used to decode encrypted
+ copyrighted material.
+ .
+ This package provides the shared library.

--- a/build_info/libbluray-bdj.control
+++ b/build_info/libbluray-bdj.control
@@ -1,0 +1,24 @@
+Package: libbluray-bdj
+Version: @DEB_LIBBLURAY_V@
+Priority: optional
+Section: Libraries
+Source: libbluray
+Maintainer: Debian Multimedia Maintainers <debian-multimedia@lists.debian.org>
+Architecture: @DEB_ARCH@
+Depends: libbluray2 (>= @DEB_LIBBLURAY_V@), openjdk-jre
+Homepage: http://www.videolan.org/developers/libbluray.html
+Tag: role::shared-lib
+Description: Blu-ray Disc Java support library (BD-J library)
+ libbluray is an open-source library designed for Blu-Ray Discs playback for
+ media players, like VLC or MPlayer. This research project is developed by an
+ international team of developers from Doom9. libbluray integrates navigation,
+ playlist parsing, menus, and BD-J.
+ .
+ NB: Most commercial Blu-Ray are restricted by AACS or BD+ technologies and this
+ library is not enough to playback those discs.
+ .
+ BD-J support is important because many of the advanced features and extra
+ content in Blu-ray movies uses BD-J. Programs designed to provide support for
+ those features must depend on this.
+ .
+ This package provides the BD-J library.

--- a/build_info/libbluray-bin.control
+++ b/build_info/libbluray-bin.control
@@ -1,0 +1,18 @@
+Package: libbluray-bin
+Version: @DEB_LIBBLURAY_V@
+Priority: optional
+Architecture: @DEB_ARCH@
+Section: Utilities
+Maintainer: @DEB_MAINTAINER@
+Depends: libbluray2 (= @DEB_LIBBLURAY_V@)
+Homepage: http://www.videolan.org/developers/libbluray.html
+Description: Blu-ray disc playback support library (tools)
+ libbluray is an open-source library designed for Blu-Ray Discs playback for
+ media players, like VLC or MPlayer. This research project is developed by an
+ international team of developers from Doom9. libbluray integrates navigation,
+ playlist parsing, menus, and BD-J.
+ .
+ NB: Most commercial Blu-Ray are restricted by AACS or BD+ technologies and this
+ library is not enough to playback those discs.
+ .
+ This package provides a simple tool to retrieve information about a Blu-ray.

--- a/build_info/libbluray-dev.control
+++ b/build_info/libbluray-dev.control
@@ -1,0 +1,20 @@
+Package: libbluray-dev
+Version: @DEB_LIBBLURAY_V@
+Priority: optional
+Architecture: @DEB_ARCH@
+Section: Development
+Maintainer: @DEB_MAINTAINER@
+Depends: libbluray2 (= @DEB_LIBBLURAY_V@), libfreetype-dev, libfontconfig-dev
+Homepage: http://www.videolan.org/developers/libbluray.html
+Tag: devel::library, role::devel-lib
+APT-Sources: https://mirror.xtom.com.hk/debian buster/main amd64 Packages
+Description: Blu-ray disc playback support library (development files)
+ libbluray is an open-source library designed for Blu-Ray Discs playback for
+ media players, like VLC or MPlayer. This research project is developed by an
+ international team of developers from Doom9. libbluray integrates navigation,
+ playlist parsing, menus, and BD-J.
+ .
+ NB: Most commercial Blu-Ray are restricted by AACS or BD+ technologies and this
+ library is not enough to playback those discs.
+ .
+ This package provides the necessary files needed for development.

--- a/build_info/libbluray2.control
+++ b/build_info/libbluray2.control
@@ -1,0 +1,21 @@
+Package: libbluray2
+Version: @DEB_LIBBLURAY_V@
+Architecture: @DEB_ARCH@
+Priority: optional
+Section: Libraries
+Maintainer: @DEB_MAINTAINER@
+Depends: libfontconfig1 (>= 2.12.6), libfreetype6 (>= 2.2.1)
+Recommends: libaacs0
+Suggests: libbluray-bdj
+Homepage: http://www.videolan.org/developers/libbluray.html
+Tag: role::shared-lib
+Description: Blu-ray disc playback support library (shared library)
+ libbluray is an open-source library designed for Blu-Ray Discs playback for
+ media players, like VLC or MPlayer. This research project is developed by an
+ international team of developers from Doom9. libbluray integrates navigation,
+ playlist parsing, menus, and BD-J.
+ .
+ NB: Most commercial Blu-Ray are restricted by AACS or BD+ technologies and this
+ library is not enough to playback those discs.
+ .
+ This package provides the shared library.

--- a/build_info/libdvdnav-dev.control
+++ b/build_info/libdvdnav-dev.control
@@ -1,0 +1,12 @@
+Package: libdvdnav-dev
+Version: @DEB_LIBDVDNAV_V@
+Architecture: @DEB_ARCH@
+Maintainer: @DEB_MAINTAINER@
+Depends: libdvdnav4 (= @DEB_LIBDVDNAV_V@), pkg-config, libdvdread-dev
+Suggests: libdvdcss-dev
+Section: Development
+Priority: optional
+Homepage: http://dvdnav.mplayerhq.hu/
+Description: DVD navigation library (development)
+ libdvdnav is a DVD navigation library, which provides an interface to the advanced features of DVDs, like menus and navigation. It contains the VM and other parts useful for writing DVD players. It's based on Ogle, but was modified to be used by xine and mplayer.
+ This package contains the development files.

--- a/build_info/libdvdnav4.control
+++ b/build_info/libdvdnav4.control
@@ -1,0 +1,11 @@
+Package: libdvdnav4
+Version: @DEB_LIBDVDNAV_V@
+Architecture: @DEB_ARCH@
+Maintainer: @DEB_MAINTAINER@
+Depends: libdvdread8
+Suggests: libdvdcss2
+Section: Libraries
+Priority: optional
+Homepage: http://dvdnav.mplayerhq.hu/
+Description: DVD navigation library
+ libdvdnav is a DVD navigation library, which provides an interface to the advanced features of DVDs, like menus and navigation. It contains the VM and other parts useful for writing DVD players. It's based on Ogle, but was modified to be used by xine and mplayer.

--- a/build_info/libdvdread-dev.control
+++ b/build_info/libdvdread-dev.control
@@ -1,0 +1,16 @@
+Package: libdvdread-dev
+Version: @DEB_LIBDVDREAD_V@
+Architecture: @DEB_ARCH@
+Maintainer: @DEB_MAINTAINER@
+Depends: libdvdread8 (= @DEB_LIBDVDREAD_V@), pkg-config
+Recommends: libdvdnav-dev
+Suggests: libdvdcss-dev
+Section: libdevel
+Priority: optional
+Homepage: http://dvdnav.mplayerhq.hu/
+Description: library for reading DVDs (development)
+ libdvdread provides the functionality that is required to access many DVDs. It
+ parses IFO files, reads NAV-blocks, and performs CSS authentication and
+ descrambling.
+ .
+ This package contains the development files.

--- a/build_info/libdvdread8.control
+++ b/build_info/libdvdread8.control
@@ -1,0 +1,16 @@
+Package: libdvdread8
+Version: @DEB_LIBDVDREAD_V@
+Architecture: @DEB_ARCH@
+Maintainer: @DEB_MAINTAINER@
+Recommends: libdvdnav4
+Suggests: libdvdcss2
+Section: Libraries
+Priority: optional
+Homepage: http://dvdnav.mplayerhq.hu/
+Description: library for reading DVDs
+ libdvdread provides the functionality that is required to access many DVDs. It
+ parses IFO files, reads NAV-blocks, and performs CSS authentication and
+ descrambling.
+ .
+ libdvdread probes for libdvdcss at runtime and if found, will use it to
+ decrypt sections of the DVD as necessary.

--- a/build_info/libmpeg2-4-dev.control
+++ b/build_info/libmpeg2-4-dev.control
@@ -1,0 +1,13 @@
+Package: mpeg2dec
+Version: @DEB_LIBMPEG2_V@
+Priority: optional
+Section: Development
+Architecture: @DEB_ARCH@
+Maintainer: @DEB_MAINTAINER@
+Depends: libmpeg2-4 (= @DEB_LIBMPEG2_V@)
+Homepage: http://libmpeg2.sourceforge.net/
+Description: libmpeg2 development libraries and headers
+ libmpeg2 is a library which can decode MPEG1 and MPEG2 video streams.
+ .
+ This package contains the libraries and headers required to compile
+ programs which use libmpeg2.

--- a/build_info/libmpeg2-4.control
+++ b/build_info/libmpeg2-4.control
@@ -1,0 +1,30 @@
+Package: libmpeg2-4
+Version: @DEB_LIBMPEG2_V@
+Priority: optional
+Section: Libraries
+Architecture: @DEB_ARCH@
+Maintainer: @DEB_MAINTAINER@
+Homepage: http://libmpeg2.sourceforge.net/
+Description: MPEG1 and MPEG2 video decoder library
+ libmpeg2 is a library which can decode MPEG1 and MPEG2 video streams.
+ .
+ The main features in libmpeg2 are:
+ .
+  * Conformance - libmpeg2 is able to decode all mpeg streams that conform to
+    certain restrictions. For streams that follow these restrictions, libmpeg2
+    is probably 100% conformant to the mpeg standards - and there's a pretty
+    extensive test suite to check this.
+ .
+  * Speed - there has been huge efforts there, and libmpeg2 is probably the
+    fastest library around for what it does.
+ .
+  * Portability - most of the code is written in C, and when platform-specific
+    optimizations are used, there always is a generic C routine to fall back
+    on.  This should be portable to all architectures - at least it is known
+    people run this code on x86, ppc, sparc, arm and sh4.
+ .
+  * Reuseability - libmpeg2 is not intended to include any project-specific
+    code, but it should still include enough features to be used by very
+    diverse projects.
+ .
+ This package contains the libmpeg2 shared libraries.

--- a/build_info/libnfs-dev.control
+++ b/build_info/libnfs-dev.control
@@ -1,0 +1,17 @@
+Package: libnfs-dev
+Version: @DEB_LIBNFS_V@
+Architecture: @DEB_ARCH@
+Maintainer: @DEB_MAINTAINER@
+Section: Development
+Priority: optional
+Depends: libnfs14 (= @DEB_LIBNFS_V@)
+Homepage: https://github.com/sahlberg/libnfs
+Description: NFS client library (shared library)
+ LIBNFS is a client library for accessing NFS shares over a network.
+ .
+ LIBNFS offers three different APIs, for different use :
+ 1, RAW : A fully async low level rpc library for nfs protocols
+ 2, NFS ASYNC : A fully asynchronous library for high level vfs functions
+ 3, NFS SYNC : A synchronous library for high level vfs functions
+ .
+ This package provides the necessary files needed for development.

--- a/build_info/libnfs-utils.control
+++ b/build_info/libnfs-utils.control
@@ -1,0 +1,17 @@
+Package: libnfs-utils
+Version: @DEB_LIBNFS_V@
+Architecture: @DEB_ARCH@
+Maintainer: @DEB_MAINTAINER@
+Depends: libnfs14 (>= @DEB_LIBNFS_V@)
+Section: Libraries
+Priority: optional
+Homepage: https://github.com/sahlberg/libnfs
+Description: NFS client library (shared library)
+ LIBNFS is a client library for accessing NFS shares over a network.
+ .
+ LIBNFS offers three different APIs, for different use :
+ 1, RAW : A fully async low level rpc library for nfs protocols
+ 2, NFS ASYNC : A fully asynchronous library for high level vfs functions
+ 3, NFS SYNC : A synchronous library for high level vfs functions
+ .
+ This package provides command line utilities.

--- a/build_info/libnfs14.control
+++ b/build_info/libnfs14.control
@@ -1,0 +1,16 @@
+Package: libnfs14
+Version: @DEB_LIBNFS_V@
+Architecture: @DEB_ARCH@
+Maintainer: @DEB_MAINTAINER@
+Section: Libraries
+Priority: optional
+Homepage: https://github.com/sahlberg/libnfs
+Description: NFS client library (shared library)
+ LIBNFS is a client library for accessing NFS shares over a network.
+ .
+ LIBNFS offers three different APIs, for different use :
+ 1, RAW : A fully async low level rpc library for nfs protocols
+ 2, NFS ASYNC : A fully asynchronous library for high level vfs functions
+ 3, NFS SYNC : A synchronous library for high level vfs functions
+ .
+ This package provides the shared library

--- a/build_info/libsmb2-1.control
+++ b/build_info/libsmb2-1.control
@@ -1,0 +1,14 @@
+Package: libsmb2-1
+Version: @DEB_LIBSMB2_V@
+Architecture: @DEB_ARCH@
+Maintainer: @DEB_MAINTAINER@
+Section: Libraries
+Depends: libssl3 (>= 3.0.7)
+Priority: optional
+Homepage: https://github.com/sahlberg/libnfs
+Description: SMB2/3 client library
+ Libsmb2 is a userspace client library for accessing SMB2/SMB3 shares on 
+ a network. It is high performance and fully async. It supports both 
+ zero-copy for SMB READ/WRITE commands as well as compounded commands.
+ .
+ This package provides the shared libraries.

--- a/build_info/libsmb2-dev.control
+++ b/build_info/libsmb2-dev.control
@@ -1,0 +1,13 @@
+Package: libsmb2-dev
+Version: @DEB_LIBSMB2_V@
+Architecture: @DEB_ARCH@
+Maintainer: @DEB_MAINTAINER@
+Section: Development
+Priority: optional
+Homepage: https://github.com/sahlberg/libnfs
+Description: SMB2/3 client library
+ Libsmb2 is a userspace client library for accessing SMB2/SMB3 shares on 
+ a network. It is high performance and fully async. It supports both 
+ zero-copy for SMB READ/WRITE commands as well as compounded commands.
+ .
+ This package provides the headers and other development files.

--- a/build_info/libvlc-bin.control
+++ b/build_info/libvlc-bin.control
@@ -1,0 +1,15 @@
+Package: libvlc-bin
+Version: @DEB_VLC_V@
+Architecture: @DEB_ARCH@
+Author: VideoLAN <videolan@videolan.org>
+Priority: optional
+Section: Multimedia
+Maintainer: @DEB_MAINTAINER@
+Depends: libvlc5 (>= @DEB_VLC_V@)
+Homepage: https://www.videolan.org/vlc/
+Description: tools for VLC's base library
+ VLC is the VideoLAN project's media player. It plays MPEG, MPEG-2, MPEG-4,
+ DivX, MOV, WMV, QuickTime, WebM, FLAC, MP3, Ogg/Vorbis files, DVDs, VCDs,
+ podcasts, and multimedia streams from various network sources.
+ .
+ This package contains the vlc-cache-gen binary.

--- a/build_info/libvlc-bin.postinst
+++ b/build_info/libvlc-bin.postinst
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -e
+
+run_vlc_cache_gen() {
+    if ! test -d @MEMO_PREFIX@@MEMO_SUB_PREFIX@/lib/vlc/plugins
+    then
+        return
+    fi
+    files=`find @MEMO_PREFIX@@MEMO_SUB_PREFIX@/lib/vlc/plugins -name '*.dylib' -type f -print -quit`
+    if test -n "$files"
+    then
+        # run vlc-cache-gen since there are plugins
+        if ! @MEMO_PREFIX@@MEMO_SUB_PREFIX@/lib/vlc/vlc-cache-gen @MEMO_PREFIX@@MEMO_SUB_PREFIX@/lib/vlc/plugins 2>&1
+        then
+            echo "WARNING: Regenerating VLC plugin cache failed."
+            echo "Please run '@MEMO_PREFIX@@MEMO_SUB_PREFIX@/lib/vlc/vlc-cache-gen @MEMO_PREFIX@@MEMO_SUB_PREFIX@/lib/vlc/plugins' manually."
+        fi
+    else
+        # no plugins, so remove plugins.dat
+        rm -f @MEMO_PREFIX@@MEMO_SUB_PREFIX@/lib/vlc/plugins/plugins.dat
+    fi
+}
+
+case "$1" in
+    triggered)
+        run_vlc_cache_gen
+        exit 0
+        ;;
+    configure)
+        dpkg-trigger @MEMO_PREFIX@@MEMO_SUB_PREFIX@/lib/vlc/plugins
+        ;;
+esac

--- a/build_info/libvlc-bin.prerm
+++ b/build_info/libvlc-bin.prerm
@@ -1,0 +1,10 @@
+#! /bin/sh
+set -e
+
+
+
+case "$1" in
+    remove)
+        rm -f @MEMO_PREFIX@@MEMO_SUB_PREFIX/lib/vlc/plugins/plugins.dat
+        ;;
+esac

--- a/build_info/libvlc-bin.triggers
+++ b/build_info/libvlc-bin.triggers
@@ -1,0 +1,1 @@
+interest @MEMO_PREFIX@@MEMO_SUB_PREFIX@/lib/vlc/plugins

--- a/build_info/libvlc-dev.control
+++ b/build_info/libvlc-dev.control
@@ -1,0 +1,15 @@
+Package: libvlc-dev
+Version: @DEB_VLC_V@
+Architecture: @DEB_ARCH@
+Priority: optional
+Section: Development
+Maintainer: @DEB_MAINTAINER@
+Depends: libvlc5 (= @DEB_VLC_V@)
+Homepage: https://www.videolan.org/vlc/
+Description: development files for libvlc
+ This package contains headers and a static library required to build
+ standalone applications that use VLC features.
+ .
+ VLC is the VideoLAN project's media player. It plays MPEG, MPEG-2, MPEG-4,
+ DivX, MOV, WMV, QuickTime, WebM, FLAC, MP3, Ogg/Vorbis files, DVDs, VCDs,
+ podcasts, and multimedia streams from various network sources.

--- a/build_info/libvlc5.control
+++ b/build_info/libvlc5.control
@@ -1,0 +1,16 @@
+Package: libvlc5
+Version: @DEB_VLC_V@
+Architecture: @DEB_ARCH@
+Priority: optional
+Section: Libraries
+Maintainer: @DEB_MAINTAINER@
+Depends: libvlccore9 (>= @DEB_VLC_V@)
+Recommends: libvlc-bin (= @DEB_VLC_V@)
+Homepage: https://www.videolan.org/vlc/
+Description: multimedia player and streamer library
+ VLC is the VideoLAN project's media player. It plays MPEG, MPEG-2, MPEG-4,
+ DivX, MOV, WMV, QuickTime, WebM, FLAC, MP3, Ogg/Vorbis files, DVDs, VCDs,
+ podcasts, and multimedia streams from various network sources.
+ .
+ This package contains the shared library required by applications using VLC
+ features.

--- a/build_info/libvlccore-dev.control
+++ b/build_info/libvlccore-dev.control
@@ -1,0 +1,16 @@
+Package: libvlccore-dev
+Version: @DEB_VLC_V@
+Architecture: @DEB_ARCH@
+Author: VideoLAN <videolan@videolan.org>
+Priority: optional
+Section: Multimedia
+Maintainer: @DEB_MAINTAINER@
+Depends: libvlccore9 (= @DEB_VLC_V@)
+Homepage: https://www.videolan.org/vlc/
+Description: development files for libvlccore
+ VLC is the VideoLAN project's media player. It plays MPEG, MPEG-2, MPEG-4,
+ DivX, MOV, WMV, QuickTime, WebM, FLAC, MP3, Ogg/Vorbis files, DVDs, VCDs,
+ podcasts, and multimedia streams from various network sources.
+ .
+ This package contains headers and a static library required to build plugins
+ for VLC.

--- a/build_info/libvlccore9.control
+++ b/build_info/libvlccore9.control
@@ -1,0 +1,16 @@
+Package: libvlccore9
+Version: @DEB_VLC_V@
+Architecture: @DEB_ARCH@
+Priority: optional
+Section: Libraries
+Maintainer: @DEB_MAINTAINER@
+Provides: vlc-plugin-abi-3-0-0f
+Depends: libidn2-0 (>= 1.13)
+Recommends: libproxy-tools
+Homepage: https://www.videolan.org/vlc/
+Description: base library for VLC and its modules
+ VLC is the VideoLAN project's media player. It plays MPEG, MPEG-2, MPEG-4,
+ DivX, MOV, WMV, QuickTime, WebM, FLAC, MP3, Ogg/Vorbis files, DVDs, VCDs,
+ podcasts, and multimedia streams from various network sources.
+ .
+ This package contains the shared library required by VLC modules and libvlc.

--- a/build_info/mpeg2dec.control
+++ b/build_info/mpeg2dec.control
@@ -1,0 +1,13 @@
+Package: mpeg2dec
+Version: @DEB_LIBMPEG2_V@
+Priority: optional
+Section: X11
+Architecture: @DEB_ARCH@
+Maintainer: @DEB_MAINTAINER@
+Depends: libmpeg2-4 (>= @DEB_LIBMPEG2_V@), libx11-6, libxext6
+Homepage: http://libmpeg2.sourceforge.net/
+Description: Simple libmpeg2 video decoder application
+ Simple libmpeg2 application which can decode and play ES, PS, and TS video
+ streams.  Includes extract_mpeg2 demuxer and various output drivers.
+ .
+ This package provides the mpeg2dec and extract_mpeg2 tools.

--- a/build_info/vlc-bin.control
+++ b/build_info/vlc-bin.control
@@ -1,0 +1,15 @@
+Package: vlc-bin
+Version: @DEB_VLC_V@
+Architecture: @DEB_ARCH@
+Author: VideoLAN <videolan@videolan.org>
+Priority: optional
+Section: Multimedia
+Maintainer: @DEB_MAINTAINER@
+Depends: libvlc-bin (= @DEB_VLC_V@), libvlc5 (>= @DEB_VLC_V@)
+Homepage: https://www.videolan.org/vlc/
+Description: binaries from VLC
+ VLC is the VideoLAN project's media player. It plays MPEG, MPEG-2, MPEG-4,
+ DivX, MOV, WMV, QuickTime, WebM, FLAC, MP3, Ogg/Vorbis files, DVDs, VCDs,
+ podcasts, and multimedia streams from various network sources.
+ .
+ This package contains the VLC's binaries.

--- a/build_info/vlc-bin.control.macosx
+++ b/build_info/vlc-bin.control.macosx
@@ -1,0 +1,15 @@
+Package: vlc-bin
+Version: @DEB_VLC_V@
+Architecture: @DEB_ARCH@
+Author: VideoLAN <videolan@videolan.org>
+Priority: optional
+Section: Multimedia
+Maintainer: @DEB_MAINTAINER@
+Depends: libvlc-bin (= @DEB_VLC_V@), libvlc5 (>= @DEB_VLC_V@), vlc.app (>= @DEB_VLC_V@)
+Homepage: https://www.videolan.org/vlc/
+Description: binaries from VLC
+ VLC is the VideoLAN project's media player. It plays MPEG, MPEG-2, MPEG-4,
+ DivX, MOV, WMV, QuickTime, WebM, FLAC, MP3, Ogg/Vorbis files, DVDs, VCDs,
+ podcasts, and multimedia streams from various network sources.
+ .
+ This package contains the VLC's binaries.

--- a/build_info/vlc-data.control
+++ b/build_info/vlc-data.control
@@ -1,0 +1,14 @@
+Package: vlc-data
+Version: @DEB_VLC_V@
+Architecture: all
+Author: VideoLAN <videolan@videolan.org>
+Priority: optional
+Section: Multimedia
+Maintainer: @DEB_MAINTAINER@
+Homepage: https://www.videolan.org/vlc/
+Description: common data for VLC
+ VLC is the VideoLAN project's media player. It plays MPEG, MPEG-2, MPEG-4,
+ DivX, MOV, WMV, QuickTime, WebM, FLAC, MP3, Ogg/Vorbis files, DVDs, VCDs,
+ podcasts, and multimedia streams from various network sources.
+ .
+ This package contains icons and shell scripts for VLC media player.

--- a/build_info/vlc-l10n.control
+++ b/build_info/vlc-l10n.control
@@ -1,0 +1,14 @@
+Package: vlc-l10n
+Version: @DEB_VLC_V@
+Architecture: all
+Author: VideoLAN <videolan@videolan.org>
+Priority: optional
+Section: Multimedia
+Maintainer: @DEB_MAINTAINER@
+Homepage: https://www.videolan.org/vlc/
+Description: translations for VLC
+ VLC is the VideoLAN project's media player. It plays MPEG, MPEG-2, MPEG-4,
+ DivX, MOV, WMV, QuickTime, WebM, FLAC, MP3, Ogg/Vorbis files, DVDs, VCDs,
+ podcasts, and multimedia streams from various network sources.
+ .
+ This package contains localisations for VLC media player.

--- a/build_info/vlc-plugin-access-extra.control
+++ b/build_info/vlc-plugin-access-extra.control
@@ -1,0 +1,16 @@
+Package: vlc-plugin-access-extra
+Version: @DEB_VLC_V@
+Architecture: @DEB_ARCH@
+Author: VideoLAN <videolan@videolan.org>
+Priority: optional
+Section: Multimedia
+Depends: libxcb-composite0, libxcb1, vlc-plugin-abi-3-0-0f, libvlccore9 (>= @DEB_VLC_V@)
+Enhances: vlc
+Maintainer: @DEB_MAINTAINER@
+Homepage: https://www.videolan.org/vlc/
+Description: multimedia player and streamer (extra access plugins)
+ VLC is the VideoLAN project's media player. It plays MPEG, MPEG-2, MPEG-4,
+ DivX, MOV, WMV, QuickTime, WebM, FLAC, MP3, Ogg/Vorbis files, DVDs, VCDs,
+ podcasts, and multimedia streams from various network sources.
+ .
+ This package contains additional access plugins.

--- a/build_info/vlc-plugin-base.control
+++ b/build_info/vlc-plugin-base.control
@@ -1,0 +1,18 @@
+Package: vlc-plugin-base
+Version: @DEB_VLC_V@
+Architecture: @DEB_ARCH@
+Author: VideoLAN <videolan@videolan.org>
+Priority: optional
+Depends: vlc-plugin-abi-3-0-0f, libvlccore9 (>= @DEB_VLC_V@), libarchive13 (>= 3.1.2), libx264-164, libavutil57, libavformat59, libavcodec59, libass9 (>= 0.13.6), libdca0 (>= 0.0.5), libdav1d6, libdvdnav4 (>= 6.1.0), libdvdread8 (>= 6.1.0), libflac8 (>= 1.3.0), libfontconfig1 (>= 2.12.6), libfreetype6 (>= 2.2.1), libfribidi0 (>= 1.0.0), libglib2.0-0 (>= 2.28.0), libgnutls30 (>= 3.7.2), libharfbuzz0b (>= 0.9.4), libidn2-0, libjpeg62-turbo (>= 1.3.1), libmpg123-0 (>= 1.26.3), libncursesw6 (>= 6), libogg0 (>= 1.1.0), libopus0 (>= 1.1), libpostproc56 (>= 5.0), libprotobuf32 (>= 3.21.0), libsoxr0 (>= 0.1.2), libspeex1 (>= 1.2.0), libssh2-1 (>= 1.2.3), libswscale6 (>= 5.0), libvorbis0a (>= 1.1.2), libx264-164, libx265-199 (>= 3.5), libxcb-keysyms1 (>= 0.4.0), libxcb1, libxml2 (>= 2.7.4), vlc-data (= @DEB_VLC_V@), libdvdcss2, libmpeg2-4 (>= 0.5.1), libluajit-5.1-2, libnfs14 (>= 5.0), libsmb2-1 (>= 4.0), libxcb-xfixes0, libsamplerate0, libxcb-render0, libxcb-shape0, libprotobuf-lite32 (>= 3.21)
+Enhances: vlc
+Recommends: xdg-utils 
+Section: Multimedia
+Maintainer: @DEB_MAINTAINER@
+Homepage: https://www.videolan.org/vlc/
+Description: multimedia player and streamer (base plugins)
+ VLC is the VideoLAN project's media player. It plays MPEG, MPEG-2, MPEG-4,
+ DivX, MOV, WMV, QuickTime, WebM, FLAC, MP3, Ogg/Vorbis files, DVDs, VCDs,
+ podcasts, and multimedia streams from various network sources.
+ .
+ This package contains most plugins which are shipped in more specialied 
+ plugin packages.

--- a/build_info/vlc-plugin-base.control.macosx
+++ b/build_info/vlc-plugin-base.control.macosx
@@ -1,0 +1,18 @@
+Package: vlc-plugin-base
+Version: @DEB_VLC_V@
+Architecture: @DEB_ARCH@
+Author: VideoLAN <videolan@videolan.org>
+Priority: optional
+Depends: vlc-plugin-abi-3-0-0f, libvlccore9 (>= @DEB_VLC_V@), libarchive13 (>= 3.1.2), libx264-164, libavutil57, libavformat59, libavcodec59, libass9 (>= 0.13.6), libdca0 (>= 0.0.5), libdav1d6, libdvdnav4 (>= 6.1.0), libdvdread8 (>= 6.1.0), libflac8 (>= 1.3.0), libfontconfig1 (>= 2.12.6), libfreetype6 (>= 2.2.1), libfribidi0 (>= 1.0.0), libglib2.0-0 (>= 2.28.0), libgnutls30 (>= 3.7.2), libharfbuzz0b (>= 0.9.4), libidn2-0, libjpeg62-turbo (>= 1.3.1), libmpg123-0 (>= 1.26.3), libncursesw6 (>= 6), libogg0 (>= 1.1.0), libopus0 (>= 1.1), libpostproc56 (>= 5.0), libprotobuf32 (>= 3.21.0), libsoxr0 (>= 0.1.2), libspeex1 (>= 1.2.0), libssh2-1 (>= 1.2.3), libswscale6 (>= 5.0), libvorbis0a (>= 1.1.2), libx264-164, libx265-199 (>= 3.5), libxcb-keysyms1 (>= 0.4.0), libxcb1, libxml2 (>= 2.7.4), vlc-data (= @DEB_VLC_V@), libdvdcss2, libmpeg2-4 (>= 0.5.1), libluajit-5.1-2, libnfs14 (>= 5.0), libsmb2-1 (>= 4.0), libbluray2 (>= 1.0.0), libaacs0 (>= 0.11), libxcb-xfixes0, libsamplerate0, libxcb-render0, libxcb-shape0, libprotobuf-lite32 (>= 3.21)
+Enhances: vlc
+Recommends: xdg-utils 
+Section: Multimedia
+Maintainer: @DEB_MAINTAINER@
+Homepage: https://www.videolan.org/vlc/
+Description: multimedia player and streamer (base plugins)
+ VLC is the VideoLAN project's media player. It plays MPEG, MPEG-2, MPEG-4,
+ DivX, MOV, WMV, QuickTime, WebM, FLAC, MP3, Ogg/Vorbis files, DVDs, VCDs,
+ podcasts, and multimedia streams from various network sources.
+ .
+ This package contains most plugins which are shipped in more specialied 
+ plugin packages.

--- a/build_info/vlc-plugin-video-output.control
+++ b/build_info/vlc-plugin-video-output.control
@@ -1,0 +1,16 @@
+Package: vlc-plugin-video-output
+Version: @DEB_VLC_V@
+Architecture: @DEB_ARCH@
+Author: VideoLAN <videolan@videolan.org>
+Priority: optional
+Enhances: vlc
+Depends: libx11-6, libxcb-keysyms1, libxcb-shm0, libxcb-xv0 (>= 1.2), libxcb1, libvlccore9 (>= @DEB_VLC_V@), vlc-plugin-abi-3-0-0f, libsm6, libgles2, libgl1, libice6 (>= 1.0.0), libcaca0 (>= 0.99.beta17-1), libavutil57 (>= 5.0), libavcodec59 (>= 5.0)
+Section: Multimedia
+Maintainer: @DEB_MAINTAINER@
+Homepage: https://www.videolan.org/vlc/
+Description: multimedia player and streamer (video output plugins)
+ VLC is the VideoLAN project's media player. It plays MPEG, MPEG-2, MPEG-4,
+ DivX, MOV, WMV, QuickTime, WebM, FLAC, MP3, Ogg/Vorbis files, DVDs, VCDs,
+ podcasts, and multimedia streams from various network sources.
+ .
+ This package contains the video output plugins.

--- a/build_info/vlc-plugin-video-splitter.control
+++ b/build_info/vlc-plugin-video-splitter.control
@@ -1,0 +1,16 @@
+Package: vlc-plugin-video-splitter
+Version: @DEB_VLC_V@
+Architecture: @DEB_ARCH@
+Author: VideoLAN <videolan@videolan.org>
+Priority: optional
+Enhances: vlc
+Depends: vlc-plugin-abi-3-0-0f, libxcb-randr0 (>= 1.1), libxcb1, libvlccore9 (>= @DEB_VLC_V@)
+Section: Multimedia
+Maintainer: @DEB_MAINTAINER@
+Homepage: https://www.videolan.org/vlc/
+Description: multimedia player and streamer (video splitter plugins)
+ VLC is the VideoLAN project's media player. It plays MPEG, MPEG-2, MPEG-4,
+ DivX, MOV, WMV, QuickTime, WebM, FLAC, MP3, Ogg/Vorbis files, DVDs, VCDs,
+ podcasts, and multimedia streams from various network sources.
+ .
+ This package contains the video splitter plugins.

--- a/build_info/vlc-plugin-visualization.control
+++ b/build_info/vlc-plugin-visualization.control
@@ -1,0 +1,16 @@
+Package: vlc-plugin-visualization
+Version: @DEB_VLC_V@
+Architecture: @DEB_ARCH@
+Author: VideoLAN <videolan@videolan.org>
+Priority: optional
+Enhances: vlc
+Depends: vlc-plugin-abi-3-0-0f, libgl1, libvlccore9 (>= @DEB_VLC_V@)
+Section: Multimedia
+Maintainer: @DEB_MAINTAINER@
+Homepage: https://www.videolan.org/vlc/
+Description: multimedia player and streamer (visualization plugins)
+ VLC is the VideoLAN project's media player. It plays MPEG, MPEG-2, MPEG-4,
+ DivX, MOV, WMV, QuickTime, WebM, FLAC, MP3, Ogg/Vorbis files, DVDs, VCDs,
+ podcasts, and multimedia streams from various network sources.
+ .
+ This package contains the visualization plugins.

--- a/build_info/vlc.app.control.macosx
+++ b/build_info/vlc.app.control.macosx
@@ -1,0 +1,12 @@
+Package: vlc.app
+Version: @DEB_VLC_V@
+Architecture: @DEB_ARCH@
+Author: VideoLAN <videolan@videolan.org>
+Priority: optional
+Depends: vlc-bin (= @DEB_VLC_V@), libvlc-bin (= @DEB_VLC_V@), vlc-data (= @DEB_VLC_V@), vlc-plugin-base (= @DEB_VLC_V@), vlc-plugin-video-output (= @DEB_VLC_V@)
+Recommends: vlc-l10n (= @DEB_VLC_V@), vlc-plugin-access-extra (= @DEB_VLC_V@), vlc-plugin-video-splitter (= @DEB_VLC_V@), vlc-plugin-visualization (= @DEB_VLC_V@)
+Section: Multimedia
+Maintainer: @DEB_MAINTAINER@
+Homepage: https://www.videolan.org/vlc/
+Description: VLC application bundle
+ This is the macOS .app bundle of VLC.

--- a/build_info/vlc.app.postinst.macosx
+++ b/build_info/vlc.app.postinst.macosx
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+case "$1" in
+	abort-upgrade)
+	mv @MEMO_PREFIX@/tmp/vlc.app_PkgInfo_sip_fs_workaround @MEMO_PREFIX@/Applications/VLC.app/Contents
+	;;
+esac
+
+ln -s @MEMO_PREFIX@/Applications/VLC.app /Applications/VLC.app
+exit 0

--- a/build_info/vlc.app.postrm.macosx
+++ b/build_info/vlc.app.postrm.macosx
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+case "$1" in
+	upgrade|failed-upgrade)
+	rm -f /tmp/vlc.app_PkgInfo_sip_fs_workaround
+	;;
+esac
+exit 0

--- a/build_info/vlc.app.prerm.macosx
+++ b/build_info/vlc.app.prerm.macosx
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+case "$1" in
+	upgrade|failed-upgrade)
+	mv @MEMO_PREFIX@/Applications/VLC.app/Contents/PkgInfo /tmp/vlc.app_PkgInfo_sip_fs_workaround
+	;;
+esac
+rm /Applications/VLC.app
+exit 0

--- a/build_info/vlc.control
+++ b/build_info/vlc.control
@@ -1,0 +1,29 @@
+Package: vlc
+Version: @DEB_VLC_V@
+Architecture: @DEB_ARCH@
+Author: VideoLAN <videolan@videolan.org>
+Priority: optional
+Section: Multimedia
+Maintainer: @DEB_MAINTAINER@
+Provides: mp3-decoder
+Depends: vlc-bin (= @DEB_VLC_V@)
+Recommends: vlc-l10n (= @DEB_VLC_V@), vlc-plugin-access-extra (= @DEB_VLC_V@), vlc-plugin-notify (= @DEB_VLC_V@), vlc-plugin-samba (= @DEB_VLC_V@), vlc-plugin-skins2 (= @DEB_VLC_V@), vlc-plugin-video-splitter (= @DEB_VLC_V@), vlc-plugin-visualization (= @DEB_VLC_V@)
+Suggests: vlc-plugin-fluidsynth (= @DEB_VLC_V@), vlc-plugin-jack (= @DEB_VLC_V@), vlc-plugin-svg (= @DEB_VLC_V@)
+Homepage: https://www.videolan.org/vlc/
+Description: multimedia player and streamer
+ VLC is the VideoLAN project's media player. It plays MPEG, MPEG-2, MPEG-4,
+ DivX, MOV, WMV, QuickTime, WebM, FLAC, MP3, Ogg/Vorbis files, DVDs, VCDs,
+ podcasts, and multimedia streams from various network sources.
+ .
+ VLC can also be used as a streaming server that duplicates the stream it
+ reads and multicasts them through the network to other clients, or serves
+ them through HTTP.
+ .
+ VLC has support for on-the-fly transcoding of audio and video formats, either
+ for broadcasting purposes or for movie format transformations. Support for
+ most output methods is provided by this package, but features can be added by
+ installing additional plugins:
+  * vlc-plugin-access-extra
+  * vlc-plugin-video-output
+  * vlc-plugin-video-splitter
+  * vlc-plugin-visualization

--- a/build_misc/entitlements/vlc-macos.xml
+++ b/build_misc/entitlements/vlc-macos.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<false/>
+	<key>com.apple.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.assets.movies.read-write</key>
+	<true/>
+	<key>com.apple.security.assets.music.read-write</key>
+	<true/>
+	<key>com.apple.security.assets.pictures.read-write</key>
+	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
+	<key>com.apple.security.device.microphone</key>
+	<true/>
+	<key>com.apple.security.device.usb</key>
+	<true/>
+	<key>com.apple.security.device.serial</key>
+	<true/>
+	<key>com.apple.security.files.downloads.read-write</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
+	<key>com.apple.security.temporary-exception.files.home-relative-path.read-only</key>
+	<string>/</string>
+	<key>com.apple.security.temporary-exception.files.absolute-path.read-only</key>
+	<string>/tmp/</string>
+	<key>com.apple.security.temporary-exception.apple-events</key>
+	<string>com.Growl.GrowlHelperApp</string>
+	<key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
+	<string>GrowlApplicationBridgePathway</string>
+</dict>
+</plist>

--- a/build_misc/entitlements/vlc.xml
+++ b/build_misc/entitlements/vlc.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>platform-application</key>
+	<true/>
+	<key>dynamic-codesigning</key>
+	<true/>
+	<key>com.apple.private.security.container-required</key>
+	<true/>
+	<key>com.apple.security.exception.files.absolute-path.read-write</key>
+	<array>
+		<string>/</string>
+	</array>	
+	<key>com.apple.private.skip-library-validation</key>
+	<true/>
+	<key>com.apple.security.assets.movies.read-write</key>
+	<true/>
+	<key>com.apple.security.assets.music.read-write</key>
+	<true/>
+	<key>com.apple.security.assets.pictures.read-write</key>
+	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
+	<key>com.apple.security.device.microphone</key>
+	<true/>
+	<key>com.apple.security.device.usb</key>
+	<true/>
+	<key>com.apple.security.device.serial</key>
+	<true/>
+	<key>com.apple.security.files.downloads.read-write</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
+	<key>com.apple.security.temporary-exception.files.home-relative-path.read-only</key>
+	<string>/</string>
+	<key>com.apple.security.temporary-exception.files.absolute-path.read-only</key>
+	<string>/tmp/</string>
+	<key>com.apple.security.temporary-exception.apple-events</key>
+	<string>com.Growl.GrowlHelperApp</string>
+	<key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
+	<string>GrowlApplicationBridgePathway</string>
+</dict>
+</plist>

--- a/build_misc/vlc/libvlcmodname.c
+++ b/build_misc/vlc/libvlcmodname.c
@@ -1,0 +1,1 @@
+const char vlc_module_name[] = "libvlc";

--- a/build_patch/libbluray/configure.ac..diff
+++ b/build_patch/libbluray/configure.ac..diff
@@ -1,0 +1,18 @@
+diff -urN a/configure.ac b/configure.ac
+--- a/configure.ac	2021-04-05 22:12:22.000000000 +0800
++++ b/configure.ac	2021-05-11 21:29:21.481708422 +0800
+@@ -173,14 +173,6 @@
+   LIBS="$saved_LIBS"
+ ])
+ 
+-dnl libxml2 for metadata parser
+-AS_IF([test "x$with_libxml2" != "xno"], [
+-  PKG_CHECK_MODULES([LIBXML2], [libxml-2.0 >= 2.6],
+-    [with_libxml2=yes; AC_DEFINE([HAVE_LIBXML2], [1],
+-        [Define to 1 if libxml2 is to be used for metadata parsing])])
+-  PACKAGES="$PACKAGES libxml-2.0 >= 2.6"
+-])
+-
+ dnl FreeType2
+ AS_IF([test "x$with_freetype" != "xno"], [
+   PKG_CHECK_MODULES([FT2], [freetype2],

--- a/build_patch/vlc-ios/mac-screen.diff
+++ b/build_patch/vlc-ios/mac-screen.diff
@@ -1,0 +1,15 @@
+diff -urN a/modules/access/Makefile.am d/modules/access/Makefile.am
+--- a/modules/access/Makefile.am	2022-02-21 17:19:30.000000000 +0800
++++ d/modules/access/Makefile.am	2022-06-05 07:11:43.309485688 +0800
+@@ -182,11 +182,6 @@
+ libscreen_plugin_la_LIBADD = -lgdi32
+ access_LTLIBRARIES += libscreen_plugin.la
+ endif
+-if HAVE_MAC_SCREEN
+-libscreen_plugin_la_SOURCES += access/screen/mac.c
+-libscreen_plugin_la_LDFLAGS += "-Wl,-framework,OpenGL,-framework,ApplicationServices"
+-access_LTLIBRARIES += libscreen_plugin.la
+-endif
+ 
+ librdp_plugin_la_SOURCES = access/rdp.c
+ librdp_plugin_la_CFLAGS = $(AM_CFLAGS) $(FREERDP_CFLAGS)

--- a/build_patch/vlc/atomics.diff
+++ b/build_patch/vlc/atomics.diff
@@ -1,0 +1,18 @@
+diff -urN a/include/vlc_atomic.h b/include/vlc_atomic.h
+--- a/include/vlc_atomic.h	2017-12-21 17:51:16.000000000 +0800
++++ b/include/vlc_atomic.h	2022-06-05 00:48:37.219429368 +0800
+@@ -34,11 +34,13 @@
+ #endif
+ 
+ # ifndef __cplusplus
+-#  if !defined (__STDC_NO_ATOMICS__)
++#  if 0
+ /*** Native C11 atomics ***/
+ #   include <stdatomic.h>
+ 
+ #  else
++#include <stdbool.h>
++#include <stdint.h>
+ /*** Intel/GCC atomics ***/
+ 
+ #  define ATOMIC_FLAG_INIT false

--- a/build_patch/vlc/libtool.diff
+++ b/build_patch/vlc/libtool.diff
@@ -1,0 +1,12 @@
+diff -urN a/modules/Makefile.am b/modules/Makefile.am
+--- a/modules/Makefile.am	2017-11-30 07:35:29.000000000 +0800
++++ b/modules/Makefile.am	2021-05-22 11:29:50.000000000 +0800
+@@ -58,7 +58,7 @@
+ include mux/Makefile.am
+ include stream_out/Makefile.am
+ endif
+-
++AM_LIBTOOLFLAGS = --tag=CC
+ BUILT_SOURCES += dummy.cpp
+ 
+ dummy.cpp:

--- a/makefiles/aom.mk
+++ b/makefiles/aom.mk
@@ -19,6 +19,7 @@ aom: aom-setup
 		-DBUILD_SHARED_LIBS=1 \
 		-DCONFIG_RUNTIME_CPU_DETECT=0 \
 		-DENABLE_TESTS=0 \
+		-DENABLE_DOCS=0 \
 		-DGIT_EXECUTABLE=/non-existant-binary \
 		-DAOM_TARGET_CPU="$(MEMO_ARCH)" \
 		..

--- a/makefiles/libaacs.mk
+++ b/makefiles/libaacs.mk
@@ -1,0 +1,54 @@
+ifneq ($(PROCURSUS),1)
+$(error Use the main Makefile)
+endif
+
+ifneq (,$(findstring darwin,$(MEMO_TARGET)))
+SUBPROJECTS     += libaacs
+LIBAACS_VERSION := 0.11.1
+DEB_LIBAACS_V   ?= $(LIBAACS_VERSION)
+
+libaacs-setup: setup
+	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://download.videolan.org/pub/videolan/libaacs/$(LIBAACS_VERSION)/libaacs-$(LIBAACS_VERSION).tar.bz2{$(comma).sha512})
+	$(call CHECKSUM_VERIFY,sha512,libaacs-$(LIBAACS_VERSION).tar.bz2)
+	$(call EXTRACT_TAR,libaacs-$(LIBAACS_VERSION).tar.bz2,libaacs-$(LIBAACS_VERSION),libaacs)
+
+ifneq ($(wildcard $(BUILD_WORK)/libaacs/.build_complete),)
+libaacs:
+	@echo "Using previously built libaacs."
+else
+libaacs: libgcrypt gnupg libaacs-setup
+	cd $(BUILD_WORK)/libaacs && ./bootstrap && ./configure -C \
+		$(DEFAULT_CONFIGURE_FLAGS) \
+		--with-libgcrypt-prefix=$(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX) \
+		--with-libgpg-error-prefix=$(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)
+	+$(MAKE) -C $(BUILD_WORK)/libaacs
+	+$(MAKE) -C $(BUILD_WORK)/libaacs install \
+		DESTDIR=$(BUILD_STAGE)/libaacs
+	$(call AFTER_BUILD,copy)
+endif
+
+libaacs-package: libaacs-stage
+	# libaacs.mk Package Structure
+	rm -rf $(BUILD_DIST)/libaacs
+	mkdir -p $(BUILD_DIST)/libaacs{0,-dev}/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
+
+	# libaacs.mk Prep libaacs0
+	cp -a $(BUILD_STAGE)/libaacs/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/libaacs.0.dylib $(BUILD_DIST)/libaacs0/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
+	cp -a $(BUILD_STAGE)/libaacs/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin $(BUILD_DIST)/libaacs0/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)
+
+	# libaacs.mk Prep libaacs-dev
+	cp -a $(BUILD_STAGE)/libaacs/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/{libaacs.{a,dylib},pkgconfig} $(BUILD_DIST)/libaacs-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
+	cp -a $(BUILD_STAGE)/libaacs/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include $(BUILD_DIST)/libaacs-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)
+
+	# libaacs.mk Sign
+	$(call SIGN,libaacs0,general.xml)
+
+	# libaacs.mk Make .debs
+	$(call PACK,libaacs0,DEB_LIBAACS_V)
+	$(call PACK,libaacs-dev,DEB_LIBAACS_V)
+
+	# libaacs.mk Build cleanup
+	rm -rf $(BUILD_DIST)/libaacs{0,-dev}
+
+.PHONY: libaacs libaacs-package
+endif

--- a/makefiles/libbdplus.mk
+++ b/makefiles/libbdplus.mk
@@ -1,0 +1,61 @@
+ifneq ($(PROCURSUS),1)
+$(error Use the main Makefile)
+endif
+
+SUBPROJECTS       += libbdplus
+LIBBDPLUS_VERSION := 0.2.0
+DEB_LIBBDPLUS_V   ?= $(LIBBDPLUS_VERSION)
+
+libbdplus-setup: setup
+	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),http://download.videolan.org/pub/videolan/libbdplus/$(LIBBDPLUS_VERSION)/libbdplus-$(LIBBDPLUS_VERSION).tar.bz2{$(comma).sha512})
+	$(call CHECKSUM_VERIFY,sha512,libbdplus-$(LIBBDPLUS_VERSION).tar.bz2)
+	$(call EXTRACT_TAR,libbdplus-$(LIBBDPLUS_VERSION).tar.bz2,libbdplus-$(LIBBDPLUS_VERSION),libbdplus)
+
+# This makes it easier to define dependencies later
+ifneq (,$(findstring darwin,$(MEMO_TARGET)))
+LIBBDPLUS_DEPS := libgcrypt gnupg libaacs
+LIBBDPLUS_OPTS := --with-libaacs
+else
+LIBBDPLUS_DEPS := libgcrypt gnupg
+LIBBDPLUS_OPTS := --without-libaacs
+endif
+
+ifneq ($(wildcard $(BUILD_WORK)/libbdplus/.build_complete),)
+libbdplus:
+	@echo "Using previously built libbdplus."
+else
+libbdplus: libbdplus-setup $(LIBBDPLUS_DEPS)
+	cd $(BUILD_WORK)/libbdplus && ./configure -C \
+		$(DEFAULT_CONFIGURE_FLAGS) \
+		$(LIBBDPLUS_OPTS) \
+		--with-libgcrypt-prefix=$(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX) \
+		--with-gpg-error-prefix=$(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)
+	+$(MAKE) -C $(BUILD_WORK)/libbdplus
+	+$(MAKE) -C $(BUILD_WORK)/libbdplus install \
+		DESTDIR=$(BUILD_STAGE)/libbdplus
+	$(call AFTER_BUILD,copy)
+endif
+
+libbdplus-package: libbdplus-stage
+	# libbdplus.mk Package Structure
+	rm -rf $(BUILD_DIST)/libbdplus{0,-dev}
+	mkdir -p $(BUILD_DIST)/libbdplus{0,-dev}/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
+
+	# libbdplus.mk Prep libbdplus0
+	cp -a $(BUILD_STAGE)/libbdplus/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/libbdplus.0.dylib $(BUILD_DIST)/libbdplus0/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
+
+	# libbdplus.mk Prep libbdplus-dev
+	cp -a $(BUILD_STAGE)/libbdplus/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/{libbdplus.{a,dylib},pkgconfig} $(BUILD_DIST)/libbdplus-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
+	cp -a $(BUILD_STAGE)/libbdplus/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include $(BUILD_DIST)/libbdplus-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)
+
+	# libbdplus.mk Sign
+	$(call SIGN,libbdplus0,general.xml)
+
+	# libbdplus.mk Make .debs
+	$(call PACK,libbdplus0,DEB_LIBBDPLUS_V)
+	$(call PACK,libbdplus-dev,DEB_LIBBDPLUS_V)
+
+	# libbdplus.mk Build cleanup
+	rm -rf $(BUILD_DIST)/libbdplus0
+
+.PHONY: libbdplus libbdplus-package

--- a/makefiles/libbluray.mk
+++ b/makefiles/libbluray.mk
@@ -1,0 +1,70 @@
+ifneq ($(PROCURSUS),1)
+$(error Use the main Makefile)
+endif
+
+ifneq (,$(findstring darwin,$(MEMO_TARGET)))
+
+SUBPROJECTS       += libbluray
+LIBBLURAY_VERSION := 1.3.3
+DEB_LIBBLURAY_V   ?= $(LIBBLURAY_VERSION)
+
+libbluray-setup: setup
+	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://download.videolan.org/pub/videolan/libbluray/$(LIBBLURAY_VERSION)/libbluray-$(LIBBLURAY_VERSION).tar.bz2{$(comma).sha512})
+	$(call CHECKSUM_VERIFY,sha512,libbluray-$(LIBBLURAY_VERSION).tar.bz2)
+	$(call EXTRACT_TAR,libbluray-$(LIBBLURAY_VERSION).tar.bz2,libbluray-$(LIBBLURAY_VERSION),libbluray)
+	$(call DO_PATCH,libbluray,libbluray,-p1)
+
+ifneq ($(call HAS_COMMAND,ant),1)
+libbluray:
+	$(error Install ant)
+
+else ifneq ($(wildcard $(BUILD_WORK)/libbluray/.build_complete),)
+libbluray:
+	@echo "Using previously built libbluray."
+else
+libbluray: fontconfig expat libbluray-setup
+	cd $(BUILD_WORK)/libbluray && ./bootstrap && ./configure -C \
+		$(DEFAULT_CONFIGURE_FLAGS)
+	+$(MAKE) -C $(BUILD_WORK)/libbluray
+	+$(MAKE) -C $(BUILD_WORK)/libbluray install \
+		DESTDIR=$(BUILD_STAGE)/libbluray
+	$(call AFTER_BUILD,copy)
+endif
+
+libbluray-package: libbluray-stage
+	# libbluray.mk Package Structure
+	rm -rf $(BUILD_DIST)/libbluray{2,-dev,-bin,-bdj}
+	mkdir -p $(BUILD_DIST)/libbluray{2,-dev,-bin,-bdj}/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)
+	mkdir -p $(BUILD_DIST)/libbluray{2,-dev}/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
+	mkdir -p $(BUILD_DIST)/libbluray-bdj/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share
+	mkdir -p $(BUILD_DIST)/libbluray-bin/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin
+
+	# libbluray.mk Prep libbluray2
+	cp -a $(BUILD_STAGE)/libbluray/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/libbluray.2.dylib $(BUILD_DIST)/libbluray2/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
+
+	# libbluray.mk Prep libbluray-dev
+	cp -a $(BUILD_STAGE)/libbluray/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include $(BUILD_DIST)/libbluray-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)
+	cp -a $(BUILD_STAGE)/libbluray/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/{libbluray.{dylib,a},pkgconfig} $(BUILD_DIST)/libbluray-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
+
+	# libbluray.mk Prep libbluray-bin
+	cp -a $(BUILD_STAGE)/libbluray/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin $(BUILD_DIST)/libbluray-bin/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)
+
+	# libbluray.mk Prep libbluray-bdj
+	cp -a $(BUILD_STAGE)/libbluray/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/java $(BUILD_DIST)/libbluray-bdj/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share
+
+	# libbluray.mk Sign
+	$(call SIGN,libbluray2,general.xml)
+	$(call SIGN,libbluray-bin,general.xml)
+
+	# libbluray.mk Make .debs
+	$(call PACK,libbluray2,DEB_LIBBLURAY_V)
+	$(call PACK,libbluray-dev,DEB_LIBBLURAY_V)
+	$(call PACK,libbluray-bin,DEB_LIBBLURAY_V)
+	$(call PACK,libbluray-bdj,DEB_LIBBLURAY_V)
+
+	# libbluray.mk Build cleanup
+	rm -rf $(BUILD_DIST)/libbluray{2,-dev,-bin,-bdj}
+
+.PHONY: libbluray libbluray-package
+
+endif

--- a/makefiles/libcaca.mk
+++ b/makefiles/libcaca.mk
@@ -40,7 +40,7 @@ libcaca-package: libcaca-stage
 
 	# libcaca.mk Prep caca-utils
 	cp -a $(BUILD_STAGE)/libcaca/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin $(BUILD_DIST)/caca-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)
-	cp -a $(BUILD_STAGE)/libcaca/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/man/man1/!(caca-config.1) $(BUILD_DIST)/caca-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/man/man1
+	cp -a $(BUILD_STAGE)/libcaca/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/man/man1/!(caca-config.1$(MEMO_MANPAGE_SUFFIX)) $(BUILD_DIST)/caca-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/man/man1
 	cp -a $(BUILD_STAGE)/libcaca/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/caca-config $(BUILD_DIST)/caca-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin
 
 	# libcaca.mk Prep libcaca0
@@ -52,7 +52,7 @@ libcaca-package: libcaca-stage
 	cp -a $(BUILD_STAGE)/libcaca/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/{libcaca{,++}.{a,dylib},pkgconfig} $(BUILD_DIST)/libcaca-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
 	cp -a $(BUILD_STAGE)/libcaca/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include $(BUILD_DIST)/libcaca-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)
 	cp -a $(BUILD_STAGE)/libcaca/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/caca-config $(BUILD_DIST)/libcaca-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin
-	cp -a $(BUILD_STAGE)/libcaca/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/man/man1/caca-config.1 $(BUILD_DIST)/libcaca-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/man/man1
+	cp -a $(BUILD_STAGE)/libcaca/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/man/man1/caca-config.1$(MEMO_MANPAGE_SUFFIX) $(BUILD_DIST)/libcaca-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/man/man1
 
 	# libcaca.mk Sign
 	$(call SIGN,caca-utils,general.xml)

--- a/makefiles/libdvdnav.mk
+++ b/makefiles/libdvdnav.mk
@@ -1,0 +1,51 @@
+ifneq ($(PROCURSUS),1)
+$(error Use the main Makefile)
+endif
+
+SUBPROJECTS       += libdvdnav
+LIBDVDNAV_VERSION := 6.1.1
+DEB_LIBDVDNAV_V   ?= $(LIBDVDNAV_VERSION)
+
+libdvdnav-setup: setup
+	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://download.videolan.org/pub/videolan/libdvdnav/$(LIBDVDNAV_VERSION)/libdvdnav-$(LIBDVDNAV_VERSION).tar.bz2{$(comma).asc})
+	$(call PGP_VERIFY,libdvdnav-$(LIBDVDNAV_VERSION).tar.bz2,asc)
+	$(call EXTRACT_TAR,libdvdnav-$(LIBDVDNAV_VERSION).tar.bz2,libdvdnav-$(LIBDVDNAV_VERSION),libdvdnav)
+
+ifneq ($(wildcard $(BUILD_WORK)/libdvdnav/.build_complete),)
+libdvdnav:
+	@echo "Using previously built libdvdnav."
+else
+libdvdnav: libdvdnav-setup libdvdread
+	cd $(BUILD_WORK)/libdvdnav && ./configure -C \
+		$(DEFAULT_CONFIGURE_FLAGS)
+	+$(MAKE) -C $(BUILD_WORK)/libdvdnav
+	+$(MAKE) -C $(BUILD_WORK)/libdvdnav install \
+		DESTDIR=$(BUILD_STAGE)/libdvdnav
+	$(call AFTER_BUILD,copy)
+endif
+
+libdvdnav-package: libdvdnav-stage
+	# libdvdnav.mk Package Structure
+	rm -rf $(BUILD_DIST)/libdvdnav{4-dev}
+	mkdir -p $(BUILD_DIST)/libdvdnav{4,-dev}/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
+	mkdir -p $(BUILD_DIST)/libdvdnav4/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/doc
+
+	# libdvdnav.mk Prep libdvdnav
+	cp -a $(BUILD_STAGE)/libdvdnav/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/libdvdnav.4.dylib $(BUILD_DIST)/libdvdnav4/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
+	cp -a $(BUILD_STAGE)/libdvdnav/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/doc/libdvdnav $(BUILD_DIST)/libdvdnav4/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/doc/libdvdnav4
+
+	# libdvdnav.mk Prep libdvdnav-dev
+	cp -a $(BUILD_STAGE)/libdvdnav/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include $(BUILD_DIST)/libdvdnav-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)
+	cp -a $(BUILD_STAGE)/libdvdnav/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/{libdvdnav.{dylib,la,a},pkgconfig} $(BUILD_DIST)/libdvdnav-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
+
+	# libdvdnav.mk Sign
+	$(call SIGN,libdvdnav4,general.xml)
+
+	# libdvdnav.mk Make .debs
+	$(call PACK,libdvdnav4,DEB_LIBDVDNAV_V)
+	$(call PACK,libdvdnav-dev,DEB_LIBDVDNAV_V)
+
+	# libdvdnav.mk Build cleanup
+	rm -rf $(BUILD_DIST)/libdvdnav{4,-dev}
+
+.PHONY: libdvdnav libdvdnav-package

--- a/makefiles/libdvdread.mk
+++ b/makefiles/libdvdread.mk
@@ -1,0 +1,49 @@
+ifneq ($(PROCURSUS),1)
+$(error Use the main Makefile)
+endif
+
+SUBPROJECTS        += libdvdread
+LIBDVDREAD_VERSION := 6.1.3
+DEB_LIBDVDREAD_V   ?= $(LIBDVDREAD_VERSION)
+
+libdvdread-setup: setup
+	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://download.videolan.org/pub/videolan/libdvdread/$(LIBDVDREAD_VERSION)/libdvdread-$(LIBDVDREAD_VERSION).tar.bz2{$(comma).asc})
+	$(call PGP_VERIFY,libdvdread-$(LIBDVDREAD_VERSION).tar.bz2,asc)
+	$(call EXTRACT_TAR,libdvdread-$(LIBDVDREAD_VERSION).tar.bz2,libdvdread-$(LIBDVDREAD_VERSION),libdvdread)
+
+ifneq ($(wildcard $(BUILD_WORK)/libdvdread/.build_complete),)
+libdvdread:
+	@echo "Using previously built libdvdread."
+else
+libdvdread: libdvdread-setup
+	cd $(BUILD_WORK)/libdvdread && ./configure -C \
+		$(DEFAULT_CONFIGURE_FLAGS)
+	+$(MAKE) -C $(BUILD_WORK)/libdvdread
+	+$(MAKE) -C $(BUILD_WORK)/libdvdread install \
+		DESTDIR=$(BUILD_STAGE)/libdvdread
+	$(call AFTER_BUILD,copy)
+endif
+
+libdvdread-package: libdvdread-stage
+	# libdvdread.mk Package Structure
+	rm -rf $(BUILD_DIST)/libdvdread{8,-dev}
+	mkdir -p $(BUILD_DIST)/libdvdread{8,-dev}/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
+
+	# libdvdread.mk Prep libdvdread8
+	cp -a $(BUILD_STAGE)/libdvdread/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/libdvdread.8.dylib $(BUILD_DIST)/libdvdread8/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
+
+	# libdvdread.mk Prep libdvdread-dev
+	cp -a $(BUILD_STAGE)/libdvdread/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include $(BUILD_DIST)/libdvdread-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)
+	cp -a $(BUILD_STAGE)/libdvdread/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/{libdvdread.{dylib,la,a},pkgconfig} $(BUILD_DIST)/libdvdread-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
+
+	# libdvdread.mk Sign
+	$(call SIGN,libdvdread8,general.xml)
+
+	# libdvdread.mk Make .debs
+	$(call PACK,libdvdread8,DEB_LIBDVDREAD_V)
+	$(call PACK,libdvdread-dev,DEB_LIBDVDREAD_V)
+
+	# libdvdread.mk Build cleanup
+	rm -rf $(BUILD_DIST)/libdvdread{8,-dev}
+
+.PHONY: libdvdread libdvdread-package

--- a/makefiles/libmpeg2.mk
+++ b/makefiles/libmpeg2.mk
@@ -1,0 +1,56 @@
+ifneq ($(PROCURSUS),1)
+$(error Use the main Makefile)
+endif
+
+SUBPROJECTS      += libmpeg2
+LIBMPEG2_VERSION := 0.5.1
+DEB_LIBMPEG2_V   ?= $(LIBMPEG2_VERSION)
+
+libmpeg2-setup: setup
+	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://libmpeg2.sourceforge.io/files/libmpeg2-$(LIBMPEG2_VERSION).tar.gz)
+	$(call EXTRACT_TAR,libmpeg2-$(LIBMPEG2_VERSION).tar.gz,libmpeg2-$(LIBMPEG2_VERSION),libmpeg2)
+
+ifneq ($(wildcard $(BUILD_WORK)/libmpeg2/.build_complete),)
+libmpeg2:
+	@echo "Using previously built libmpeg2."
+else
+libmpeg2: libmpeg2-setup libx11 libxext
+	cd $(BUILD_WORK)/libmpeg2 && autoreconf -fi && ./configure -C \
+		$(DEFAULT_CONFIGURE_FLAGS) \
+		CFLAGS="-std=gnu89 $(CFLAGS)"
+	+$(MAKE) -C $(BUILD_WORK)/libmpeg2
+	+$(MAKE) -C $(BUILD_WORK)/libmpeg2 install \
+		DESTDIR=$(BUILD_STAGE)/libmpeg2
+	$(call AFTER_BUILD,copy)
+endif
+
+libmpeg2-package: libmpeg2-stage
+	# libmpeg2.mk Package Structure
+	rm -rf $(BUILD_DIST)/{libmpeg2-4{,-dev},mpeg2dec}
+	mkdir -p $(BUILD_DIST)/libmpeg2-4{,-dev}/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
+	mkdir -p $(BUILD_DIST)/mpeg2dec/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/{bin,share/man/man1}
+
+	# libmpeg2.mk Prep libmpeg2-4
+	cp -a $(BUILD_STAGE)/libmpeg2/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/libmpeg2{,convert}.0.dylib $(BUILD_DIST)/libmpeg2-4/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
+
+	# libmpeg2.mk Prep libmpeg2-4-dev
+	cp -a $(BUILD_STAGE)/libmpeg2/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include $(BUILD_DIST)/libmpeg2-4-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)
+	cp -a $(BUILD_STAGE)/libmpeg2/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/{pkgconfig,libmpeg2{,convert}.{dylib,a}} $(BUILD_DIST)/libmpeg2-4-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
+
+	# libmpeg2.mk Prep mpeg2dec
+	cp -a $(BUILD_STAGE)/libmpeg2/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/{mpeg2dec,extract_mpeg2} $(BUILD_DIST)/mpeg2dec/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin
+	cp -a $(BUILD_STAGE)/libmpeg2/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/man/man1/{mpeg2dec,extract_mpeg2}.1$(MEMO_MANPAGE_SUFFIX) $(BUILD_DIST)/mpeg2dec/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/man/man1
+
+	# libmpeg2.mk Sign
+	$(call SIGN,libmpeg2-4,general.xml)
+	$(call SIGN,mpeg2dec,general.xml)
+
+	# libmpeg2.mk Make .debs
+	$(call PACK,libmpeg2-4,DEB_LIBMPEG2_V)
+	$(call PACK,libmpeg2-4-dev,DEB_LIBMPEG2_V)
+	$(call PACK,mpeg2dec,DEB_LIBMPEG2_V)
+
+	# libmpeg2.mk Build cleanup
+	rm -rf $(BUILD_DIST)/{libmpeg2-4{,-dev},mpeg2dec}
+
+.PHONY: libmpeg2 libmpeg2-package

--- a/makefiles/libnfs.mk
+++ b/makefiles/libnfs.mk
@@ -1,0 +1,58 @@
+ifneq ($(PROCURSUS),1)
+$(error Use the main Makefile)
+endif
+
+SUBPROJECTS    += libnfs
+LIBNFS_VERSION := 5.0.2
+DEB_LIBNFS_V   ?= $(LIBNFS_VERSION)
+
+libnfs-setup: setup
+	$(call GITHUB_ARCHIVE,sahlberg,libnfs,$(LIBNFS_VERSION),libnfs-$(LIBNFS_VERSION))
+	$(call EXTRACT_TAR,libnfs-$(LIBNFS_VERSION).tar.gz,libnfs-libnfs-$(LIBNFS_VERSION),libnfs)
+
+ifneq ($(wildcard $(BUILD_WORK)/libnfs/.build_complete),)
+libnfs:
+	@echo "Using previously built libnfs."
+else
+libnfs: libnfs-setup
+	cd $(BUILD_WORK)/libnfs && autoreconf -fi && ./configure -C \
+		$(DEFAULT_CONFIGURE_FLAGS) \
+		--enable-utils \
+		--enable-pthread \
+		--disable-examples \
+		--disable-werror
+	+$(MAKE) -C $(BUILD_WORK)/libnfs
+	+$(MAKE) -C $(BUILD_WORK)/libnfs install \
+		DESTDIR="$(BUILD_STAGE)/libnfs"
+	$(call AFTER_BUILD,copy)
+endif
+
+libnfs-package: libnfs-stage
+	# libnfs.mk Package Structure
+	rm -rf $(BUILD_DIST)/libnfs{14,-dev,-utils}
+	mkdir -p $(BUILD_DIST)/libnfs{14,-dev,-utils}/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)
+	mkdir -p $(BUILD_DIST)/libnfs{14,-dev}/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
+
+	# libnfs.mk Prep libnfs14
+	cp -a $(BUILD_STAGE)/libnfs/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/libnfs.14.dylib $(BUILD_DIST)/libnfs14/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
+
+	# libnfs.mk Prep libnfs-dev
+	cp -a $(BUILD_STAGE)/libnfs/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/{libnfs.{dylib,a},pkgconfig} $(BUILD_DIST)/libnfs-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
+	cp -a $(BUILD_STAGE)/libnfs/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include $(BUILD_DIST)/libnfs-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)
+
+	# libnfs.mk Prep libnfs-utils
+	cp -a $(BUILD_STAGE)/libnfs/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/{bin,share} $(BUILD_DIST)/libnfs-utils/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)
+
+	# libnfs.mk Sign
+	$(call SIGN,libnfs14,general.xml)
+	$(call SIGN,libnfs-utils,general.xml)
+
+	# libnfs.mk Make .debs
+	$(call PACK,libnfs14,DEB_LIBNFS_V)
+	$(call PACK,libnfs-dev,DEB_LIBNFS_V)
+	$(call PACK,libnfs-utils,DEB_LIBNFS_V)
+
+	# libnfs.mk Build cleanup
+	rm -rf $(BUILD_DIST)/libnfs{14,-dev,-utils}
+
+.PHONY: libnfs libnfs-package

--- a/makefiles/libsmb2.mk
+++ b/makefiles/libsmb2.mk
@@ -1,0 +1,52 @@
+ifneq ($(PROCURSUS),1)
+$(error Use the main Makefile)
+endif
+
+SUBPROJECTS     += libsmb2
+LIBSMB2_VERSION := 4.0.0
+DEB_LIBSMB2_V   ?= $(LIBSMB2_VERSION)
+
+libsmb2-setup: setup
+	$(call GITHUB_ARCHIVE,sahlberg,libsmb2,$(LIBSMB2_VERSION),v$(LIBSMB2_VERSION))
+	$(call EXTRACT_TAR,libsmb2-$(LIBSMB2_VERSION).tar.gz,libsmb2-$(LIBSMB2_VERSION),libsmb2)
+	sed -i '/DHAVE_LIBKRB5/d' $(BUILD_WORK)/libsmb2/CMakeLists.txt # NO
+	mkdir -p $(BUILD_WORK)/libsmb2/build
+
+ifneq ($(wildcard $(BUILD_WORK)/libsmb2/.build_complete),)
+libsmb2:
+	@echo "Using previously built libsmb2."
+else
+libsmb2: libsmb2-setup openssl
+	cd $(BUILD_WORK)/libsmb2/build && cmake \
+		$(DEFAULT_CMAKE_FLAGS) \
+		-DBUILD_SHARED_LIBS=ON \
+		..
+	+$(MAKE) -C $(BUILD_WORK)/libsmb2/build
+	+$(MAKE) -C $(BUILD_WORK)/libsmb2/build install \
+		DESTDIR="$(BUILD_STAGE)/libsmb2"
+	$(call AFTER_BUILD,copy)
+endif
+
+libsmb2-package: libsmb2-stage
+	# libsmb2.mk Package Structure
+	rm -rf $(BUILD_DIST)/libsmb2-{1,dev}
+	mkdir -p $(BUILD_DIST)/libsmb2-{1,dev}/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
+
+	# libsmb2.mk Prep libsmb2-1
+	cp -a $(BUILD_STAGE)/libsmb2/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/libsmb2.{1,$(LIBSMB2_VERSION)}.dylib $(BUILD_DIST)/libsmb2-1/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
+
+	# libsmb2.mk Prep libsmb2-dev
+	cp -a $(BUILD_STAGE)/libsmb2/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/{libsmb2.dylib,pkgconfig,cmake} $(BUILD_DIST)/libsmb2-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
+	cp -a $(BUILD_STAGE)/libsmb2/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include $(BUILD_DIST)/libsmb2-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)
+
+	# libsmb2.mk Sign
+	$(call SIGN,libsmb2-1,general.xml)
+
+	# libsmb2.mk Make .debs
+	$(call PACK,libsmb2-1,DEB_LIBSMB2_V)
+	$(call PACK,libsmb2-dev,DEB_LIBSMB2_V)
+
+	# libsmb2.mk Build cleanup
+	rm -rf $(BUILD_DIST)/libsmb2-{1,dev}
+
+.PHONY: libsmb2 libsmb2-package

--- a/makefiles/libsodium.mk
+++ b/makefiles/libsodium.mk
@@ -7,7 +7,8 @@ LIBSODIUM_VERSION     := 1.0.18
 DEB_LIBSODIUM_V       ?= $(LIBSODIUM_VERSION)
 
 libsodium-setup: setup
-	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://download.libsodium.org/libsodium/releases/libsodium-$(LIBSODIUM_VERSION).tar.gz)
+	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://download.libsodium.org/libsodium/releases/libsodium-$(LIBSODIUM_VERSION).tar.gz{$(comma).sig})
+	$(call PGP_VERIFY,libsodium-$(LIBSODIUM_VERSION).tar.gz)
 	$(call EXTRACT_TAR,libsodium-$(LIBSODIUM_VERSION).tar.gz,libsodium-$(LIBSODIUM_VERSION),libsodium)
 
 ifneq ($(wildcard $(BUILD_WORK)/libsodium/.build_complete),)

--- a/makefiles/mpg123.mk
+++ b/makefiles/mpg123.mk
@@ -21,7 +21,7 @@ mpg123: mpg123-setup
 		--with-cpu=aarch64
 	+$(MAKE) -C $(BUILD_WORK)/mpg123 install \
 		DESTDIR=$(BUILD_STAGE)/mpg123
-	$(call AFTER_BUILD)
+	$(call AFTER_BUILD,copy)
 endif
 
 mpg123-package: mpg123-stage

--- a/makefiles/mpg123.mk
+++ b/makefiles/mpg123.mk
@@ -6,6 +6,15 @@ SUBPROJECTS    += mpg123
 MPG123_VERSION := 1.26.3
 DEB_MPG123_V   ?= $(MPG123_VERSION)
 
+ifeq ($(MEMO_ARCH),x86_64h)
+MPG123_CPU_TYPE := avx
+else ifeq ($(MEMO_ARCH),x86_64)
+MPG123_CPU_TYPE := x86-64
+else ifneq (,$(findstring arm64,$(MEMO_ARCH)))
+MPG123_CPU_TYPE := aarch64
+else
+MPG123_CPU_TYPE := generic_dither
+endif
 mpg123-setup: setup
 	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://www.mpg123.de/download/mpg123-$(MPG123_VERSION).tar.bz2)
 	$(call EXTRACT_TAR,mpg123-$(MPG123_VERSION).tar.bz2,mpg123-$(MPG123_VERSION),mpg123)
@@ -18,7 +27,7 @@ mpg123: mpg123-setup
 	cd $(BUILD_WORK)/mpg123 && ./configure \
 		$(DEFAULT_CONFIGURE_FLAGS) \
 		--with-audio=coreaudio \
-		--with-cpu=aarch64
+		--with-cpu=$(MPG123_CPU_TYPE)
 	+$(MAKE) -C $(BUILD_WORK)/mpg123 install \
 		DESTDIR=$(BUILD_STAGE)/mpg123
 	$(call AFTER_BUILD,copy)

--- a/makefiles/sdl2.mk
+++ b/makefiles/sdl2.mk
@@ -29,7 +29,7 @@ ifneq ($(wildcard $(BUILD_WORK)/sdl2/.build_complete),)
 sdl2:
 	@echo "Using previously built sdl2."
 else
-sdl2: sdl2-setup
+sdl2: sdl2-setup libx11 libxcb xorgproto
 	cd $(BUILD_WORK)/sdl2 && ./configure -C \
 		$(DEFAULT_CONFIGURE_FLAGS) \
 		--enable-hidapi \

--- a/makefiles/vlc.mk
+++ b/makefiles/vlc.mk
@@ -1,0 +1,281 @@
+ifneq ($(PROCURSUS),1)
+$(error Use the main Makefile)
+endif
+
+SUBPROJECTS += vlc
+VLC_VERSION := 3.0.18
+DEB_VLC_V   ?= $(VLC_VERSION)
+
+vlc-setup: setup
+	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://download.videolan.org/vlc/$(VLC_VERSION)/vlc-$(VLC_VERSION).tar.xz{$(comma).asc})
+	$(call PGP_VERIFY,vlc-$(VLC_VERSION).tar.xz,asc)
+	$(call EXTRACT_TAR,vlc-$(VLC_VERSION).tar.xz,vlc-$(VLC_VERSION),vlc)
+	$(call DO_PATCH,vlc,vlc,-p1)
+ifeq (,$(findstring darwin,$(MEMO_TARGET)))
+	$(call DO_PATCH,vlc-ios,vlc,-p1)
+	sed -i 's/-framework,ApplicationServices//g' $(BUILD_WORK)/vlc/modules/access/Makefile.am
+	sed -i 's/libaudiounit_ios_plugin_la_LDFLAGS = /libaudiounit_ios_plugin_la_LDFLAGS = -framework Foundation -lobjc /g' $(BUILD_WORK)/vlc/modules/audio_output/Makefile.am
+	sed -i 's|-Wl,-framework,VideoToolbox|-Wl,-framework,VideoToolbox -Wl,-framework,UIKit|g' $(BUILD_WORK)/vlc/modules/{video_chroma,codec}/Makefile.am
+	sed -i 's/-framework,Cocoa/-framework,Foundation/g' $(BUILD_WORK)/vlc/modules/video_output/Makefile.am
+	sed -i 's|libvout_ios_plugin_la_LDFLAGS = |libvout_ios_plugin_la_LDFLAGS = -lGLESv2 -framework Foundation -lobjc |g' $(BUILD_WORK)/vlc/modules/video_output/Makefile.am
+	sed -i 's|include <OpenGL/|include <GL/|g' $(BUILD_WORK)/vlc/modules/visualization/glspectrum.c
+	sed -i 's/,-framework,OpenGL/,-lGL/g' $(BUILD_WORK)/vlc/modules/{video_output,access}/Makefile.am
+	sed -i 's/-Wl,-lGLES,/-Wl,-framework,OpenGLES,/g' $(BUILD_WORK)/vlc/modules/video_output/Makefile.am
+	sed -i 's|libglconv_cvpx_plugin_la_LDFLAGS = \$$|libglconv_cvpx_plugin_la_LDFLAGS = -Wl,$(BUILD_WORK)/vlc/modules/codec/.libs/vt_utils.o,-framework,CoreFoundation,-framework,CoreVideo $$|g' $(BUILD_WORK)/vlc/modules/video_output/Makefile.am
+endif
+	sed -i 's|libaudiotoolboxmidi_plugin_la_LDFLAGS += -Wl,-framework,CoreFoundation,-framework,AudioUnit,-framework,AudioToolbox|libaudiotoolboxmidi_plugin_la_LDFLAGS += -Wl,-framework,CoreFoundation,-framework,AudioToolbox,-framework,CoreAudio|g' $(BUILD_WORK)/vlc/modules/codec/Makefile.am
+	sed -i 's|-framework,AudioUnit,|-framework,CoreAudio,|g' $(BUILD_WORK)/vlc/modules/audio_output/Makefile.am
+	sed -i 's|libgl_plugin_la_LIBADD = |libgl_plugin_la_LIBADD = -lGLESv2 |g' $(BUILD_WORK)/vlc/modules/video_output/Makefile.am
+
+ifneq (,$(findstring darwin,$(MEMO_TARGET)))
+VLC_EXTRA_DEPS := libaacs libbluray
+VLC_OPTS := --enable-bluray \
+	--enable-osx-notifications \
+	--enable-macosx
+else
+VLC_EXTRA_DEPS :=
+VLC_OPTS := --disable-osx-notifications \
+	--disable-macosx \
+	--disable-bluray \
+	--disable-minimal-macosx
+endif
+
+ifeq (,$(findstring arm,$(MEMO_TARGET)))
+VLC_OPTS += --enable-mmx \
+	--enable-sse \
+	--disable-neon \
+	--disable-arm64
+else
+VLC_OPTS += --disable-mmx \
+        --disable-sse \
+	--disable-neon \
+	--enable-arm64
+endif
+ifneq ($(wildcard $(BUILD_WORK)/vlc/.build_complete),)
+vlc:
+	@echo "Using previously built vlc."
+else ifneq ($(call HAS_COMMAND,luac5.1),1)
+vlc:
+	@echo "Install lua5.1 before building"
+else
+vlc: vlc-setup aom dav1d ffmpeg fontconfig freetype frei0r gnutls lame libarchive libass libdvdcss libdvdnav libdvdread libpng16 libsoxr libssh2 libvidstab libvorbis libvpx libopencore-amr openjpeg libopus libx11 libxft libxcb luajit rav1e rtmpdump rubberband sdl2 libsnappy libspeex libsrt libtheora libwebp mesa x264 x265 libxvidcore xz libdca libtasn1 flac zstd p11-kit brotli libtiff glib2.0 libmpeg2 mpg123 libcaca libprotobuf libnfs libsmb2 libsamplerate $(VLC_EXTRA_DEPS)
+	# VLC does not like it when static libraries are enabled!
+	cd $(BUILD_WORK)/vlc && ./bootstrap && ./configure -C \
+		$(shell echo '$(DEFAULT_CONFIGURE_FLAGS)' | sed 's/--enable-static//g' ) \
+		--disable-static \
+		--disable-debug \
+		--with-macosx-sdk=$(TARGET_SYSROOT) \
+		--enable-nfs \
+		--enable-smb2 \
+		--enable-macosx-avfoundation \
+		--disable-qt \
+		--disable-sparkle \
+		--disable-update-check \
+		--disable-vcd \
+		--disable-dbus \
+		--enable-archive \
+		--enable-png \
+		--enable-dvdnav \
+		--enable-samplerate \
+		--enable-dvdread \
+		--enable-sftp \
+		--enable-run-as-root \
+		--enable-x264 \
+		--enable-x265 \
+		--with-x \
+		--with-libintl-prefix=$(BUILD_BASE) \
+		--disable-altivec \
+		--disable-live555 \
+		--disable-dc1394 \
+		--disable-dv1394 \
+		--disable-linsys \
+		--enable-lua \
+		--disable-opencv \
+		--enable-libcddb \
+		--disable-vnc \
+		--disable-tiger \
+		--enable-css \
+		--enable-xcb \
+		--enable-xvideo \
+		--enable-freetype \
+		--enable-fontconfig \
+		--disable-svg \
+		--disable-alsa \
+		--disable-sndio \
+		--disable-a52 \
+		--disable-kate \
+		--enable-gles2 \
+		--enable-libmpeg2 \
+		--enable-mpg123 \
+		--enable-caca \
+		$(VLC_OPTS) \
+		LUA_CFLAGS="-I$(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include/luajit-2.1" \
+		LUA_LIBS="-lluajit-5.1" \
+		LUAC="$(shell command -v luac5.1)" \
+		CFLAGS="$(CFLAGS) -std=gnu17 -fcommon" \
+		CXXFLAGS="$(CXXFLAGS) -std=gnu++17 -fcommon" \
+		OBJCFLAGS="$(CFLAGS) -fcommon" \
+		LIBS="-framework CFNetwork"
+	+sed -i \
+		-e 's/vlc_osx_LINK = \$$(LIBTOOL) \$$/vlc_osx_LINK = $$(LIBTOOL) --tag=CC $$/g' \
+		-e 's/vlc_osx_static_LINK = \$$(LIBTOOL) \$$/vlc_osx_static_LINK = $$(LIBTOOL) --tag=CC $$/g' \
+		-e 's|cd \$$(bindir); mv vlc-osx vlc|cd $(BUILD_STAGE)/vlc/$$(bindir); mv vlc-osx vlc|' \
+		$(BUILD_WORK)/vlc/bin/Makefile # We sed in two stages as seding the prefix before compile with break some paths
+	+$(MAKE) -C $(BUILD_WORK)/vlc
+	+sed -i \
+		-e 's| \$$(prefix)| $(BUILD_STAGE)/vlc/$$(prefix)|g' \
+		-e 's| "\$$(prefix)| "$(BUILD_STAGE)/vlc/$$(prefix)|g' \
+		$(BUILD_WORK)/vlc/Makefile
+ifneq (,$(findstring darwin,$(MEMO_TARGET)))
+	+$(MAKE) -C $(BUILD_WORK)/vlc -j1 --output-sync=target VLC.app \
+		DESTDIR=$(BUILD_STAGE)/vlc \
+		CONTRIB_DIR=$(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)
+else
+	+$(MAKE) -C $(BUILD_WORK)/vlc -j1 --output-sync=target install \
+		DESTDIR=$(BUILD_STAGE)/vlc
+endif
+	find $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/plugins -name '*.la' -delete
+ifeq (,$(findstring darwin,$(MEMO_TARGET)))
+	rm -f $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/plugins/access/libshm_plugin.dylib
+	for file in $$(find $(BUILD_STAGE)/vlc -type f -exec sh -c "file -ib '{}' | grep -q 'x-mach-binary; charset=binary'" \; -print); do \
+		$(I_N_T) -change '@rpath/libvlc.dylib' '$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/libvlc.5.dylib' -change '@rpath/libvlccore.dylib' '$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/libvlccore.9.dylib' $${file};  \
+	done
+else
+	mkdir -p $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)/Applications
+	cp -a $(BUILD_WORK)/vlc/VLC.app $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)/Applications
+	rm -rf $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/macosx
+	cp -a $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)/Applications/VLC.app/Contents/MacOS/share/. $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share
+	rm -rf $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)/Applications/VLC.app/Contents/MacOS/{share,plugins,VLC,lib/*}
+	$(I_N_T) -change '@rpath/libexpat.1.dylib' '/usr/lib/libexpat.1.dylib' $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/plugins/codec/liblibass_plugin.dylib
+	$(I_N_T) -change '@rpath/libexpat.1.dylib' '/usr/lib/libexpat.1.dylib' $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc//plugins/access/liblibbluray_plugin.dylib
+endif
+	$(I_N_T) -add_rpath $(MEMO_PREFIX)/lib/vlc $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/plugins/video_output/libxcb_xv_plugin.dylib
+	$(I_N_T) -add_rpath $(MEMO_PREFIX)/lib/vlc $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/plugins/video_output/libxcb_x11_plugin.dylib
+	$(call AFTER_BUILD,copy)
+endif
+
+vlc-package: vlc-stage
+	# vlc.mk Package Structure
+	rm -rf $(BUILD_DIST)/{vlc.app,vlc{,-bin,-data,-l10n,-plugin-{access-extra,base,video-output,video-splitter,visualization}},libvlc{-bin,-dev,5,core{9,-dev}}}
+	mkdir -p $(BUILD_DIST)/{vlc{,-bin,-data,-l10n,-plugin-{access-extra,base,video-output,video-splitter,visualization}},libvlc{-bin,-dev,5,core{9,-dev}}}
+	mkdir -p $(BUILD_DIST)/{vlc-{bin,data,l10n,plugin-{access-extra,base,video-output,video-splitter,visualization}},libvlc{-bin,-dev,5,core{9,-dev}}}/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)
+	mkdir -p $(BUILD_DIST)/vlc-{bin,data,l10n}/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share
+	mkdir -p $(BUILD_DIST)/vlc-plugin-{base,access-extra,video-output,video-splitter,visualization}/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/plugins
+	mkdir -p $(BUILD_DIST)/vlc-plugin-base/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/plugins/{video_output,access_output,access}
+	mkdir -p $(BUILD_DIST)/vlc-plugin-access-extra/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/plugins/{access,access_output,video_output}
+	mkdir -p $(BUILD_DIST)/vlc-plugin-video-output/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/plugins/video_output
+	mkdir -p $(BUILD_DIST)/libvlc{-bin,-dev,5,core{9,-dev}}/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
+	mkdir -p $(BUILD_DIST)/libvlc{core,}-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/{lib/pkgconfig,include/vlc}
+	mkdir -p $(BUILD_DIST)/libvlc{-bin,core-dev}/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc
+	mkdir -p $(BUILD_DIST)/vlc.app/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/{lib/vlc,share,bin}
+
+	# vlc.mk Prep vlc
+	# vlc.mk Prep vlc-bin
+	cp -a $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin $(BUILD_DIST)/vlc-bin/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)
+	cp -a $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/man $(BUILD_DIST)/vlc-bin/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share
+	$(LN_SR) $(BUILD_DIST)/vlc-bin/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/man/man1/{,c}vlc.1$(MEMO_MANPAGE_SUFFIX)
+	$(LN_SR) $(BUILD_DIST)/vlc-bin/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/man/man1/{,n}vlc.1$(MEMO_MANPAGE_SUFFIX)
+	$(LN_SR) $(BUILD_DIST)/vlc-bin/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/man/man1/{,r}vlc.1$(MEMO_MANPAGE_SUFFIX)
+
+	# vlc.mk Prep vlc-data
+	cp -a $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/{vlc,icons} $(BUILD_DIST)/vlc-data/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share
+ifneq (,$(findstring darwin,$(MEMO_TARGET)))
+	cp -a $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/{hrtfs,lua} $(BUILD_DIST)/vlc-data/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share
+endif
+
+	# vlc.mk Prep vlc-plugin-base
+	cp -a $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/lua $(BUILD_DIST)/vlc-plugin-base/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc
+	cp -a $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/plugins/{audio_mixer,meta_engine,audio_output,gui,audio_filter,codec,control,stream_extractor,demux,keystore,logger,misc,mux,packetizer,services_discovery,spu,stream_filter,stream_out,text_renderer,video_chroma,video_filter} $(BUILD_DIST)/vlc-plugin-base/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/plugins
+	cp -a $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/plugins/access/!(libaccess_srt|libvnc|libxcb_screen|libaccess_output_srt)_plugin.dylib $(BUILD_DIST)/vlc-plugin-base/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/plugins/access
+	cp -a $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/plugins/video_output/lib{yuv,vdummy}_plugin.dylib $(BUILD_DIST)/vlc-plugin-base/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/plugins/video_output
+	cp -a $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/plugins/access_output/!(libaccess_output_srt_plugin.dylib) $(BUILD_DIST)/vlc-plugin-base/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/plugins/access_output
+
+	# vlc.mk Prep vlc-plugin-access-extra
+	cp -a $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/plugins/access/{libaccess_srt,libxcb_screen}_plugin.dylib $(BUILD_DIST)/vlc-plugin-access-extra/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/plugins/access
+	cp -a $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/plugins/access_output/libaccess_output_srt_plugin.dylib $(BUILD_DIST)/vlc-plugin-access-extra/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/plugins/access_output
+
+	# vlc.mk Prep vlc-plugin-video-output
+	cp -a $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/plugins/video_output/!(libfb|libvdummy|libvmem|libyuv)_plugin.dylib $(BUILD_DIST)/vlc-plugin-video-output/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/plugins/video_output
+	cp -a $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/libvlc_xcb_events.{,0.}dylib $(BUILD_DIST)/vlc-plugin-video-output/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc
+
+	# vlc.mk Prep vlc-plugin-video-splitter
+	cp -a $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/plugins/video_splitter $(BUILD_DIST)/vlc-plugin-video-splitter/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/plugins
+
+	# vlc.mk Prep vlc-plugin-visualization
+	cp -a $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/plugins/visualization $(BUILD_DIST)/vlc-plugin-visualization/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/plugins
+
+	# vlc.mk Prep vlc-l10n
+	cp -a $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/locale $(BUILD_DIST)/vlc-l10n/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share
+
+	# vlc.mk Prep libvlc5
+	cp -a $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/libvlc.5.dylib $(BUILD_DIST)/libvlc5/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
+
+	# vlc.mk Prep libvlccore9
+	cp -a $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/libvlccore.9.dylib $(BUILD_DIST)/libvlc5/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
+
+ifneq (,$(findstring darwin,$(MEMO_TARGET)))
+	# vlc.mk Prep vlc.app
+	cp -a $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)/Applications $(BUILD_DIST)/vlc.app/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)
+	$(LN_S) $(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/libvlc_xcb_events.0.dylib $(BUILD_DIST)/vlc.app/$(MEMO_PREFIX)/Applications/VLC.app/Contents/MacOS/lib/libvlc_xcb_events.0.dylib
+	$(LN_S) $(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/libvlccore.dylib $(BUILD_DIST)/vlc.app/$(MEMO_PREFIX)/Applications/VLC.app/Contents/MacOS/lib/libvlccore.9.dylib
+	$(LN_S) $(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/libvlc.5.dylib $(BUILD_DIST)/vlc.app/$(MEMO_PREFIX)/Applications/VLC.app/Contents/MacOS/lib/libvlc.5.dylib
+	$(LN_S) $(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/locale $(BUILD_DIST)/vlc.app/$(MEMO_PREFIX)/Applications/VLC.app/Contents/MacOS/share
+	# Please note that the directory structure is different, however symlink it anyways
+	$(LN_S) $(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/plugins $(BUILD_DIST)/vlc.app/$(MEMO_PREFIX)/Applications/VLC.app/Contents/MacOS/plugins
+	$(LN_S) $(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/vlc-cache-gen $(BUILD_DIST)/vlc.app/$(MEMO_PREFIX)/Applications/VLC.app/Contents/MacOS/vlc-cache-gen
+	$(LN_S) $(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/vlc $(BUILD_DIST)/vlc.app/$(MEMO_PREFIX)/Applications/VLC.app/Contents/MacOS/VLC
+endif
+
+	# vlc.mk Prep libvlc-dev
+	cp -a $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/libvlc.dylib $(BUILD_DIST)/libvlc-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
+	cp -a $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/pkgconfig/libvlc.pc $(BUILD_DIST)/libvlc-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/pkgconfig/
+	cp -a $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include/vlc/{deprecated,vlc,libvlc_}*.h $(BUILD_DIST)/libvlc-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include/vlc
+
+	# vlc.mk Prep libvlc-bin
+	cp -a $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/vlc-cache-gen $(BUILD_DIST)/libvlc-bin/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc
+
+	# vlc.mk Prep libvlccore-dev
+	cp -a $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/libvlccore.dylib $(BUILD_DIST)/libvlccore-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
+	cp -a $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/pkgconfig/vlc-plugin.pc $(BUILD_DIST)/libvlccore-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/pkgconfig/
+	cp -a $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include/vlc/plugins $(BUILD_DIST)/libvlccore-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include/vlc
+	cp -a $(BUILD_STAGE)/vlc/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc/libcompat.a $(BUILD_DIST)/libvlccore-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/vlc
+
+	# vlc.mk Sign
+	$(call SIGN,vlc-bin,vlc.xml,vlc-macos.xml)
+	$(call SIGN,vlc-plugin-base,vlc.xml,vlc-macos.xml)
+	$(call SIGN,vlc-plugin-access-extra,vlc.xml,vlc-macos.xml)
+	$(call SIGN,vlc-plugin-video-output,vlc.xml,vlc-macos.xml)
+	$(call SIGN,vlc-plugin-video-splitter,vlc.xml,vlc-macos.xml)
+	$(call SIGN,vlc-plugin-visualization,vlc.xml,vlc-macos.xml)
+	$(call SIGN,libvlc5,vlc.xml,vlc-macos.xml)
+	$(call SIGN,libvlccore9,vlc.xml,vlc-macos.xml)
+ifneq (,$(findstring darwin,$(MEMO_TARGET)))
+	# codesign VLC.app **correctly**
+	codesign $(MEMO_CODESIGN_EXTRA_FLAGS) -fs - $(BUILD_DIST)/vlc.app/$(MEMO_PREFIX)/Applications/VLC.app || true # .jar files moment
+endif
+	$(call SIGN,libvlc-bin,vlc.xml,vlc-macos.xml)
+
+
+	# vlc.mk Make .debs
+	$(call PACK,vlc,DEB_VLC_V)
+	$(call PACK,vlc-bin,DEB_VLC_V)
+	$(call PACK,vlc-data,DEB_VLC_V)
+	$(call PACK,vlc-l10n,DEB_VLC_V)
+	$(call PACK,vlc-plugin-base,DEB_VLC_V)
+	$(call PACK,vlc-plugin-access-extra,DEB_VLC_V)
+	$(call PACK,vlc-plugin-video-output,DEB_VLC_V)
+	$(call PACK,vlc-plugin-video-splitter,DEB_VLC_V)
+	$(call PACK,vlc-plugin-visualization,DEB_VLC_V)
+	$(call PACK,libvlc5,DEB_VLC_V)
+	$(call PACK,libvlccore9,DEB_VLC_V)
+ifneq (,$(findstring darwin,$(MEMO_TARGET)))
+	$(call PACK,vlc.app,DEB_VLC_V)
+endif
+	$(call PACK,libvlc-dev,DEB_VLC_V)
+	$(call PACK,libvlc-bin,DEB_VLC_V)
+	$(call PACK,libvlccore-dev,DEB_VLC_V)
+
+	# vlc.mk Build cleanup
+	rm -rf $(BUILD_DIST)/{vlc.app,vlc{,-bin,-data,-l10n,-plugin-{access-extra,base,video-output,video-splitter,visualization}},libvlc{-bin,-dev,5,core{9,-dev}}}
+
+.PHONY: vlc vlc-package


### PR DESCRIPTION
This PR adds VLC media player, since I am not aware of a command line iOS audio player that can play many files formats.
On macOS, an working GUI `.app` is made

What works on iOS:
- Audio playback
- cursus TUI `vlc -I ncurses`
- CLI prompt UI `vlc -I oldrc`
- CLI, no UI `cvlc`

On macOS, it would install `VLC.app` and does work correctly

The following projects are added as build dependencies for VLC
- libaacs
- libdvdread
- libdvdnav
- libbdplus
- libbluray
- libmpeg2
- libnfs
- libsmb2

While making this PR, problems are discovered and fixed in the following packages:
- sdl2
- aom
- mpg123
- libcaca

`nasm` does not accept `CFLAGS`-like flags, so set `ASFLAGS` to empty when assembling x86.
misc: Verify libsodium download with a GPG key

### All Submissions

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [ ] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)

### Package Additions/Updates

* [x] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [x] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
