### PR TITLE
bender: Fix building on supported targets

### DIFF
--- a/makefiles/bender.mk
+++ b/makefiles/bender.mk
@@ -9,7 +9,7 @@ BENDER_VERSION   := 1.1.1
 DEB_BENDER_V     ?= $(BENDER_VERSION)
 
 bender-setup: setup
-	$(call GITHUB_ARCHIVE,aspenluxxxy,bender,$(BENDER_VERSION),v$(BENDER_VERSION))
+	$(call GITHUB_ARCHIVE,Absolucy,bender,$(BENDER_VERSION),v$(BENDER_VERSION))
 	$(call EXTRACT_TAR,bender-$(BENDER_VERSION).tar.gz,bender-$(BENDER_VERSION),bender)
 
 ifneq ($(wildcard $(BUILD_WORK)/bender/.build_complete),)
@@ -17,6 +17,7 @@ bender:
 	@echo "Using previously built bender."
 else
 bender: bender-setup
+	sed -e "24,25s|aspen.*/|dfrankland/|" -i $(BUILD_WORK)/bender/Cargo.toml
 	cd $(BUILD_WORK)/bender && $(DEFAULT_RUST_FLAGS) cargo build \
 		--release \
 		--target=$(RUST_TARGET)

--- a/makefiles/bender.mk
+++ b/makefiles/bender.mk
@@ -17,7 +17,7 @@ bender:
 	@echo "Using previously built bender."
 else
 bender: bender-setup
-	sed -e "24,25s|aspen.*/|dfrankland/|" -i $(BUILD_WORK)/bender/Cargo.toml
+	sed -e "24,25s|aspen.*/|dfrankland/|" -e "5s|aspen.*<.*>|Absolucy <lucy@absolucy.moe>|" -i $(BUILD_WORK)/bender/Cargo.toml
 	cd $(BUILD_WORK)/bender && $(DEFAULT_RUST_FLAGS) cargo build \
 		--release \
 		--target=$(RUST_TARGET)


### PR DESCRIPTION
In its current state, upstream cannot build `bender`; this change fixes that. On top of that, I've decided to patch in the author's new credentials, since they're no longer accepting pull requests.

Tested on iOS 12 & iOS 14, building directly on macOS. 

### Checklist
* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [x] This Pull Request doesn't contain any package additions; it's a small change (e.g README change, small package update)
* [x] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [ ] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
