### PR TITLE
gzip: Update to 1.12

### DIFF
--- a/makefiles/gzip.mk
+++ b/makefiles/gzip.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 STRAPPROJECTS += gzip
-GZIP_VERSION  := 1.11
+GZIP_VERSION  := 1.12
 DEB_GZIP_V    ?= $(GZIP_VERSION)
 
 gzip-setup: setup

--- a/makefiles/gzip.mk
+++ b/makefiles/gzip.mk
@@ -18,10 +18,9 @@ gzip:
 else
 gzip: gzip-setup
 	cd $(BUILD_WORK)/gzip && ./configure -C \
-		$(DEFAULT_CONFIGURE_FLAGS) \
-		--disable-dependency-tracking
+		$(DEFAULT_CONFIGURE_FLAGS)
 	+$(MAKE) -C $(BUILD_WORK)/gzip install \
-		DESTDIR=$(BUILD_STAGE)/gzip
+		DESTDIR="$(BUILD_STAGE)/gzip"
 ifneq ($(MEMO_SUB_PREFIX),)
 	for bin in $(BUILD_STAGE)/gzip/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/*; do \
 		$(LN_S) $(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/$$(basename $$bin) $(BUILD_STAGE)/gzip/$(MEMO_PREFIX)/bin/$$(basename $$bin); \


### PR DESCRIPTION
This PR updates gzip to its latest released version, 1.12. Tested on iOS 12 and macOS 12.6.1, building on macOS.

### Checklist

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [ ] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)
* [x] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [x] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
