### PR TITLE
dpkg: Update to 1.21.15

### DIFF
--- a/build_patch/dpkg-ios/ios.diff
+++ b/build_patch/dpkg-ios/ios.diff
@@ -1,9 +1,9 @@
-diff -urN dpkg-1.20.0/data/cputable dpkg/data/cputable
---- dpkg-1.20.0/data/cputable	2019-11-05 06:59:03.000000000 -0500
-+++ dpkg/data/cputable	2020-06-09 01:42:14.325741148 -0400
-@@ -21,6 +21,7 @@
- alpha		alpha		alpha.*			64	little
+diff -urN a/data/cputable b/data/cputable
+--- a/data/cputable
++++ b/data/cputable
+@@ -22,6 +22,7 @@
  amd64		x86_64		(amd64|x86_64)		64	little
+ arc		arc		arc			32	little
  armeb		armeb		arm.*b			32	big
 +armk		armk		arm.*k			32	little
  arm		arm		arm.*			32	little

--- a/build_patch/dpkg-macos/malwareworkaround.diff
+++ b/build_patch/dpkg-macos/malwareworkaround.diff
@@ -1,13 +1,13 @@
-diff -urN dpkg/src/unpack.c dpkg/src/unpack.c
---- dpkg/src/main/unpack.c	2021-03-11 08:23:22.000000000 -0500
-+++ dpkg/src/main/unpack.c	2021-03-11 08:22:45.000000000 -0500
-@@ -1084,6 +1084,9 @@
+diff -urN a/src/main/unpack.c b/src/main/unpack.c
+--- a/src/main/unpack.c
++++ b/src/main/unpack.c
+@@ -1189,6 +1189,9 @@
      if (strcmp(usenode->name, "/.") == 0)
        continue;
 
-+    if(strstr(usenode->name,"bin/dpkg") != NULL || strstr(usenode->name,"bin/apt") != NULL)
++    if (strcmp(usenode->name, "bin/dpkg") != NULL || strstr(usenode->name, "bin/apt") != NULL)
 +      continue;
 +
-     varbuf_rollback(&fnametmpvb, &fname_state);
+     varbuf_rollback(&fnametmp_state);
      varbuf_add_str(&fnametmpvb, usenode->name);
      varbuf_add_str(&fnametmpvb, DPKGTEMPEXT);

--- a/build_patch/dpkg/0001-dpkg-Add-Zstandard-compression-and-decompression-sup.patch
+++ b/build_patch/dpkg/0001-dpkg-Add-Zstandard-compression-and-decompression-sup.patch
@@ -1,24 +1,24 @@
-diff --color -urN dpkg-1.21.7/README dpkg-1.21.7/README
---- dpkg-1.21.7/README	2022-03-26 17:17:58.000000000 +0000
-+++ dpkg-1.21.7/README	2022-06-01 14:51:06.598462000 +0000
-@@ -83,6 +83,7 @@
- 
-   libmd (used by libdpkg, currently falling back to embedded code)
+diff -urN a/README b/README
+--- a/README
++++ b/README
+@@ -85,6 +85,7 @@
+
+   libmd (used by libdpkg, required if libc is missing digest functions)
    libz (from zlib, used instead of gzip command-line tool)
 +  libzstd (from libzstd, used instead of zstd command-line tool)
    liblzma (from xz utils, used instead of xz command-line tool)
    libbz2 (from bzip2, used instead of bzip2 command-line tool)
    libselinux
-diff --color -urN dpkg-1.21.7/configure.ac dpkg-1.21.7/configure.ac
---- dpkg-1.21.7/configure.ac	2022-03-26 17:17:58.000000000 +0000
-+++ dpkg-1.21.7/configure.ac	2022-06-01 14:52:32.215831000 +0000
+diff -urN a/configure.ac b/configure.ac
+--- a/configure.ac
++++ b/configure.ac
 @@ -72,7 +72,7 @@
    [zsh vendor completions directory [DATADIR/zsh/vendor-completions]])
- 
+
  # Set default dpkg-deb values
 -DPKG_DEB_COMPRESSOR([xz])
 +DPKG_DEB_COMPRESSOR([zstd])
- 
+
  # Checks for programs.
  AC_PROG_SED
 @@ -95,6 +95,7 @@
@@ -33,49 +33,51 @@ diff --color -urN dpkg-1.21.7/configure.ac dpkg-1.21.7/configure.ac
      libkvm  . . . . . . . . . . . : ${have_libkvm:-no}
      libselinux  . . . . . . . . . : $have_libselinux
      libmd . . . . . . . . . . . . : $have_libmd
-+    libzstd  . . . . . . . . . .  : $have_libzstd
++    libzstd . . . . . . . . . . . : $have_libzstd
      libz  . . . . . . . . . . . . : $have_libz_impl
      liblzma . . . . . . . . . . . : $have_liblzma
      libbz2  . . . . . . . . . . . : $have_libbz2
-diff --color -urN dpkg-1.21.7/debian/control dpkg-1.21.7/debian/control
---- dpkg-1.21.7/debian/control	2022-03-26 17:17:58.000000000 +0000
-+++ dpkg-1.21.7/debian/control	2022-06-01 14:53:15.413903000 +0000
-@@ -16,7 +16,9 @@
- # Needed for --porefs defaults, conditional addenda and mode=eof.
+diff -urN a/debian/control b/debian/control
+--- a/debian/control
++++ b/debian/control
+@@ -17,7 +17,9 @@
   po4a (>= 0.59),
