### PR TITLE
chore: Remove unmaintained mirror from list

### DIFF
--- a/mirrors.txt
+++ b/mirrors.txt
@@ -1,3 +1,2 @@
 https://apt.procurs.us
-https://repo.quiprr.dev/procursus
 https://procursus.itsnebula.net


### PR DESCRIPTION
quiprr no longer maintains their mirror, so it should be removed from the list hosted by Github.