### PR TITLE
micro: Update to 2.0.11

### DIFF
--- a/makefiles/micro.mk
+++ b/makefiles/micro.mk
@@ -7,8 +7,7 @@ MICRO_VERSION  := 2.0.11
 DEB_MICRO_V    ?= $(MICRO_VERSION)
 
 micro-setup: setup
-	$(call GITHUB_ARCHIVE,zyedidia,micro,$(MICRO_VERSION),v$(MICRO_VERSION),micro)
-	$(call EXTRACT_TAR,micro-$(MICRO_VERSION).tar.gz,micro-$(MICRO_VERSION),micro)
+	$(call GIT_CLONE,https://github.com/zyedidia/micro.git,v$(MICRO_VERSION),micro)
 	mkdir -p $(BUILD_STAGE)/micro/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin
 
 ifneq ($(wildcard $(BUILD_WORK)/micro/.build_complete),)
@@ -17,7 +16,9 @@ micro:
 else
 micro: micro-setup
 	$(MAKE) -C $(BUILD_WORK)/micro build \
-		$(DEFAULT_GOLANG_FLAGS)
+		$(DEFAULT_GOLANG_FLAGS) \
+		VERSION="$(DEB_MICRO_V)" \
+		DATE="$(shell date '+%B %u, %Y')"
 	$(INSTALL) -Dm755 $(BUILD_WORK)/micro/micro $(BUILD_STAGE)/micro/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/micro
 	$(INSTALL) -Dm644 $(BUILD_WORK)/micro/assets/packaging/micro.1 $(BUILD_STAGE)/micro/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/man/man1/micro.1
 	$(INSTALL) -Dm644 $(BUILD_WORK)/micro/assets/packaging/micro.desktop $(BUILD_STAGE)/micro/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/applications/micro.desktop
@@ -27,10 +28,9 @@ endif
 micro-package: micro-stage
 	# micro.mk Package Structure
 	rm -rf $(BUILD_DIST)/micro
-	mkdir -p $(BUILD_DIST)/micro/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)
 
 	# micro.mk Prep micro
-	cp -a $(BUILD_STAGE)/micro/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/{bin,share} $(BUILD_DIST)/micro/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)
+	cp -a $(BUILD_STAGE)/micro $(BUILD_DIST)
 
 	# micro.mk Sign
 	$(call SIGN,micro,general.xml)

--- a/makefiles/micro.mk
+++ b/makefiles/micro.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS    += micro
-MICRO_VERSION  := 2.0.10
+MICRO_VERSION  := 2.0.11
 DEB_MICRO_V    ?= $(MICRO_VERSION)
 
 micro-setup: setup


### PR DESCRIPTION
This PR updates `micro` to its latest released version, 2.0.11. The Makefile now:

- Reports the correct hash from the editor's repository
- Displays the version of the package with `--version`, and is dynamic (should there ever be a patch)

This new version of the project provides further support for languages in its embedded runtime, while also adding more features. Tested both on iOS 12 and macOS Monterrey 12.6.1.

### All Submissions

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [x] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)

### Package Additions/Updates

* [x] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [x] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