+  libmd-dev,
   zlib1g-dev,
 + zstd,
   libbz2-dev,
 + libzstd-dev,
-  liblzma-dev,
+ # Version needed for multi-threaded decompressor support.
+  liblzma-dev (>= 5.4.0),
   libselinux1-dev [linux-any],
-  libncurses-dev (>= 6.1+20180210) | libncursesw5-dev,
-diff --color -urN dpkg-1.21.7/debian/rules dpkg-1.21.7/debian/rules
---- dpkg-1.21.7/debian/rules	2022-03-26 17:17:58.000000000 +0000
-+++ dpkg-1.21.7/debian/rules	2022-06-01 14:54:05.977727000 +0000
-@@ -52,6 +52,7 @@
+diff -urN a/debian/rules b/debian/rules
+--- a/debian/rules
++++ b/debian/rules
+@@ -51,6 +51,7 @@
+ 		--libexecdir=\$${exec_prefix}/lib \
  		--with-devlibdir=\$${prefix}/lib/$(DEB_HOST_MULTIARCH) \
- 		--without-libmd \
  		--with-libz \
 +		--with-libzstd \
  		--with-liblzma \
  		--with-libbz2 \
  		# EOL
-@@ -80,3 +81,10 @@
- 
+@@ -80,5 +81,12 @@
  override_dh_bugfiles:
  	dh_bugfiles -A
-+
+
 +override_dh_builddeb:
-+	# Make debootstrap life easier on non-Debian based systems by
++	# Make deboostrap life easier on non-Debian based systems by
 +	# compressing dpkg.deb with xz instead of zstd.
 +	dh_builddeb -pdpkg -- -Zxz
 +	dh_builddeb -a -Ndpkg
 +	dh_builddeb
-diff --color -urN dpkg-1.21.7/lib/dpkg/Makefile.am dpkg-1.21.7/lib/dpkg/Makefile.am
---- dpkg-1.21.7/lib/dpkg/Makefile.am	2022-03-26 17:17:58.000000000 +0000
-+++ dpkg-1.21.7/lib/dpkg/Makefile.am	2022-06-01 14:54:21.665675000 +0000
-@@ -43,6 +43,7 @@
++
+ override_dh_compress:
+ 	dh_compress -Xspec/
+diff -urN a/lib/dpkg/Makefile.am b/lib/dpkg/Makefile.am
+--- a/lib/dpkg/Makefile.am
++++ b/lib/dpkg/Makefile.am
+@@ -44,6 +44,7 @@
  libdpkg_la_LIBADD += \
  	$(LIBINTL) \
  	$(Z_LIBS) \
@@ -83,10 +85,10 @@ diff --color -urN dpkg-1.21.7/lib/dpkg/Makefile.am dpkg-1.21.7/lib/dpkg/Makefile
  	$(LZMA_LIBS) \
  	$(BZ2_LIBS) \
  	# EOL
-diff --color -urN dpkg-1.21.7/lib/dpkg/compress.c dpkg-1.21.7/lib/dpkg/compress.c
---- dpkg-1.21.7/lib/dpkg/compress.c	2022-03-26 17:17:58.000000000 +0000
-+++ dpkg-1.21.7/lib/dpkg/compress.c	2022-06-01 15:04:01.335217000 +0000
-@@ -36,6 +36,9 @@
+diff -urN a/lib/dpkg/compress.c b/lib/dpkg/compress.c
+--- a/lib/dpkg/compress.c
++++ b/lib/dpkg/compress.c
+@@ -32,6 +32,9 @@
  #if USE_LIBZ_IMPL != USE_LIBZ_IMPL_NONE
  #include <compat-zlib.h>
  #endif
@@ -96,7 +98,7 @@ diff --color -urN dpkg-1.21.7/lib/dpkg/compress.c dpkg-1.21.7/lib/dpkg/compress.
  #ifdef WITH_LIBLZMA
  #include <lzma.h>
  #endif
-@@ -52,6 +55,7 @@
+@@ -49,6 +52,7 @@
  #include <dpkg/command.h>
  #include <dpkg/compress.h>
  #if USE_LIBZ_IMPL == USE_LIBZ_IMPL_NONE || \
@@ -104,130 +106,129 @@ diff --color -urN dpkg-1.21.7/lib/dpkg/compress.c dpkg-1.21.7/lib/dpkg/compress.
      !defined(WITH_LIBLZMA) || \
      !defined(WITH_LIBBZ2)
  #include <dpkg/subproc.h>
-@@ -918,6 +922,161 @@
+@@ -932,6 +936,160 @@
  };
- 
+
  /*
-+ * Zstd compressor.
++ * Zstd compressor
 + */
 +
-+#define ZSTD	"zstd"
++#define ZSTD "zstd"
 +
 +#ifdef WITH_LIBZSTD
