### PR TITLE
hotfix: Fix priorities in (extreme-)clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1544,10 +1544,10 @@ ifneq ($(MEMO_QUIET),1)
 endif # ($(MEMO_QUIET),1)
 
 clean::
-	rm -rf $(BUILD_ROOT)/build_{base,stage,work}
+	rm -rf $(BUILD_ROOT)/build_{source,stage}
 
 extreme-clean: clean
-	rm -rf $(BUILD_ROOT)/build_{source,strap,dist}
+	rm -rf $(BUILD_ROOT)/build_{base,strap,work}
 
 define mootext
                  (__)


### PR DESCRIPTION
Currently, directories such as `build_base` are cleared out when running `make clean`, which is not the intention of that Makefile rule. Instead, `clean` and `extreme-clean` have been restructured so that their names are not misleading.

This PR does not include any packages, so no checklist, Katri.