### PR TITLE
Enable python scripting in lldb

### DIFF
--- a/build_info/python3-lldb-14.control
+++ b/build_info/python3-lldb-14.control
@@ -1,9 +1,9 @@
-Package: lldb-14
+Package: python3-lldb-14
 Section: Development
 Version: @DEB_LLVM_V@
 Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
-Depends: liblldb-14 (= @DEB_LLVM_V@), debugserver-14 (= @DEB_LLVM_V@), python3-lldb-14 (= @DEB_LLVM_V@)
+Depends: python3.9 (= 3.9.9-1), libpython3.9 (= 3.9.9-1)
 Priority: optional
 Homepage: https://www.llvm.org/
 Description: Next generation, high-performance debugger

--- a/build_patch/llvm/lldb-swig-multiple-declaration.diff
+++ b/build_patch/llvm/lldb-swig-multiple-declaration.diff
@@ -1,0 +1,10 @@
+--- llvm/lldb/bindings/interfaces.swig	2022-11-12 00:14:17.000000000 +0100
++++ llvm/lldb/bindings/interfaces.swig	2023-02-22 23:47:51.000000000 +0100
+@@ -2,7 +2,6 @@
+ #define __extension__ /* Undefine GCC keyword to make Swig happy when processing glibc's stdint.h. */
+ /* The ISO C99 standard specifies that in C++ implementations limit macros such
+    as INT32_MAX should only be defined if __STDC_LIMIT_MACROS is. */
+-#define __STDC_LIMIT_MACROS
+ %include "stdint.i"
+ 
+ %include "lldb/lldb-defines.h"