-+
 +static void
 +decompress_zstd(struct compress_params *params, int fd_in, int fd_out,
 +                const char *desc)
 +{
-+	size_t const buf_in_size = ZSTD_DStreamInSize();
-+	void*  const buf_in = m_malloc(buf_in_size);
-+	size_t const buf_out_size = ZSTD_DStreamOutSize();
-+	void*  const buf_out = m_malloc(buf_out_size);
-+	size_t init_result, just_read, to_read;
-+	ZSTD_DStream* const dstream = ZSTD_createDStream();
-+	if (dstream == NULL) {
-+		ohshit(_("ZSTD_createDStream error creating stream"));
-+	}
++    size_t const buf_in_size = ZSTD_DStreamInSize();
++    void*  const buf_in = m_malloc(buf_in_size);
++    size_t const buf_out_size = ZSTD_DStreamOutSize();
++    void*  const buf_out = m_malloc(buf_out_size);
++    size_t init_result, just_read, to_read;
++    ZSTD_DStream* const dstream = ZSTD_createDStream();
++    if (dstream == NULL) {
++        ohshit(_("ZSTD_createDStream error creating stream"));
++    }
 +
-+	init_result = ZSTD_initDStream(dstream);
-+	if (ZSTD_isError(init_result)) {
-+		ohshit(_("ZSTD_initDStream error : %s"), ZSTD_getErrorName(init_result));
-+	}
++    init_result = ZSTD_initDStream(dstream);
++    if (ZSTD_isError(init_result)) {
++        ohshit(_("ZSTD_initDStream error : %s"), ZSTD_getErrorName(init_result));
++    }
 +
-+	to_read = init_result;
-+	while ((just_read = fd_read(fd_in, buf_in, to_read))) {
-+		ZSTD_inBuffer input = { buf_in, just_read, 0 };
-+		while (input.pos < input.size) {
-+			size_t actualwrite;
-+			ZSTD_outBuffer output = { buf_out, buf_out_size, 0 };
-+			to_read = ZSTD_decompressStream(dstream, &output , &input);
-+			if (ZSTD_isError(to_read)) {
-+				ohshit(_("ZSTD_decompressStream error : %s \n"),
-+				       ZSTD_getErrorName(to_read));
-+			}
-+			actualwrite = fd_write(fd_out, output.dst, output.pos);
-+			if (actualwrite != output.pos) {
-+				const char *errmsg = strerror(errno);
-+				ohshite(_("%s: internal zstd write error: '%s'"), desc, errmsg);
-+			}
-+			/* possible next frame */
-+			if (to_read == 0) {
-+				init_result = ZSTD_initDStream(dstream);
-+				if (ZSTD_isError(init_result)) {
-+					ohshit(_("ZSTD_initDStream error : %s"), ZSTD_getErrorName(init_result));
-+				}
-+				to_read = init_result;
-+			}
-+		}
-+	}
++    to_read = init_result;
++    while ((just_read = fd_read(fd_in, buf_in, to_read))) {
++        ZSTD_inBuffer input = {  buf_in, just_read, 0 };
++        while (input.pos < input.size) {
++            size_t actualwrite;
++            ZSTD_outBuffer output = { buf_out, buf_out_size, 0 };
++            to_read = ZSTD_decompressStream(dstream, &output, &input);
++            if (ZSTD_isError(to_read)) {
++                ohshit(_("ZSTD_decompressStream error : %s \n"),
++                       ZSTD_getErrorName(to_read));
++            }
++            actualwrite = fd_write(fd_out, output.dst, output.pos);
++            if (actualwrite != output.pos) {
++                const char *errmsg = strerror(errno);
++                ohshite(_("%s: internal zstd write error: '%s'"), desc, errmsg);
++            }
++            /* possible next frame */
++            if (to_read == 0) {
++                init_result = ZSTD_initDStream(dstream);
++                if (ZSTD_isError(init_result)) {
++                    ohshit(_("ZSTD_initDStream error : %s"), ZSTD_getErrorName(init_result));
++                }
++                to_read = init_result;
++            }
++        }
++    }
 +
-+	ZSTD_freeDStream(dstream);
-+	free(buf_in);
-+	free(buf_out);
-+	if (close(fd_out))
-+		ohshite(_("%s: internal zstd write error"), desc);
++    ZSTD_freeDStream(dstream);
++    free(buf_in);
++    free(buf_out);
++    if (close(fd_out))
++        ohshite(_("%s: internal zstd write error"), desc);
 +}
 +
 +static void
 +compress_zstd(struct compress_params *params, int fd_in, int fd_out,
 +              const char *desc)
 +{
-+	size_t const buf_in_size = ZSTD_CStreamInSize();
-+	void*  const buf_in = m_malloc(buf_in_size);
-+	size_t const buf_out_size = ZSTD_CStreamOutSize();
-+	void*  const buf_out = m_malloc(buf_out_size);
-+	size_t init_result, end_res;
-+	size_t just_read, to_read;
-+	ZSTD_CStream* const cstream = ZSTD_createCStream();
-+	if (cstream == NULL) {
-+		ohshit(_("ZSTD_createCStream error"));
-+	}
-+	init_result = ZSTD_initCStream(cstream, params->level);
-+	if (ZSTD_isError(init_result)) {
-+		ohshit(_("ZSTD_initCStream error : %s"), ZSTD_getErrorName(init_result));
-+	}
-+	to_read = buf_in_size;
-+	while ((just_read = fd_read(fd_in, buf_in, to_read))) {
-+		ZSTD_inBuffer input = { buf_in, just_read, 0 };
-+		while (input.pos < input.size) {
-+			size_t actualwrite;
-+			ZSTD_outBuffer output = { buf_out, buf_out_size, 0 };
-+			to_read = ZSTD_compressStream(cstream, &output , &input);
-+			if (ZSTD_isError(to_read)) {
-+				ohshit(_("ZSTD_decompressStream error : %s \n"),
-+				       ZSTD_getErrorName(to_read));
-+			}
-+			actualwrite = fd_write(fd_out, output.dst, output.pos);
-+			if (actualwrite != output.pos) {
-+				const char *errmsg = strerror(errno);
-+				ohshite(_("%s: internal zstd write error: '%s'"),
-+					desc, errmsg);
-+			}
-+		}
-+	}
-+	do {
-+		size_t actualwrite;
-+		ZSTD_outBuffer output = { buf_out, buf_out_size, 0 };
-+		end_res = ZSTD_endStream(cstream, &output);
-+		if (ZSTD_isError(end_res)) {
-+			ohshit(_("ZSTD_endStream error : %s \n"),
-+			       ZSTD_getErrorName(end_res));
-+		}
-+		actualwrite = fd_write(fd_out, output.dst, output.pos);
-+		if (actualwrite != output.pos) {
-+			const char *errmsg = strerror(errno);
-+			ohshite(_("%s: internal zstd write error: '%s'"), desc,
-+				errmsg);
-+		}
-+	} while (end_res > 0);
++    size_t const buf_in_size = ZSTD_CStreamInSize();
++    void*  const buf_in = m_malloc(buf_in_size);
++    size_t const buf_out_size = ZSTD_CStreamOutSize();
++    void*  const buf_out = m_malloc(buf_out_size);
++    size_t init_result, end_res;
++    size_t just_read, to_read;
++    ZSTD_CStream* const cstream = ZSTD_createCStream();
++    if (cstream == NULL) {
++        ohshit(_("ZSTD_createCStream error"));
++    }
++    init_result = ZSTD_initCStream(cstream, params->level);
++    if (ZSTD_isError(init_result)) {
++        ohshit(_("ZSTD_initCStream error : %s"), ZSTD_getErrorName(init_result));
++    }
++    to_read = buf_in_size;
++    while ((just_read = fd_read(fd_in, buf_in, to_read))) {
++        ZSTD_inBuffer input = { buf_in, just_read, 0 };
++        while (input.pos < input.size) {
++            size_t actualwrite;
++            ZSTD_outBuffer output = { buf_out, buf_out_size, 0 };
++            to_read = ZSTD_compressStream(cstream, &output, &input);
++            if (ZSTD_isError(to_read)) {
++                ohshit(_("ZSTD_decompressStream error : %s \n"),
++                       ZSTD_getErrorName(to_read));
++            }
++            actualwrite = fd_write(fd_out, output.dst, output.pos);
++            if (actualwrite != output.pos) {
++                const char *errmsg = strerror(errno);
++                ohshite(_("%s: internal zstd write error: '%s'"),
++                        desc, errmsg);
++            }
++        }
++    }
++    do {
++        size_t actualwrite;
++        ZSTD_outBuffer output = { buf_out, buf_out_size, 0 };
++        end_res = ZSTD_endStream(cstream, &output);
++        if (ZSTD_isError(end_res)) {
++            ohshit(_("ZSTD_endStream error : %s \n"),
++                   ZSTD_getErrorName(end_res));
++        }
++        actualwrite = fd_write(fd_out, output.dst, output.pos);
++        if (actualwrite != output.pos) {
++            const char *errmsg = strerror(errno);
++            ohshite(_("%s: internal zstd write error: '%s'"), desc,
++                    errmsg);
++        }
++    } while (end_res > 0);
 +
-+	ZSTD_freeCStream(cstream);
-+	free(buf_in);
-+	free(buf_out);
++    ZSTD_freeCStream(cstream);
++    free(buf_in);
++    free(buf_out);
 +
-+	/* ZSTD_endStream() already flushed the output buffers */
-+	if (close(fd_out))
-+		ohshite(_("%s: internal zstd write error"), desc);
++    /* ZSTD_endStream() already flushed the output buffers */
++    if (close(fd_out))
++        ohshite(_("%s: internal zstd write error"), desc);
 +}
 +
 +#else
