### PR TITLE
Add ipatool

### DIFF
--- a/build_info/ipatool.control
+++ b/build_info/ipatool.control
@@ -1,0 +1,12 @@
+Package: ipatool
+Version: @DEB_IPATOOL_V@
+Architecture: @DEB_ARCH@
+Maintainer: @DEB_MAINTAINER@
+Author: Majd Alfhaily <majd@alfhaily.me>
+Section: Utilities
+Priority: optional
+Homepage: https://github.com/majd/ipatool
+Description: Command-line tool to navigate the App Store.
+ ipatool is a command line tool that allows you to search for
+ iOS apps on the App Store and download a copy of the package,
+ known as an ipa file.

--- a/makefiles/ipatool.mk
+++ b/makefiles/ipatool.mk
@@ -1,0 +1,42 @@
+ifneq ($(PROCURSUS),1)
+$(error Use the main Makefile)
+endif
+
+SUBPROJECTS     += ipatool
+IPATOOL_VERSION := 2.0.0-rc.2
+DEB_IPATOOL_V   ?= $(IPATOOL_VERSION)
+
+ipatool-setup: setup
+	$(call GITHUB_ARCHIVE,majd,ipatool,$(IPATOOL_VERSION),v$(IPATOOL_VERSION))
+	$(call EXTRACT_TAR,ipatool-$(IPATOOL_VERSION).tar.gz,ipatool-$(IPATOOL_VERSION),ipatool)
+	mkdir -p $(BUILD_STAGE)/ipatool/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin
+
+ifneq ($(wildcard $(BUILD_WORK)/ipatool/.build_complete),)
+ipatool:
+	@echo "Using previously built ipatool."
+else
+ipatool: ipatool-setup
+	cd $(BUILD_WORK)/ipatool && ./tools/version.sh
+	cd $(BUILD_WORK)/ipatool && $(DEFAULT_GOLANG_FLAGS) go build \
+		-o $(BUILD_WORK)/ipatool/ipatool
+	$(INSTALL) -Dm755 $(BUILD_WORK)/ipatool/ipatool $(BUILD_STAGE)/ipatool/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/
+	$(call AFTER_BUILD)
+endif
+
+ipatool-package: ipatool-stage
+	# ipatool.mk Package Structure
+	rm -rf $(BUILD_DIST)/ipatool
+
+	# ipatool.mk Prep ipatool
+	cp -a $(BUILD_STAGE)/ipatool $(BUILD_DIST)
+
+	# ipatool.mk Sign
+	$(call SIGN,ipatool,general.xml)
+
+	# ipatool.mk Make .debs
+	$(call PACK,ipatool,DEB_IPATOOL_V)
+
+	# ipatool.mk Build cleanup
+	rm -rf $(BUILD_DIST)/ipatool
+
+.PHONY: ipatool ipatool-package

--- a/makefiles/ipatool.mk
+++ b/makefiles/ipatool.mk
@@ -2,6 +2,8 @@ ifneq ($(PROCURSUS),1)
 $(error Use the main Makefile)
 endif
 
+ifneq (,$(findstring darwin,$(MEMO_TARGET)))
+
 SUBPROJECTS     += ipatool
 IPATOOL_VERSION := 2.0.0-rc.2
 DEB_IPATOOL_V   ?= $(IPATOOL_VERSION)
@@ -40,3 +42,5 @@ ipatool-package: ipatool-stage
 	rm -rf $(BUILD_DIST)/ipatool
 
 .PHONY: ipatool ipatool-package
+
+endif


### PR DESCRIPTION
This PR adds `ipatool`, which can now be added to Procursus as it has been rewritten in Go. This package has been restricted to only be built for macOS targets, as iOS support is not native.

Before running any other command, make sure to authenticate your Apple ID with `ipatool auth login`.

### All Submissions

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [ ] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)

### Package Additions/Updates

* [ ] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [x] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
