### PR TITLE
libgpg-error: Enable install `gpg-error-config`

### DIFF
--- a/makefiles/libgpg-error.mk
+++ b/makefiles/libgpg-error.mk
@@ -28,7 +28,7 @@ else
 libgpg-error: libgpg-error-setup gettext
 	sed -i '/{"armv7-unknown-linux-gnueabihf"  },/a \ \ \ \ {"$(GNU_HOST_TRIPLE)",  "$(GPG_SCHEME)" },' $(BUILD_WORK)/libgpg-error/src/mkheader.c
 	cd $(BUILD_WORK)/libgpg-error && ./configure -C \
-		$(DEFAULT_CONFIGURE_FLAGS)
+		$(DEFAULT_CONFIGURE_FLAGS) --enable-install-gpg-error-config
 	+$(MAKE) -C $(BUILD_WORK)/libgpg-error install \
 		DESTDIR=$(BUILD_STAGE)/libgpg-error \
 		TESTS=""


### PR DESCRIPTION
It seems that `libgcrypt` [requires as optional `gpg-error-config`](https://github.com/ProcursusTeam/Procursus/blob/e2b8309e68ea60342e8ebef733837b7dfb6044d3/makefiles/libgcrypt.mk#L29) that is part of `libgpg-error`. Anyway with [update to 1.46](https://github.com/ProcursusTeam/Procursus/commit/892f546509beecb62f72d749b3bf07d943243feb) `libgpg-error` [deprecates `gpg-error-config`](https://dev.gnupg.org/T5923).
So this PR lets building properly `libgcrypt` and so all packages that depends on it like `apt`, cURL, `git`...

Tested on iOS 15.7.1 building on macOS Monterrey (GitHub Actions).

### Checklist

* [X] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [X] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)
* [X] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [ ] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