@@ -237,58 +238,58 @@ diff --color -urN dpkg-1.21.7/lib/dpkg/compress.c dpkg-1.21.7/lib/dpkg/compress.
 +decompress_zstd(struct compress_params *params, int fd_in, int fd_out,
 +                const char *desc)
 +{
-+	fd_fd_filter(fd_in, fd_out, desc, env_zstd, ZSTD, "-dcq", NULL);
++    fd_fd_filter(fd_in, fd_out, desc, env_zstd, ZSTD, "-dcq", NULL);
 +}
 +
 +static void
 +compress_zstd(struct compress_params *params, int fd_in, int fd_out,
 +              const char *desc)
 +{
-+	char combuf[6];
++    char combuf[6];
 +
-+	snprintf(combuf, sizeof(combuf), "-c%d", params->level);
-+	fd_fd_filter(fd_in, fd_out, desc, env_zstd, ZSTD, combuf, "-q", NULL);
++    snprintf(combuf, sizeof(combuf), "-c%d", params->level);
++    fd_fd_filter(fd_in, fd_out, desc, env_zstd, ZSTD, combuf, "-q", NULL);
 +}
 +#endif
 +
 +static const struct compressor compressor_zstd = {
-+	.name = "zstd",
-+	.extension = ".zst",
-+          /* zstd commands's default is 3 but the aim is to be closer to xz's
-+           * default compression efficiency */
-+	.default_level = 19,
-+	.fixup_params = fixup_none_params,
-+	.compress = compress_zstd,
-+	.decompress = decompress_zstd,
++    .name = "zstd",
++    .extension = ".zst",
++    /* zstd commands's default is 3 but the aim is to be closer to xz's
++     * default compression efficiency */
++    .default_level = 19,
++    .fixup_params = fixup_none_params,
++    .compress = compress_zstd,
++    .decompress = decompress_zstd,
 +};
 +
 +/*
   * Generic compressor filter.
   */
