### PR TITLE
jbat: Use hack-different's Github instance

### DIFF
--- a/makefiles/jbat.mk
+++ b/makefiles/jbat.mk
@@ -8,7 +8,6 @@ DEB_JBAT_V   ?= $(JBAT_VERSION)
 
 jbat-setup: setup
 	$(call DOWNLOAD_FILE,$(BUILD_WORK)/jbat/jbat.c,https://github.com/hack-different/newosxbook-tools/raw/main/src/bat.c)
-	sed -i '/free/d' $(BUILD_WORK)/jbat/jbat.c
 
 ifneq ($(wildcard $(BUILD_WORK)/jbat/.build_complete),)
 jbat:

--- a/makefiles/jbat.mk
+++ b/makefiles/jbat.mk
@@ -7,9 +7,7 @@ JBAT_VERSION := 1.0
 DEB_JBAT_V   ?= $(JBAT_VERSION)
 
 jbat-setup: setup
-	mkdir -p $(BUILD_WORK)/jbat
-	lynx -width 1000 -dump http://newosxbook.com/src.jl\?tree\=listings\&file\=bat.c > \
-		$(BUILD_WORK)/jbat/jbat.c
+	$(call DOWNLOAD_FILE,$(BUILD_WORK)/jbat/jbat.c,https://github.com/hack-different/newosxbook-tools/raw/main/src/bat.c)
 	sed -i '/free/d' $(BUILD_WORK)/jbat/jbat.c
 
 ifneq ($(wildcard $(BUILD_WORK)/jbat/.build_complete),)

--- a/makefiles/jbat.mk
+++ b/makefiles/jbat.mk
@@ -3,11 +3,12 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS  += jbat
+JBAT_COMMIT  := b523e79866390ac4905a97d2c8c7106e9c256408
 JBAT_VERSION := 1.0
 DEB_JBAT_V   ?= $(JBAT_VERSION)
 
 jbat-setup: setup
-	$(call DOWNLOAD_FILE,$(BUILD_WORK)/jbat/jbat.c,https://github.com/hack-different/newosxbook-tools/raw/main/src/bat.c)
+	$(call DOWNLOAD_FILE,$(BUILD_WORK)/jbat/jbat.c,https://github.com/hack-different/newosxbook-tools/raw/$(JBAT_COMMIT)/src/bat.c)
 
 ifneq ($(wildcard $(BUILD_WORK)/jbat/.build_complete),)
 jbat:


### PR DESCRIPTION
This PR switches Levin's jbat tool to using hack-different's re-host on Github, which already includes patches previously made (with further improvements). Tested on iOS 12, 14, and macOS 12.6.1, building on iOS 12.

### Checklist

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [x] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)
* [x] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [x] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
