### PR TITLE
htop: Update to 3.2.2

### DIFF
--- a/makefiles/htop.mk
+++ b/makefiles/htop.mk
@@ -7,7 +7,8 @@ HTOP_VERSION := 3.2.2
 DEB_HTOP_V   ?= $(HTOP_VERSION)
 
 htop-setup: setup
-	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://github.com/htop-dev/htop/releases/download/$(HTOP_VERSION)/htop-$(HTOP_VERSION).tar.xz)
+	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://github.com/htop-dev/htop/releases/download/$(HTOP_VERSION)/htop-$(HTOP_VERSION).tar.xz{$(comma).sha256})
+	$(call CHECKSUM_VERIFY,sha256,htop-$(HTOP_VERSION).tar.xz)
 	$(call EXTRACT_TAR,htop-$(HTOP_VERSION).tar.xz,htop-$(HTOP_VERSION),htop)
 
 ifneq ($(wildcard $(BUILD_WORK)/htop/.build_complete),)

--- a/makefiles/htop.mk
+++ b/makefiles/htop.mk
@@ -7,22 +7,21 @@ HTOP_VERSION := 3.2.2
 DEB_HTOP_V   ?= $(HTOP_VERSION)
 
 htop-setup: setup
-	$(call GITHUB_ARCHIVE,htop-dev,htop,$(HTOP_VERSION),$(HTOP_VERSION))
-	$(call EXTRACT_TAR,htop-$(HTOP_VERSION).tar.gz,htop-$(HTOP_VERSION),htop)
+	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://github.com/htop-dev/htop/releases/download/$(HTOP_VERSION)/htop-$(HTOP_VERSION).tar.xz)
+	$(call EXTRACT_TAR,htop-$(HTOP_VERSION).tar.xz,htop-$(HTOP_VERSION),htop)
 
 ifneq ($(wildcard $(BUILD_WORK)/htop/.build_complete),)
 htop:
 	@echo "Using previously built htop."
 else
 htop: htop-setup ncurses
-	cd $(BUILD_WORK)/htop && ./autogen.sh
 	cd $(BUILD_WORK)/htop && ./configure \
 		$(DEFAULT_CONFIGURE_FLAGS) \
 		--disable-static \
 		--disable-linux-affinity \
 		ac_cv_lib_ncursesw_addnwstr=yes
 	+$(MAKE) -C $(BUILD_WORK)/htop install \
-		DESTDIR=$(BUILD_STAGE)/htop
+		DESTDIR="$(BUILD_STAGE)/htop"
 	rm -rf $(BUILD_STAGE)/htop/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/{applications,pixmaps}
 	$(call AFTER_BUILD)
 endif

--- a/makefiles/htop.mk
+++ b/makefiles/htop.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS  += htop
-HTOP_VERSION := 3.2.1
+HTOP_VERSION := 3.2.2
 DEB_HTOP_V   ?= $(HTOP_VERSION)
 
 htop-setup: setup


### PR DESCRIPTION
This PR updates htop to its latest released version, 3.2.2. Some notable changes to the Makefile include

- Use pre-built release tarballs from Github over downloading the source from those generated **by** Github (with `GITHUB_ARCHIVE`)
- Verify release tarball checksum with `CHECKSUM_VERIFY`

Tested on iOS 12, iOS 14, and macOS 12.6.1, building on macOS.

### Checklist

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [ ] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)
* [x] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [x] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