- 
-@@ -927,6 +1086,7 @@
+
+@@ -941,6 +1099,7 @@
  	[COMPRESSOR_TYPE_XZ] = &compressor_xz,
  	[COMPRESSOR_TYPE_BZIP2] = &compressor_bzip2,
  	[COMPRESSOR_TYPE_LZMA] = &compressor_lzma,
 +	[COMPRESSOR_TYPE_ZSTD] = &compressor_zstd,
  };
- 
+
  static const struct compressor *
-diff --color -urN dpkg-1.21.7/lib/dpkg/compress.h dpkg-1.21.7ubuntu1/lib/dpkg/compress.h
---- dpkg-1.21.7/lib/dpkg/compress.h	2022-03-26 17:17:58.000000000 +0000
-+++ dpkg-1.21.7ubuntu1/lib/dpkg/compress.h	2022-04-07 14:15:26.000000000 +0000
+diff -urN a/lib/dpkg/compress.h b/lib/dpkg/compress.h
+--- a/lib/dpkg/compress.h
++++ b/lib/dpkg/compress.h
 @@ -42,6 +42,7 @@
  	COMPRESSOR_TYPE_XZ,
  	COMPRESSOR_TYPE_BZIP2,
  	COMPRESSOR_TYPE_LZMA,
 +	COMPRESSOR_TYPE_ZSTD,
  };
- 
+
  enum compressor_strategy {
-diff --color -urN dpkg-1.21.7/m4/dpkg-build.m4 dpkg-1.21.7/m4/dpkg-build.m4
---- dpkg-1.21.7/m4/dpkg-build.m4	2022-03-26 17:17:58.000000000 +0000
-+++ dpkg-1.21.7/m4/dpkg-build.m4	2022-06-01 15:04:19.092679000 +0000
-@@ -78,7 +78,7 @@
+diff -urN a/m4/dpkg-build.m4 b/m4/dpkg-build.m4
+--- a/m4/dpkg-build.m4
++++ b/m4/dpkg-build.m4
+@@ -77,7 +77,7 @@
        [change default dpkg-deb build compressor])],
      [with_dpkg_deb_compressor=$withval], [with_dpkg_deb_compressor=$1])
    AS_CASE([$with_dpkg_deb_compressor],
@@ -297,59 +298,60 @@ diff --color -urN dpkg-1.21.7/m4/dpkg-build.m4 dpkg-1.21.7/m4/dpkg-build.m4
      [AC_MSG_ERROR([unsupported default compressor $with_dpkg_deb_compressor])])
    AC_DEFINE_UNQUOTED([DPKG_DEB_DEFAULT_COMPRESSOR],
      [COMPRESSOR_TYPE_]AS_TR_CPP(${with_dpkg_deb_compressor}),
-diff --color -urN dpkg-1.21.7/m4/dpkg-libs.m4 dpkg-1.21.7/m4/dpkg-libs.m4
---- dpkg-1.21.7/m4/dpkg-libs.m4	2022-03-26 17:17:58.000000000 +0000
-+++ dpkg-1.21.7/m4/dpkg-libs.m4	2022-06-01 15:04:54.470736000 +0000
-@@ -100,6 +100,13 @@
-                      [Define to the zlib implementation to use])
+diff -urN a/m4/dpkg-libs.m4 b/m4/dpkg-libs.m4
+--- a/m4/dpkg-libs.m4
++++ b/m4/dpkg-libs.m4
+@@ -93,6 +93,13 @@
+     [Define to the zlib implementation to use])
  ])# DPKG_LIB_Z
- 
+
 +# DPKG_LIB_ZSTD
 +# -------------
 +# Check for zstd library.
 +AC_DEFUN([DPKG_LIB_ZSTD], [
-+  DPKG_WITH_COMPRESS_LIB([zstd], [zstd.h], [ZSTD_decompressStream])
++    DPKG_WITH_COMPRESS_LIB([zstd], [zstd.h], [ZSTD_decompressStream])
 +])# DPKG_LIB_ZSTD
 +
  # DPKG_LIB_LZMA
  # -------------
  # Check for lzma library.
-diff --color -urN dpkg-1.21.7/man/dpkg-deb.pod dpkg-1.21.7/man/dpkg-deb.pod
---- dpkg-1.21.7/man/dpkg-deb.pod	2022-03-26 17:17:58.000000000 +0000
-+++ dpkg-1.21.7/man/dpkg-deb.pod	2022-06-01 15:10:51.402629000 +0000
+diff -urN a/man/dpkg-deb.pod b/man/dpkg-deb.pod
+--- a/man/dpkg-deb.pod
++++ b/man/dpkg-deb.pod
 @@ -254,7 +254,7 @@
  =item B<-z>I<compress-level>
- 
+
  Specify which compression level to use on the compressor backend, when
 -building a package (default is 9 for gzip, 6 for xz).
-+building a package (default is 9 for gzip, 6 for xz and 19 for zstd).
++building a package (default is 9 for gzip, 6 for xz, and 19 for zstd).
  The accepted values are 0-9 with: 0 being mapped to compressor none for gzip.
  Before dpkg 1.16.2 level 0 was equivalent to compressor none for all
  compressors.
 @@ -269,8 +269,8 @@
  =item B<-Z>I<compress-type>
- 
+
  Specify which compression type to use when building a package.
 -Allowed values are B<gzip>, B<xz> (since dpkg 1.15.6),
 -and B<none> (default is B<xz>).
 +Allowed values are B<gzip>, B<xz> (since dpkg 1.15.6), B<zstd>
