### PR TITLE
Add utilities from dyld-1042.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1342,7 +1342,7 @@ rebuild-%:
 
 setup:
 	@mkdir -p \
-		$(BUILD_BASE) $(BUILD_BASE)$(MEMO_PREFIX)/{{,System}/Library/Frameworks,$(MEMO_SUB_PREFIX)/{include/{bsm,objc,os/internal,sys,firehose,CoreFoundation,FSEvents,IOKit/kext,libkern,kern,arm,{mach/,}machine,CommonCrypto,Security,CoreSymbolication,Kernel/{kern,IOKit,libkern},rpc,rpcsvc,xpc/private,ktrace,mach-o,dispatch},lib/pkgconfig,$(MEMO_ALT_PREFIX)/lib}} \
+		$(BUILD_BASE) $(BUILD_BASE)$(MEMO_PREFIX)/{{,System}/Library/Frameworks,$(MEMO_SUB_PREFIX)/{include/{bsm,corecrypto,objc,os/internal,sys,firehose,CoreFoundation,FSEvents,IOKit/kext,libkern,kern,arm,{mach/,}machine,CommonCrypto,Security,CoreSymbolication,Kernel/{kern,IOKit,libkern},rpc,rpcsvc,sandbox,xpc/private,ktrace,mach-o/{arm,arm64,x86_64},dispatch},lib/pkgconfig,$(MEMO_ALT_PREFIX)/lib}} \
 		$(BUILD_SOURCE) $(BUILD_WORK) $(BUILD_STAGE) $(BUILD_STRAP)
 
 	@rm -rf $(BUILD_BASE)/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include/System
@@ -1355,7 +1355,9 @@ setup:
 		https://github.com/apple-oss-distributions/libutil/raw/libutil-64/{mntopts$(comma)libutil}.h \
 		https://github.com/apple-oss-distributions/xnu/raw/xnu-8792.81.2/{EXTERNAL_HEADERS/mach-o/nlist$(comma)osfmk/mach/vm_statistics}.h \
 		https://github.com/apple-oss-distributions/libmalloc/raw/libmalloc-374.100.5/private/stack_logging.h \
