### PR TITLE
lsd: Update to 0.23.1

### DIFF
--- a/makefiles/lsd.mk
+++ b/makefiles/lsd.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS += lsd
-LSD_VERSION := 0.20.1
+LSD_VERSION := 0.23.1
 DEB_LSD_V   ?= $(LSD_VERSION)
 
 lsd-setup: setup

--- a/makefiles/lsd.mk
+++ b/makefiles/lsd.mk
@@ -15,10 +15,9 @@ lsd:
 	@echo "Using previously built lsd."
 else
 lsd: lsd-setup
-	# Use Lucy's fork of rust-users w/ iOS support
-	sed -i 's|users = "0.11.*"|users = {git = "https://github.com/Absolucy/rust-users", branch = "ios"}|g' \
+	sed -i -e 's|users = "0.11.*"|users = {git = "https://github.com/ogham/rust-users", rev = "refs/pull/46/head"}|g' \
 		$(BUILD_WORK)/lsd/Cargo.toml
-	cd $(BUILD_WORK)/lsd; $(DEFAULT_RUST_FLAGS) cargo build \
+	cd $(BUILD_WORK)/lsd && $(DEFAULT_RUST_FLAGS) cargo build \
 		--release \
 		--target=$(RUST_TARGET)
 	$(INSTALL) -Dm755 $(BUILD_WORK)/lsd/target/$(RUST_TARGET)/release/lsd \


### PR DESCRIPTION
This PR updates `lsd` to its latest released version, 0.23.1. With this, the project should be able to compile, as the Makefile referred to a deleted repository, which I've taken the time to fix as well. Tested on iOS 12 and macOS 12.6.1.

### All Submissions

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [x] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)

### Package Additions/Updates

* [x] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [x] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