-+(since dpkg 1.20.0) and B<none> (default is B<zstd>).
- 
++(since dpkg 1.20.0), and B<none> (default is B<xz>).
+
  =item B<--[no-]uniform-compression>
- 
-@@ -278,8 +278,7 @@
+
+@@ -278,8 +278,8 @@
  members (i.e. B<control.tar> and B<data.tar>; since dpkg 1.17.6).
  Otherwise only the
  B<data.tar> member will use those parameters. The only supported
 -compression types allowed to be uniformly used are B<none>, B<gzip>
 -and B<xz>.
-+compression types allowed to be uniformly used are B<none>, B<gzip>, B<xz>, and B<zstd>.
++compression types allowed to be uniformly used are B<none>, B<gzip>,
++B<xz>, and B<zstd>.
  The B<--no-uniform-compression> option disables uniform compression
  (since dpkg 1.19.0).
  Uniform compression is the default (since dpkg 1.19.0).
-diff --color -urN dpkg-1.21.7/src/Makefile.am dpkg-1.21.7/src/Makefile.am
---- dpkg-1.21.7/src/Makefile.am	2022-03-26 17:17:59.000000000 +0000
-+++ dpkg-1.21.7/src/Makefile.am	2022-06-01 15:11:25.246506000 +0000
+diff -urN a/src/Makefile.am b/src/Makefile.am
+--- a/src/Makefile.am
++++ b/src/Makefile.am
 @@ -99,6 +99,7 @@
  dpkg_deb_LDADD = \
  	$(LDADD) \
@@ -358,9 +360,10 @@ diff --color -urN dpkg-1.21.7/src/Makefile.am dpkg-1.21.7/src/Makefile.am
  	$(LZMA_LIBS) \
  	$(BZ2_LIBS) \
  	# EOL
---- dpkg-1.21.7/src/at/deb-format.at	2022-03-26 17:17:59.000000000 +0000
-+++ dpkg-1.21.7ubuntu1/src/at/deb-format.at	2022-05-11 16:01:31.000000000 +0000
-@@ -187,6 +187,7 @@
+diff -urN a/src/at/deb-format.at b/src/at/deb-format.at
+--- a/src/at/deb-format.at
++++ b/src/at/deb-format.at
+@@ -194,6 +194,7 @@
  xz -c data.tar >data.tar.xz
  bzip2 -c data.tar >data.tar.bz2
  lzma -c data.tar >data.tar.lzma
@@ -368,15 +371,10 @@ diff --color -urN dpkg-1.21.7/src/Makefile.am dpkg-1.21.7/src/Makefile.am
  touch _ignore
  touch unknown
  ])
