### PR TITLE
tmux: Update to 3.3a

### DIFF
--- a/build_patch/tmux/fixcross.diff
+++ b/build_patch/tmux/fixcross.diff
@@ -1,9 +1,9 @@
-diff -urN tmux/configure.ac  tmux/configure.ac
---- tmux/configure.ac	2021-04-13 03:37:43.000000000 -0400
-+++ tmux/configure.ac	2021-05-13 19:47:48.000000000 -0400
-@@ -154,25 +154,8 @@
- ])
- AC_FUNC_STRNLEN
+diff -urN a/configure.ac b/configure.ac
+--- a/configure.ac	2022-06-09 07:30:50.000000000 -0400
++++ b/configure.ac	2023-01-03 22:51:14.000000000 -0400
+@@ -187,27 +187,8 @@
+ 	[AC_LIBOBJ(strtonum) AC_MSG_RESULT(no)]
+ )
 
 -# Clang sanitizers wrap reallocarray even if it isn't available on the target
 -# system. When compiled it always returns NULL and crashes the program. To
@@ -14,6 +14,7 @@ diff -urN tmux/configure.ac  tmux/configure.ac
 -		[return (reallocarray(NULL, 1, 1) == NULL);]
 -	)],
 -	AC_MSG_RESULT(yes),
+-	[AC_LIBOBJ(reallocarray) AC_MSG_RESULT([no])],
 -	[AC_LIBOBJ(reallocarray) AC_MSG_RESULT([no])]
 -)
 -AC_MSG_CHECKING([for working recallocarray])
@@ -22,6 +23,7 @@ diff -urN tmux/configure.ac  tmux/configure.ac
 -		[return (recallocarray(NULL, 1, 1, 1) == NULL);]
 -	)],
 -	AC_MSG_RESULT(yes),
+-	[AC_LIBOBJ(recallocarray) AC_MSG_RESULT([no])],
 -	[AC_LIBOBJ(recallocarray) AC_MSG_RESULT([no])]
 -)
 +AC_LIBOBJ(reallocarray)

--- a/makefiles/tmux.mk
+++ b/makefiles/tmux.mk
@@ -3,11 +3,11 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS    += tmux
-TMUX_VERSION   := 3.2
+TMUX_VERSION   := 3.3a
 DEB_TMUX_V     ?= $(TMUX_VERSION)
 
 tmux-setup: setup
-	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://github.com/tmux/tmux/releases/download/$(TMUX_VERSION)/tmux-$(TMUX_VERSION).tar.gz)
+	$(call GITHUB_ARCHIVE,tmux,tmux,$(TMUX_VERSION),$(TMUX_VERSION))
 	$(call EXTRACT_TAR,tmux-$(TMUX_VERSION).tar.gz,tmux-$(TMUX_VERSION),tmux)
 	$(call DO_PATCH,tmux,tmux,-p1)
 
@@ -16,7 +16,7 @@ tmux:
 	@echo "Using previously built tmux."
 else
 tmux: tmux-setup ncurses libevent libutf8proc
-	cd $(BUILD_WORK)/tmux && autoreconf -fi
+	cd $(BUILD_WORK)/tmux && ./autogen.sh
 	cd $(BUILD_WORK)/tmux && ./configure \
 		$(DEFAULT_CONFIGURE_FLAGS) \
 		--disable-static \
@@ -25,7 +25,7 @@ tmux: tmux-setup ncurses libevent libutf8proc
 		LIBNCURSES_LIBS="-lncursesw" \
 		LIBNCURSES_CFLAGS="-I$(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include/ncursesw"
 	+$(MAKE) -C $(BUILD_WORK)/tmux install \
-		DESTDIR=$(BUILD_STAGE)/tmux
+		DESTDIR="$(BUILD_STAGE)/tmux"
 	$(call AFTER_BUILD)
 endif
 


### PR DESCRIPTION
This PR updates tmux to its latest released version, 3.3a. Switching over to using GITHUB_ARCHIVE, as there are no noticable differences between tarballs from those in tmux's Releases and Github.

Tested on iOS 12, iOS 14, and macOS 12.6.1, building on macOS Monterrey.

### Checklist

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [x] This Pull Request doesn't contain any package additions; it's a small change (e.g README change, package update)
* [x] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [x] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
