### PR TITLE
dpkg-repack: Update to 1.52

### DIFF
--- a/makefiles/dpkg-repack.mk
+++ b/makefiles/dpkg-repack.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS         += dpkg-repack
-DPKG_REPACK_VERSION := 1.50
+DPKG_REPACK_VERSION := 1.52
 DEB_DPKG_REPACK_V   ?= $(DPKG_REPACK_VERSION)
 
 dpkg-repack-setup: setup

--- a/makefiles/dpkg-repack.mk
+++ b/makefiles/dpkg-repack.mk
@@ -19,8 +19,8 @@ dpkg-repack: dpkg-repack-setup
 		--section 1 \
 		--center='dpkg suite' \
 		--release='$(DEB_DPKG_REPACK_V)' \
-		< dpkg-repack.pod > dpkg-repack.1
-	sed -e "s:my \$$VERSION = .*;:my \$$VERSION = '$(DEB_DPKG_REPACK_V)';:" \
+		dpkg-repack.pod dpkg-repack.1
+	sed -e "s|x.y|$(DEB_DPKG_REPACK_V)|" \
 		-e "1s|.*|#!$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/perl|" \
 		-e "s/-pd/-pP/" \
 		< $(BUILD_WORK)/dpkg-repack/dpkg-repack.pl > $(BUILD_WORK)/dpkg-repack/dpkg-repack


### PR DESCRIPTION
This PR contains the following changes, on top of `dpkg-repack` being updated to its latest released verison, 1.52

- Fix manpage's name header when generating. It's DPKG-REPACK(1), not STDIN(1)
- Improve sed pattern to set version variable. Not sure why Debian maintainers don't do it like this...

Tested on iOS 12, iOS 14, & macOS 12.6.1, building on iOS 12 and macOS 12.6.1.

### Checklist

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [x] This Pull Request doesn't contain any package additions; it's a small change (e.g README change, package update)
* [x] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [x] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