-@@ -471,6 +472,18 @@
- ], [], [debian-binary
- control.tar.gz
- data.tar.bz2
-+drwxr-xr-x root/root         0 1970-01-01 00:00 ./
-+-rw-r--r-- root/root         5 1970-01-01 00:00 ./file-templ
-+])
-+
-+AT_CHECK([
+@@ -483,6 +484,18 @@
+ ])
+
+ AT_CHECK([
 +# Test data.tar.zst member
 +ar rc pkg-data-zst.deb debian-binary control.tar.gz data.tar.zst
 +ar t pkg-data-zst.deb
@@ -384,13 +382,18 @@ diff --color -urN dpkg-1.21.7/src/Makefile.am dpkg-1.21.7/src/Makefile.am
 +], [], [debian-binary
 +control.tar.gz
 +data.tar.zst
- drwxr-xr-x root/root         0 1970-01-01 00:00 ./
- -rw-r--r-- root/root         5 1970-01-01 00:00 ./file-templ
- ])
-diff --color -urN dpkg-1.21.7/src/deb/extract.c dpkg-1.21.7/src/deb/extract.c
---- dpkg-1.21.7/src/deb/extract.c	2022-03-26 17:17:59.000000000 +0000
-+++ dpkg-1.21.7/src/deb/extract.c	2022-06-01 15:11:52.702366000 +0000
-@@ -183,6 +183,7 @@
++drwxr-xr-x root/root         0 1970-01-01 00:00 ./
++-rw-r--r-- root/root         5 1970-01-01 00:00 ./file-templ
++])
++
++AT_CHECK([
+ # Test data.tar.lzma member
+ ar rc pkg-data-lzma.deb debian-binary control.tar.gz data.tar.lzma
+ ar t pkg-data-lzma.deb
+diff -urN a/src/deb/extract.c b/src/deb/extract.c
+--- a/src/deb/extract.c
++++ b/src/deb/extract.c
+@@ -184,6 +184,7 @@
            decompress_params.type = compressor_find_by_extension(extension);
            if (decompress_params.type != COMPRESSOR_TYPE_NONE &&
                decompress_params.type != COMPRESSOR_TYPE_GZIP &&
@@ -398,10 +401,10 @@ diff --color -urN dpkg-1.21.7/src/deb/extract.c dpkg-1.21.7/src/deb/extract.c
                decompress_params.type != COMPRESSOR_TYPE_XZ)
              ohshit(_("archive '%s' uses unknown compression for member '%.*s', "
                       "giving up"),
-diff --color -urN dpkg-1.21.7/src/deb/main.c dpkg-1.21.7/src/deb/main.c
---- dpkg-1.21.7/src/deb/main.c	2022-03-26 17:17:59.000000000 +0000
-+++ dpkg-1.21.7/src/deb/main.c	2022-06-01 15:12:18.788425000 +0000
-@@ -108,7 +108,7 @@
+diff -urN a/src/deb/main.c b/src/deb/main.c
+--- a/src/deb/main.c
++++ b/src/deb/main.c
+@@ -109,7 +109,7 @@
  "      --[no-]uniform-compression   Use the compression params on all members.\n"
  "  -z#                              Set the compression level when building.\n"
  "  -Z<type>                         Set the compression type used when building.\n"
@@ -410,7 +413,7 @@ diff --color -urN dpkg-1.21.7/src/deb/main.c dpkg-1.21.7/src/deb/main.c
  "  -S<strategy>                     Set the compression strategy when building.\n"
  "                                     Allowed values: none; extreme (xz);\n"
  "                                     filtered, huffman, rle, fixed (gzip).\n"
-@@ -245,6 +245,7 @@
+@@ -303,6 +303,7 @@
    if (opt_uniform_compression &&
        (compress_params.type != COMPRESSOR_TYPE_NONE &&
         compress_params.type != COMPRESSOR_TYPE_GZIP &&

--- a/build_patch/dpkg/compile.diff
+++ b/build_patch/dpkg/compile.diff
@@ -1,14 +1,14 @@
-diff -urN dpkg-1.20.0/lib/dpkg/i18n.c dpkg/lib/dpkg/i18n.c
---- dpkg-1.20.0/lib/dpkg/i18n.c	2020-01-17 18:07:01.000000000 -0500
-+++ dpkg/lib/dpkg/i18n.c	2020-06-09 01:42:14.321741090 -0400
+diff -urN a/lib/dpkg/i18n.c b/lib/dpkg/i18n.c
+--- a/lib/dpkg/i18n.c	2020-01-17 18:07:01.000000000 -0500
++++ b/lib/dpkg/i18n.c	2020-06-09 01:42:14.321741090 -0400
 @@ -22,6 +22,10 @@
  #include <compat.h>
- 
+
  #include <dpkg/i18n.h>
-+#ifdef __APPLE__ 
-+#include <string.h> 
-+#include <xlocale.h> 
++#ifdef __APPLE__
++#include <string.h>
++#include <xlocale.h>
 +#endif
- 
+
  #ifdef HAVE_USELOCALE
  static locale_t dpkg_C_locale;

--- a/build_patch/dpkg/extrainst.diff
+++ b/build_patch/dpkg/extrainst.diff
@@ -17,7 +17,7 @@ diff -urN a/src/main/unpack.c b/src/main/unpack.c
 
    tar_deferred_extract(newfiles_queue.head, pkg);
 +  if (oldversionstatus == PKG_STAT_NOTINSTALLED || oldversionstatus == PKG_STAT_CONFIGFILES) {
-+    maintscript_new(pkg, EXTRAINSTFILE, "extra-installation", cidir, cdirrest,
++    maintscript_new(pkg, EXTRAINSTFILE, "extra-installation", cidir, cidirrest,
 +                    "install", NULL);
 +  } else {
 +    maintscript_new(pkg, EXTRAINSTFILE, "extra-installation", cidir, cidirrest,

--- a/build_patch/dpkg/extrainst.diff
+++ b/build_patch/dpkg/extrainst.diff
@@ -1,5 +1,6 @@
---- dpkg-1.21.7/lib/dpkg/dpkg.h	2022-03-26 17:17:58.000000000 +0000
-+++ dpkg-1.21.7/lib/dpkg/dpkg.h	2022-06-01 15:18:34.621589000 +0000
+diff -urN a/lib/dpkg/dpkg.h b/lib/dpkg/dpkg.h
+--- a/lib/dpkg/dpkg.h
++++ b/lib/dpkg/dpkg.h
 @@ -68,6 +68,7 @@
  #define CONTROLFILE        "control"
  #define CONFFILESFILE      "conffiles"
@@ -8,21 +9,22 @@
  #define POSTINSTFILE       "postinst"
  #define PRERMFILE          "prerm"
  #define POSTRMFILE         "postrm"
---- dpkg-1.21.7/src/main/unpack.c	2022-03-26 17:17:59.000000000 +0000
-+++ dpkg-1.21.7/src/main/unpack.c	2022-06-01 15:18:11.112664000 +0000
+diff -urN a/src/main/unpack.c b/src/main/unpack.c
+--- a/src/main/unpack.c
++++ b/src/main/unpack.c
 @@ -1577,6 +1577,15 @@
    subproc_reap(pid, BACKEND " --fsys-tarfile", SUBPROC_NOPIPE);
- 
+
    tar_deferred_extract(newfiles_queue.head, pkg);
 +  if (oldversionstatus == PKG_STAT_NOTINSTALLED || oldversionstatus == PKG_STAT_CONFIGFILES) {
-+    maintscript_new(pkg, EXTRAINSTFILE, "extra-installation", cidir, cidirrest,
++    maintscript_new(pkg, EXTRAINSTFILE, "extra-installation", cidir, cdirrest,
 +                    "install", NULL);
 +  } else {
-+    maintscript_new(pkg, EXTRAINSTFILE, "extra-installation", cidir, cidirrest, 
-+                    "upgrade", 
-+                    versiondescribe(&pkg->installed.version, vdew_nonambig), 
++    maintscript_new(pkg, EXTRAINSTFILE, "extra-installation", cidir, cidirrest,
++                    "upgrade",
++                    versiondescribe(&pkg->installed.version, vdew_nonambig),
 +                    NULL);
 +  }
- 
+
    if (oldversionstatus == PKG_STAT_HALFINSTALLED ||
        oldversionstatus == PKG_STAT_UNPACKED) {

--- a/build_patch/dpkg/no-update-dsc.diff
+++ b/build_patch/dpkg/no-update-dsc.diff
@@ -1,7 +1,7 @@
-diff -urN dpkg-1.20.0/src/help.c dpkg/src/help.c
---- dpkg-1.20.0/src/main/help.c	2020-01-17 18:07:01.000000000 -0500
-+++ dpkg/src/main/help.c	2020-06-09 01:42:14.321741090 -0400
-@@ -121,7 +121,6 @@
+diff -urN a/src/main/help.c b/src/main/help.c
+--- a/src/main/help.c
++++ b/src/main/help.c
+@@ -124,7 +124,6 @@
      /* Mac OS X uses dyld (Mach-O) instead of ld.so (ELF), and does not have
       * an ldconfig. */
  #if defined(__APPLE__) && defined(__MACH__)

--- a/makefiles/dpkg.mk
+++ b/makefiles/dpkg.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 STRAPPROJECTS  += dpkg
-DPKG_VERSION   := 1.21.9
+DPKG_VERSION   := 1.21.15
 DEB_DPKG_V     ?= $(DPKG_VERSION)
 
 dpkg-setup: setup

--- a/makefiles/dpkg.mk
+++ b/makefiles/dpkg.mk
@@ -22,14 +22,14 @@ dpkg:
 else
 dpkg: dpkg-setup gettext xz zstd libmd zlib-ng
 ifeq (,$(findstring darwin,$(MEMO_TARGET)))
-	sed -i '/base-bsd-darwin/a base-bsd-darwin-arm64		$(DEB_ARCH)' $(BUILD_WORK)/dpkg/data/tupletable
+	sed -e '|base-bsd-darwin|a base-bsd-darwin-arm64\t\t$(DEB_ARCH)' -i $(BUILD_WORK)/dpkg/data/tupletable
 endif
 	cd $(BUILD_WORK)/dpkg && ./autogen
 	cd $(BUILD_WORK)/dpkg && ./configure -C \
 		$(DEFAULT_CONFIGURE_FLAGS) \
 		--with-libz-ng \
-		--with-admindir=$(MEMO_PREFIX)/Library/dpkg \
-		--with-logdir=$(MEMO_PREFIX)/var/log \
+		--with-admindir="$(MEMO_PREFIX)/Library/dpkg" \
+		--with-logdir="$(MEMO_PREFIX)/var/log" \
 		--disable-start-stop-daemon \
 		--disable-dselect \
 		--without-libselinux \
@@ -38,13 +38,13 @@ endif
 		PERL_LIBDIR='$$(prefix)/share/perl5' \
 		PERL="$(shell command -v perl)" \
 		TAR=$(GNU_PREFIX)tar \
-		LZMA_LIBS='$(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)$(MEMO_ALT_PREFIX)/lib/liblzma.dylib'
+		LZMA_LIBS="$(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)$(MEMO_ALT_PREFIX)/lib/liblzma.dylib"
 	+$(MAKE) -C $(BUILD_WORK)/dpkg \
 		PERL="$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/perl"
 	+$(MAKE) -C $(BUILD_WORK)/dpkg install \
 		DESTDIR="$(BUILD_STAGE)/dpkg"
 	mkdir -p $(BUILD_STAGE)/dpkg/$(MEMO_PREFIX)/var/lib
-	$(LN_S) /$(MEMO_PREFIX)/Library/dpkg $(BUILD_STAGE)/dpkg/$(MEMO_PREFIX)/var/lib/dpkg
+	$(LN_S) $(MEMO_PREFIX)/Library/dpkg $(BUILD_STAGE)/dpkg/$(MEMO_PREFIX)/var/lib/dpkg
 	$(call AFTER_BUILD)
 endif
 
@@ -64,7 +64,7 @@ dpkg-package: dpkg-stage
 	rm -f $(BUILD_DIST)/dpkg/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/locale/*/LC_MESSAGES/!(dpkg.mo)
 	cp -a $(BUILD_STAGE)/dpkg/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/dpkg/{{abi,cpu,os,tuple}table,sh} $(BUILD_DIST)/dpkg/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/dpkg
 	mkdir -p $(BUILD_DIST)/dpkg/$(MEMO_PREFIX)/etc/dpkg/origins/
-	echo -e "Vendor: Procursus\nVendor-URL: https://github.com/ProcursusTeam/Procursus/\nBugs: mailto://me@diatrus.com" > $(BUILD_DIST)/dpkg/$(MEMO_PREFIX)/etc/dpkg/origins/procursus
+	echo -e "Vendor: Procursus\nVendor-URL: https://github.com/ProcursusTeam/Procursus/\nBugs: mailto://support@procurs.us" > $(BUILD_DIST)/dpkg/$(MEMO_PREFIX)/etc/dpkg/origins/procursus
 	$(LN_S) procursus $(BUILD_DIST)/dpkg/$(MEMO_PREFIX)/etc/dpkg/origins/default
 
 	# dpkg.mk Prep dpkg-dev


### PR DESCRIPTION
This PR updates `dpkg` to its latest released version, 1.21.15. Specific changes were documented under the commit message. Tested on iOS 14 and macOS 12.6.1, building on macOS.

### Checklist

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [x] This Pull Request doesn't contain any package additions; it's a small change (e.g README change, package update)
* [x] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [x] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
