### PR TITLE
ncurses: Update to 6.4

### DIFF
--- a/makefiles/ncurses.mk
+++ b/makefiles/ncurses.mk
@@ -7,7 +7,7 @@ STRAPPROJECTS   += ncurses
 else # ($(MEMO_TARGET),darwin-\*)
 SUBPROJECTS     += ncurses
 endif # ($(MEMO_TARGET),darwin-\*)
-NCURSES_VERSION := 6.3+20220423-2
+NCURSES_VERSION := 6.4
 DEB_NCURSES_V   ?= $(NCURSES_VERSION)
 
 ncurses-setup: setup

--- a/makefiles/ncurses.mk
+++ b/makefiles/ncurses.mk
@@ -11,8 +11,8 @@ NCURSES_VERSION := 6.4
 DEB_NCURSES_V   ?= $(NCURSES_VERSION)
 
 ncurses-setup: setup
-	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://salsa.debian.org/debian/ncurses/-/archive/debian/$(NCURSES_VERSION)/ncurses-debian-$(NCURSES_VERSION).tar.gz)
-	$(call EXTRACT_TAR,ncurses-debian-$(NCURSES_VERSION).tar.gz,ncurses-debian-$(NCURSES_VERSION),ncurses)
+	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://salsa.debian.org/debian/ncurses/-/archive/upstream/$(NCURSES_VERSION)/ncurses-upstream-$(NCURSES_VERSION).tar.gz)
+	$(call EXTRACT_TAR,ncurses-upstream-$(NCURSES_VERSION).tar.gz,ncurses-upstream-$(NCURSES_VERSION),ncurses)
 
 ifneq ($(wildcard $(BUILD_WORK)/ncurses/.build_complete),)
 ncurses:


### PR DESCRIPTION
This PR updates `ncurses` to its latest upstream version, 6.4. The update addresses several issues, [including one affecting vim instances within tmux.](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1027435)

### Checklist

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [ ] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)
* [x] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [x] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
