### PR TITLE
templates: Add -trimpath to Go template

### DIFF
--- a/build_misc/templates/go.mk
+++ b/build_misc/templates/go.mk
@@ -26,7 +26,6 @@ endif
 @pkg@-package: @pkg@-stage
 	# @pkg@.mk Package Structure
 	rm -rf $(BUILD_DIST)/@pkg@
-	mkdir -p $(BUILD_DIST)
 
 	# @pkg@.mk Prep @pkg@
 	cp -a $(BUILD_STAGE)/@pkg@ $(BUILD_DIST)

--- a/build_misc/templates/go.mk
+++ b/build_misc/templates/go.mk
@@ -17,7 +17,8 @@ ifneq ($(wildcard $(BUILD_WORK)/@pkg@/.build_complete),)
 else
 @pkg@: @pkg@-setup
 	cd $(BUILD_WORK)/@pkg@ && $(DEFAULT_GOLANG_FLAGS) go build \
-			-o $(BUILD_WORK)/@pkg@/@pkg@
+		-trimpath \
+		-o $(BUILD_WORK)/@pkg@/@pkg@
 	$(INSTALL) -Dm755 $(BUILD_WORK)/@pkg@/@pkg@ $(BUILD_STAGE)/@pkg@/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/
 	$(call AFTER_BUILD)
 endif


### PR DESCRIPTION
This PR introduces the `-trimpath` flag to the Go Makefile template, while cleaning up things that are no longer necessary. For more information as to why this flag was introduced, check out Debian's hosted manpage of [`go-build(1)`](https://manpages.debian.org/unstable/golang-go/go-build.1.en.html#trimpath).

### Checklist

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [x] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)
* [ ] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [ ] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
