### PR TITLE
netcat: Fix packaging

### DIFF
--- a/makefiles/netcat.mk
+++ b/makefiles/netcat.mk
@@ -27,10 +27,9 @@ endif
 netcat-package: netcat-stage
 	# netcat.mk Package Structure
 	rm -rf $(BUILD_DIST)/netcat
-	mkdir -p $(BUILD_DIST)/netcat
 
 	# netcat.mk Prep netcat
-	cp -a $(BUILD_STAGE)/netcat/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX) $(BUILD_DIST)/netcat
+	cp -a $(BUILD_STAGE)/netcat $(BUILD_DIST)
 
 	# netcat.mk Sign
 	$(call SIGN,netcat,general.xml)


### PR DESCRIPTION
This PR fixes a small error in the packaging recipe of netcat where files were incorrectly copied over from `build_stage` to `build_dist`, specifically affecting rootless support. No functionality of the package itself was changed.

### Checklist

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [x] This Pull Request doesn't contain any package additions; it's a small change (e.g README change, recipe fixes)
* [x] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [ ] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
