### PR TITLE
p7zip: Moved in new organization

### DIFF
--- a/makefiles/p7zip.mk
+++ b/makefiles/p7zip.mk
@@ -7,7 +7,7 @@ P7ZIP_VERSION  := 17.04
 DEB_P7ZIP_V    ?= $(P7ZIP_VERSION)
 
 p7zip-setup: setup
-	$(call GITHUB_ARCHIVE,jinfeihan57,p7zip,$(P7ZIP_VERSION),v$(P7ZIP_VERSION))
+	$(call GITHUB_ARCHIVE,p7zip-project,p7zip,$(P7ZIP_VERSION),v$(P7ZIP_VERSION))
 	$(call EXTRACT_TAR,p7zip-$(P7ZIP_VERSION).tar.gz,p7zip-$(P7ZIP_VERSION),p7zip)
 	chmod 0755 $(BUILD_WORK)/p7zip/install.sh
 


### PR DESCRIPTION
This little PR change URL for p7zip. It seems that there is an [organization](https://github.com/p7zip-project) that mantains this project. So the [previous repo](https://github.com/jinfeihan57/p7zip) now is a fork without releases.

Tested on iOS 15.7.1 building on macOS Monterrey (GitHub Actions).

### Checklist

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [X] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)
* [X] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [X] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