-		https://github.com/apple-oss-distributions/Libc/raw/Libc-1534.40.2/{gen/get_compat$(comma)include/struct}.h)
+		https://github.com/apple-oss-distributions/Libc/raw/Libc-1534.40.2/{gen/get_compat$(comma)include/struct$(comma)darwin/libc_private$(comma)stdlib/FreeBSD/atexit}.h \
+		https://github.com/Torrekie/apple_internal_sdk/raw/965215417ac58e6a6ff554a8ba682c7d2205a108/usr/include/CrashReporterClient.h \
+		https://github.com/Torrekie/apple_internal_sdk/raw/1e71206e6c6c75e5948ab9007685e5bf0a54f57d/usr/include/libamfi.h)
 
 	@$(call DOWNLOAD_FILES,$(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include/mach-o, \
 		https://github.com/apple-oss-distributions/dyld/raw/dyld-955/{include/mach-o/dyld_{process_info$(comma)introspection}$(comma)cache-builder/dyld_cache_format}.h)
@@ -1369,7 +1371,7 @@ setup:
 	@$(call DOWNLOAD_FILES,$(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include/Kernel/libkern, \
 		https://github.com/apple-oss-distributions/xnu/raw/xnu-8792.81.2/libkern/libkern/OSKextLibPrivate.h)
 
-	@$(call DOWNLOAD_FILES,$(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include/kern,https://github.com/apple-oss-distributions/xnu/raw/xnu-8792.81.2/osfmk/kern/debug.h)
+	@$(call DOWNLOAD_FILES,$(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include/kern,https://github.com/apple-oss-distributions/xnu/raw/xnu-8792.81.2/osfmk/kern/{debug$(comma)cs_blobs}.h)
 
 	@$(call DOWNLOAD_FILES,$(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include/arm, \
 		https://github.com/apple-oss-distributions/xnu/raw/xnu-8792.81.2/{bsd/arm/disklabel$(comma)osfmk/arm/cpu_capabilities}.h)
@@ -1379,7 +1381,8 @@ setup:
 
 	@$(call DOWNLOAD_FILES,$(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include/os, \
 		https://github.com/apple-oss-distributions/Libc/raw/Libc-1506.40.4/os/assumes.h \
-		https://github.com/apple-oss-distributions/xnu/raw/xnu-8792.81.2/libkern/os/{base_private$(comma)log_private$(comma)log}.h)
+		https://github.com/apple-oss-distributions/xnu/raw/xnu-8792.81.2/libkern/os/{base_private$(comma)log_private$(comma)log}.h \
+		https://github.com/apple-oss-distributions/libplatform/raw/libplatform-288/private/os/lock_private.h)
 
 	@$(call DOWNLOAD_FILES,$(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include/CommonCrypto, \
 		https://github.com/apple-oss-distributions/CommonCrypto/raw/CommonCrypto-60198.40.3/include/Private/CommonDigestSPI.h)
@@ -1411,7 +1414,7 @@ setup:
 		https://github.com/apple-oss-distributions/libplatform/raw/libplatform-126.50.8/include/os/internal/{internal_shared$(comma)atomic$(comma)crashlog}.h)
 
 	@$(call DOWNLOAD_FILES,$(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include/sys, \
-		https://github.com/apple-oss-distributions/xnu/raw/xnu-8792.81.2/bsd/sys/{fcntl$(comma)fsctl$(comma)spawn_internal$(comma)resource$(comma)event$(comma)kdebug$(comma)kdebug_private$(comma)proc$(comma)proc_info$(comma)pgo$(comma)proc_uuid_policy$(comma)acct$(comma)stackshot$(comma)event$(comma)mbuf$(comma)kern_memorystatus$(comma)reason}.h)
+		https://github.com/apple-oss-distributions/xnu/raw/xnu-8792.81.2/bsd/sys/{fcntl$(comma)fsctl$(comma)spawn_internal$(comma)resource$(comma)event$(comma)kdebug$(comma)kdebug_private$(comma)proc$(comma)proc_info$(comma)pgo$(comma)proc_uuid_policy$(comma)acct$(comma)stackshot$(comma)event$(comma)mbuf$(comma)kern_memorystatus$(comma)reason$(comma)dtrace$(comma)dtrace_glue$(comma)csr$(comma)content_protection$(comma)codesign$(comma)fsgetpath$(comma)commpage}.h)
 
 	@$(call DOWNLOAD_FILES,$(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include/uuid, \
 		https://github.com/apple-oss-distributions/Libc/raw/Libc-1534.40.2/uuid/namespace.h)
@@ -1456,7 +1459,7 @@ setup:
 		https://github.com/Torrekie/apple_internal_sdk/raw/322eb6573bc701e7f35af05650b0cc162d0355c1/usr/include/xpc/private.h)
 
 	@$(call DOWNLOAD_FILES,$(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include/ktrace, \
-		https://github.com/Torrekie/apple_internal_sdk/raw/fa5457b4e5246d20da5a74f1449b37dfd79f1248/usr/include/ktrace/{private$(comma)session}.h)
+		https://github.com/Torrekie/apple_internal_sdk/raw/965215417ac58e6a6ff554a8ba682c7d2205a108/usr/include/ktrace/{private$(comma)session}.h)
 
 	@$(call DOWNLOAD_FILES,$(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include/perfdata, \
 		https://github.com/Torrekie/apple_internal_sdk/raw/757ad82d5a680005bd253447dd3842217c6c8abc/usr/include/perfdata/perfdata.h)
@@ -1466,6 +1469,19 @@ setup:
 
 	@$(call DOWNLOAD_FILES,$(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include/dispatch, \
 		https://github.com/apple-oss-distributions/libdispatch/raw/libdispatch-1412/private/{private$(comma)benchmark$(comma){apply$(comma)channel$(comma)data$(comma)introspection$(comma)io$(comma)layout$(comma)mach$(comma)queue$(comma)source$(comma)time$(comma)workloop}_private}.h)
+
+	$(call DOWNLOAD_FILES,$(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include/mach-o/arm, \
+		https://github.com/apple-oss-distributions/xnu/raw/xnu-8792.81.2/EXTERNAL_HEADERS/mach-o/arm/reloc.h)
+	$(call DOWNLOAD_FILES,$(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include/mach-o/arm64, \
+		https://github.com/apple-oss-distributions/xnu/raw/xnu-8792.81.2/EXTERNAL_HEADERS/mach-o/arm64/reloc.h)
+	$(call DOWNLOAD_FILES,$(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include/mach-o/x86_64, \
+		https://github.com/apple-oss-distributions/xnu/raw/xnu-8792.81.2/EXTERNAL_HEADERS/mach-o/x86_64/reloc.h)
+
+	$(call DOWNLOAD_FILES,$(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include/sandbox, \
+		https://github.com/Torrekie/apple_internal_sdk/raw/4fef7db59e1a90a62f0ed3b609d6331d491ed1dc/usr/include/sandbox/{private$(comma)rootless}.h)
+
+	$(call DOWNLOAD_FILES,$(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include/corecrypto, \
+		https://github.com/apple-oss-distributions/xnu/raw/xnu-8792.81.2/EXTERNAL_HEADERS/corecrypto/{cc{_{config$(comma)error$(comma)fault_canary$(comma)impl$(comma)lock$(comma)macros$(comma)priv$(comma)runtime_config}$(comma)$(comma)aes$(comma)asn1$(comma)chacha20poly1305$(comma)cmac$(comma)der$(comma)der_blob$(comma)des$(comma)digest$(comma)digest_priv$(comma)drbg$(comma)drbg_impl$(comma)entropy$(comma)hmac$(comma)kprng$(comma)md4$(comma)mode$(comma)mode_impl$(comma)mode_siv$(comma)mode_siv_hmac$(comma)n$(comma)pad$(comma)rng$(comma)rng_crypto$(comma)rng_fortuna$(comma)rng_schedule$(comma)rsa$(comma)sha1$(comma)sha2$(comma)zp}$(comma)fipspost_trace}.h)
 
 	@cp -a $(BUILD_MISC)/{libxml-2.0,zlib}.pc $(BUILD_BASE)/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/pkgconfig
 
@@ -1525,7 +1541,7 @@ endif
 	@sed -i -e 's/__osloglike([0-9], [0-9])//' -e 's|extern void \*__dso_handle;|#ifndef __OS_TRACE_BASE_H__\nextern struct mach_header __dso_handle;\n#endif|' $(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include/os/log{,_private}.h
 	@sed -i 's/, ios(NA), bridgeos(NA)//' $(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include/Security/SecBasePriv.h
 	@sed -i 's/__API_UNAVAILABLE(ios, tvos, watchos) __API_UNAVAILABLE(bridgeos)//' $(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include/mach-o/dyld_process_info.h
-	@sed -i 's/, bridgeos(4.0)//' $(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include/dispatch/{mach,data,source}_private.h
+	@sed -i 's/\, bridgeos(.*))/)/g' $(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include/{dispatch/{mach,data,source}_private,os/lock_private}.h
 
 	@# Setup libiosexec
 	@cp -af $(BUILD_MISC)/libiosexec/libiosexec.h $(BUILD_BASE)/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include

--- a/build_info/dyld-tools.control
+++ b/build_info/dyld-tools.control
@@ -1,0 +1,14 @@
+Package: dyld-tools
+Section: Utilities
+Version: @DEB_DYLD_V@
+Architecture: @DEB_ARCH@
+Maintainer: @DEB_MAINTAINER@
+Priority: optional
+Description: tools for manipulating dyld-related files
+ dyld-tools is a set of tools to manipulate files related dyld.
+ The follow tools are included in this package:
+  - dyld_info: displays information used by dyld in programs and dylibs
+  - dyld_usage: report dyld activity in real time
+  - dyld_shared_cache_util: get information on or extract dyld3 shared caches
+  - dyld_closure_util: create or view dyld closures
+  - dyld_inspect: inspect the dyld shared cache

--- a/build_misc/entitlements/dyld-tools.xml
+++ b/build_misc/entitlements/dyld-tools.xml
@@ -1,0 +1,21 @@
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>platform-application</key>
+	<true/>
+	<key>com.apple.private.security.no-container</key>
+	<true/>
+	<key>com.apple.private.skip-library-validation</key>
+	<true/>
+	<key>com.apple.developer.kernel.extended-virtual-addressing</key>
+	<true/>
+	<key>com.apple.developer.kernel.increased-memory-limit</key>
+	<true/>
+	<key>get-task-allow</key>
+	<true/>
+	<key>task_for_pid-allow</key>
+	<true/>
+	<key>com.apple.system-task-ports.read</key>
+	<true/>
+</dict>
+</plist>

--- a/makefiles/dyld.mk
+++ b/makefiles/dyld.mk
@@ -1,0 +1,93 @@
+ifneq ($(PROCURSUS),1)
+$(error Use the main Makefile)
+endif
+
+ifeq (,$(findstring darwin,$(MEMO_TARGET)))
+
+SUBPROJECTS  += dyld
+DYLD_VERSION := 1042.1
+DEB_DYLD_V   ?= $(DYLD_VERSION)
+
+DYLD_CXXFLAGS := -std=c++20 -Icommon -DPRIVATE=1 -D__APPLE_API_PRIVATE=1 -Werror=nonportable-include-path -I. -Iinclude/mach-o -Ilibdyld -Idyld -Ilsl -Iinclude -Icache-builder -Icache_builder -Ilibdyld_introspection -DTARGET_OS_BRIDGE=0 -DSUPPORT_ARCH_arm64e=1 -DSUPPORT_ARCH_arm64_32=1 -Wno-assume
+DYLD_EXE	  := dyld_closure_util dyld_shared_cache_util dyld_info dyld_usage dyld_inspect
+
+dyld-setup: setup
+	$(call GITHUB_ARCHIVE,apple-oss-distributions,dyld,$(DYLD_VERSION),dyld-$(DYLD_VERSION))
+	$(call EXTRACT_TAR,dyld-$(DYLD_VERSION).tar.gz,dyld-dyld-$(DYLD_VERSION),dyld)
+	$(call DOWNLOAD_FILES,$(BUILD_WORK)/dyld, https://github.com/apple-oss-distributions/AvailabilityVersions/raw/AvailabilityVersions-111.0.1/{availability.pl$(comma)build_version_map.rb$(comma)print_dyld_os_versions.rb} https://github.com/Torrekie/apple_internal_sdk/raw/dd8ca4ba4c0556a1dbf5a49eaa683795996f49c2/misc/CrashReporterClient/CrashReporterClient.c)
+	chmod 755 $(BUILD_WORK)/dyld/availability.pl
+	sed -i \
+		-e 's/__API_UNAVAILABLE\(.*\)/;/g' \
+		-e 's/\, bridgeos(.*))/)/g' \
+		$(BUILD_WORK)/dyld/{include,common,include/mach-o}/*.h
+	sed -i '/#include <rootless.h>/d' $(BUILD_WORK)/dyld/cache-builder/FileUtils.cpp
+	sed -i 's|struct dyld_all_image_infos;$$|struct dyld_all_image_infos; extern "C" uint64_t kdebug_trace_string(uint32_t debugid, uint64_t str_id, const char *str);|' $(BUILD_WORK)/dyld/dyld/Tracing.h
+	sed -i 's|using dyld3::MachOAnalyzer;$$|using dyld3::MachOAnalyzer; extern "C" bool kdebug_is_enabled(uint32_t debugid);|' $(BUILD_WORK)/dyld/dyld/DyldRuntimeState.cpp
+	sed -i 's|// #include <System/os/reason_private.h>|extern "C" { bool kdebug_is_enabled(uint32_t debugid); int kdebug_trace(uint32_t debugid, uint64_t arg1, uint64_t arg2, uint64_t arg3, uint64_t arg4); };|' $(BUILD_WORK)/dyld/dyld/Tracing.cpp
+	sed -i 's|#include <System/sys/mman.h>|#include <sys/mman.h>|g' $(BUILD_WORK)/dyld/dyld/DyldDelegates.cpp
+ifeq ($(shell [ "$(CFVER_WHOLE)" -lt 1800 ] && echo 1),1)
+	sed -i 's/task_read_for_pid/task_for_pid/g' $(BUILD_WORK)/dyld/other-tools/dyld_inspect.cpp
+endif
+	mkdir -p $(BUILD_STAGE)/dyld/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/{bin,share/man/man1}
+
+dyld-prepare-build: dyld-setup
+	ruby $(BUILD_WORK)/dyld/build_version_map.rb $(BUILD_WORK)/dyld/availability.pl > $(BUILD_WORK)/dyld/dyld/VersionMap.h
+	ruby $(BUILD_WORK)/dyld/print_dyld_os_versions.rb $(BUILD_WORK)/dyld/availability.pl > $(BUILD_WORK)/dyld/dyld/for_dyld_priv.inc.h
+	cd $(BUILD_WORK)/dyld; \
+		echo -e "#include \"PrebuiltLoader.h\"\nint foo() { return sizeof(dyld4::PrebuiltLoader)+sizeof(dyld4::PrebuiltLoaderSet)+sizeof(dyld4::ObjCBinaryInfo)+sizeof(dyld4::Loader::DylibPatch); }\n" > test.cpp; \
+		$(CXX) $(CXXFLAGS) $(DYLD_CXXFLAGS) -Wno-incompatible-sysroot -fsyntax-only -Xclang -fdump-record-layouts -Icommon -Idyld -Iinclude -Icache-builder test.cpp > test.out; \
+		grep -A100 "class dyld4::PrebuiltLoader"        test.out | grep -B100 -m1 sizeof= > pbl.ast; \
+		grep -A100 "struct dyld4::PrebuiltLoaderSet"    test.out | grep -B100 -m1 sizeof= > pbls.ast; \
+		grep -A100 "struct dyld4::ObjCBinaryInfo"       test.out | grep -B100 -m1 sizeof= > pblsobjc.ast; \
+		grep -A100 "struct dyld4::Loader::DylibPatch"   test.out | grep -B100 -m1 sizeof= > dylibpatch.ast; \
+		cat pbl.ast pbls.ast pblsobjc.ast dylibpatch.ast | md5 | awk '{print "#define PREBUILTLOADER_VERSION 0x" substr($$0,0,8)}' > dyld/PrebuiltLoader_version.h; \
+	$(CC) $(CFLAGS) -c CrashReporterClient.c;
+
+$(BUILD_WORK)/dyld/dyld_closure_util: dyld-prepare-build
+	cd $(BUILD_WORK)/dyld; \
+		$(CXX) $(DYLD_CXXFLAGS) $(CXXFLAGS) $(LDFLAGS) other-tools/dyld_closure_util.cpp common/*.cpp lsl/*.cpp -DBUILDING_CLOSURE_UTIL=1 dyld/{DebuggerSupport,Tracing,SharedCacheRuntime,DyldProcessConfig,DyldDelegates,PrebuiltObjC,JustInTimeLoader,Loader,DyldRuntimeState,PrebuiltLoader,PrebuiltSwift}.cpp -o dyld_closure_util; 
+
+$(BUILD_WORK)/dyld/dyld_shared_cache_util: dyld-prepare-build
+	cd $(BUILD_WORK)/dyld; \
+		$(CXX) $(DYLD_CXXFLAGS) $(CXXFLAGS) $(LDFLAGS) -DBUILDING_SHARED_CACHE_UTIL=1 CrashReporterClient.o common/*.cpp lsl/*.cpp libdyld_introspection/*.cpp other-tools/{dyld_shared_cache_util,dsc_extractor}.cpp dyld/{DyldProcessConfig,DyldDelegates,DyldRuntimeState}.cpp -o dyld_shared_cache_util;
+
+$(BUILD_WORK)/dyld/dyld_info: dyld-prepare-build
+	cd $(BUILD_WORK)/dyld; \
+		$(CXX) $(DYLD_CXXFLAGS) $(CXXFLAGS) $(LDFLAGS) ./cache-builder/FileUtils.cpp lsl/*.cpp common/{CachePatching,ClosureFileSystemNull,ClosureFileSystemPhysical,Diagnostics,DyldSharedCache,FileManager,MachOAnalyzer,MachOFile,MachOLayout,MachOLoaded,MetadataVisitor,MurmurHash,OptimizerSwift,PerfectHash,ProcessAtlas,SwiftVisitor,Utils}.cpp other-tools/dyld_info.cpp -DBUILDING_DYLDINFO=1 -o dyld_info;
+
+$(BUILD_WORK)/dyld/dyld_usage: dyld-prepare-build
+	cd $(BUILD_WORK)/dyld; \
+		$(CXX) $(DYLD_CXXFLAGS) $(CXXFLAGS) $(LDFLAGS) lsl/*.cpp common/{CachePatching,ClosureFileSystemNull,ClosureFileSystemPhysical,Diagnostics,DyldSharedCache,FileManager,MachOAnalyzer,MachOFile,MachOLayout,MachOLoaded,MetadataVisitor,MurmurHash,OptimizerSwift,PerfectHash,ProcessAtlas,SwiftVisitor,Utils}.cpp libdyld_introspection/*.cpp other-tools/dyld_usage.cpp -DBUILDING_DYLDUSAGE=1 -F$(BUILD_MISC)/PrivateFrameworks -framework ktrace -o dyld_usage
+
+$(BUILD_WORK)/dyld/dyld_inspect: dyld-prepare-build
+	cd $(BUILD_WORK)/dyld; \
+		$(CXX) $(DYLD_CXXFLAGS) $(CXXFLAGS) $(LDFLAGS) lsl/*.cpp common/{CachePatching,ClosureFileSystemNull,ClosureFileSystemPhysical,Diagnostics,DyldSharedCache,FileManager,MachOAnalyzer,MachOFile,MachOLayout,MachOLoaded,MetadataVisitor,MurmurHash,OptimizerSwift,PerfectHash,ProcessAtlas,SwiftVisitor,Utils}.cpp libdyld_introspection/*.cpp other-tools/dyld_inspect.cpp -DBUILDING_DYLDINSPECT=1 -o dyld_inspect
+
+ifneq ($(wildcard $(BUILD_WORK)/dyld/.build_complete),)
+dyld:
+	@echo "Using previously built dyld."
+else
+dyld: dyld-setup $(patsubst %, $(BUILD_WORK)/dyld/%, $(DYLD_EXE))
+	$(INSTALL) -m755 $(patsubst %, $(BUILD_WORK)/dyld/%, $(DYLD_EXE)) $(BUILD_STAGE)/dyld/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin
+	$(INSTALL) -m644 $(BUILD_WORK)/dyld/doc/man/man1/dyld_{info,usage}.1 $(BUILD_STAGE)/dyld/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/man/man1
+	$(call AFTER_BUILD)
+endif
+
+dyld-package: dyld-stage
+	# dyld.mk Package Structure
+	rm -rf $(BUILD_DIST)/dyld-tools
+
+	# dyld.mk Prep dyld-tools
+	cp -a $(BUILD_STAGE)/dyld $(BUILD_DIST)/dyld-tools
+
+	# dyld.mk Sign
+	$(call SIGN,dyld-tools,dyld-tools.xml)
+
+	# dyld.mk Make .debs
+	$(call PACK,dyld-tools,DEB_DYLD_V)
+
+	# dyld.mk Build cleanup
+	rm -rf $(BUILD_DIST)/dyld-tools
+
+.PHONY: dyld dyld-package
+endif


### PR DESCRIPTION
These tools are used to operate on dyld-related files
Included tools:

  - dyld_info: displays information used by dyld in programs and dylibs
  - dyld_usage: report dyld activity in real time
  - dyld_shared_cache_util: get information on or extract dyld3 shared caches
  - dyld_closure_util: create or view dyld3 closures
  
### All Submissions

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [ ] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)

### Package Additions/Updates

* [x] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