--- a/build_patch/llvm/python-typemaps-patch.diff
+++ b/build_patch/llvm/python-typemaps-patch.diff
@@ -1,0 +1,11 @@
+--- llvm/lldb/bindings/python/python-typemaps.swig	2022-11-12 00:14:17.000000000 +0100
++++ llvm/lldb/bindings/python/python-typemaps.swig	2023-02-23 17:48:52.000000000 +0100
+@@ -435,7 +435,7 @@
+ 
+ %typemap(out) lldb::FileSP {
+   $result = nullptr;
+-  lldb::FileSP &sp = $1;
++  const lldb::FileSP &sp = $1;
+   if (sp) {
+     PythonFile pyfile = unwrapOrSetPythonException(PythonFile::FromFile(*sp));
+     if (!pyfile.IsValid())

--- a/makefiles/llvm.mk
+++ b/makefiles/llvm.mk
@@ -2,6 +2,16 @@ ifneq ($(PROCURSUS),1)
 $(error Use the main Makefile)
 endif
 
+#Checking if swig and python3 is installed
+HAS_COMMAND = $(shell type $(1) >/dev/null 2>&1 && echo 1)
+ifneq ($(call HAS_COMMAND,swig),1)
+$(error Install swig)
+endif
+ifneq ($(call HAS_COMMAND,python3),1)
+$(error Install python3)
+endif
+PYTHON3_PATH := $(shell which python3)
+
 #### Consider mlir/pstl/flang too
 
 SUBPROJECTS     += llvm
@@ -70,6 +80,8 @@ ifeq ($(wildcard $(BUILD_WORK)/../../native/llvm/.build_complete),)
 	+$(MAKE) -C $(BUILD_WORK)/../../native/llvm swift-components lldb-tblgen
 	touch $(BUILD_WORK)/../../native/llvm/.build_complete
 endif
+
+
 
 ifeq ($(wildcard $(BUILD_WORK)/llvm/build/.build_complete),)
 	case $(MEMO_TARGET) in \
@@ -145,7 +157,8 @@ ifeq ($(wildcard $(BUILD_WORK)/llvm/build/.build_complete),)
 		-DLLDB_TABLEGEN_EXE="$(BUILD_WORK)/../../native/llvm/bin/lldb-tblgen" \
 		-DLLDB_BUILD_FRAMEWORK=OFF \
 		-DLLDB_ENABLE_LUA=OFF \
-		-DLLDB_ENABLE_PYTHON=OFF \
+		-DLLDB_PYTHON_RELATIVE_PATH="$(PYTHON3_PATH)" \
+		-DLLDB_ENABLE_PYTHON=ON \
 		-DSWIFT_DARWIN_DEPLOYMENT_VERSION_IOS="$(IPHONEOS_DEPLOYMENT_TARGET)" \
 		-DSWIFT_DARWIN_DEPLOYMENT_VERSION_OSX="$(MACOSX_DEPLYMENT_TARGET)" \
 		-DSWIFT_DARWIN_DEPLOYMENT_VERSION_WATCHOS="$(WATCHOS_DEPLOYMENT_TARGET)" \
@@ -311,7 +324,7 @@ endif
 	# llvm.mk Prep liblldb-$(LLVM_MAJOR_V)
 	mkdir -p $(BUILD_DIST)/liblldb-$(LLVM_MAJOR_V)/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/llvm-$(LLVM_MAJOR_V)/lib
 	cp -a $(BUILD_STAGE)/llvm/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/llvm-$(LLVM_MAJOR_V)/lib/liblldb.$(LLVM_VERSION).dylib $(BUILD_DIST)/liblldb-$(LLVM_MAJOR_V)/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/llvm-$(LLVM_MAJOR_V)/lib
-
+	
 	# llvm.mk Prep liblldb-$(LLVM_MAJOR_V)-dev
 	mkdir -p $(BUILD_DIST)/liblldb-$(LLVM_MAJOR_V)-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/llvm-$(LLVM_MAJOR_V)/{include,lib}
 	cp -a $(BUILD_STAGE)/llvm/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/llvm-$(LLVM_MAJOR_V)/include/lldb $(BUILD_DIST)/liblldb-$(LLVM_MAJOR_V)-dev/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/llvm-$(LLVM_MAJOR_V)/include
@@ -332,10 +345,14 @@ endif
 	cp -a $(BUILD_STAGE)/llvm/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/llvm-$(LLVM_MAJOR_V)/lib/libLLVM.dylib $(BUILD_DIST)/libllvm$(LLVM_MAJOR_V)/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/llvm-$(LLVM_MAJOR_V)/lib
 	$(LN_S) libLLVM.dylib $(BUILD_DIST)/libllvm$(LLVM_MAJOR_V)/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/llvm-$(LLVM_MAJOR_V)/lib/libLLVM-$(LLVM_MAJOR_V).dylib
 
+	#llvm.mk Prep python3-lldb-$(LLVM_MAJOR_V)
+	mkdir -p $(BUILD_DIST)/python3-lldb-$(LLVM_MAJOR_V)/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/local/lib/python3.9/dist-packages
+	cp -a $(BUILD_STAGE)/llvm/opt/procursus/bin/python3/. $(BUILD_DIST)/python3-lldb-$(LLVM_MAJOR_V)/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/local/lib/python3.9/dist-packages/
+
 	# llvm.mk Prep lldb-$(LLVM_MAJOR_V)
 	mkdir -p $(BUILD_DIST)/lldb-$(LLVM_MAJOR_V)/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/llvm-$(LLVM_MAJOR_V)/bin
 	cp -a $(BUILD_STAGE)/llvm/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/llvm-$(LLVM_MAJOR_V)/bin/lldb{,-argdumper,-instr,-server,-vscode} $(BUILD_DIST)/lldb-$(LLVM_MAJOR_V)/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib/llvm-$(LLVM_MAJOR_V)/bin
-
+	
 	# llvm.mk Prep lldb
 	mkdir -p $(BUILD_DIST)/lldb/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin
 	for bin in lldb{,-argdumper,-instr,-server,-vscode}; do \
@@ -415,8 +432,6 @@ endif
 	# llvm.mk Prep lld
 	mkdir -p $(BUILD_DIST)/lld/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin
 	$(LN_S) ../lib/llvm-$(LLVM_MAJOR_V)/bin/{ld.lld,ld64.lld,lld,lld-link,wasm-ld} $(BUILD_DIST)/lld/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/
-
-
 	# llvm.mk Sign
 	$(call SIGN,clang-$(LLVM_MAJOR_V),general.xml)
 	$(call SIGN,clangd-$(LLVM_MAJOR_V),general.xml)
@@ -461,6 +476,7 @@ endif
 	$(call PACK,liblldb-$(LLVM_MAJOR_V),DEB_LLVM_V)
 	$(call PACK,liblldb-$(LLVM_MAJOR_V)-dev,DEB_LLVM_V)
 	$(call PACK,libllvm$(LLVM_MAJOR_V),DEB_LLVM_V)			# Provides libllvm-polly
+	$(call PACK,python3-lldb-$(LLVM_MAJOR_V),DEB_LLVM_V)
 	$(call PACK,lldb-$(LLVM_MAJOR_V),DEB_LLVM_V)
 	$(call PACK,lldb,DEB_LLVM_V)
 	$(call PACK,swift-$(SWIFT_VERSION),DEB_SWIFT_V)


### PR DESCRIPTION
This PR enables python scripting support in lldb.
New package `python3-lldb-14` is added and now `lldb-14` depends on it.
`swig` and `python3` is required to build llvm.

Build tested on macOS 12 host for iOS 15.1.
