### PR TITLE
grep: Update to 3.10

### DIFF
--- a/makefiles/grep.mk
+++ b/makefiles/grep.mk
@@ -2,10 +2,6 @@ ifneq ($(PROCURSUS),1)
 $(error Use the main Makefile)
 endif
 
-ifneq (,$(findstring darwin,$(MEMO_TARGET)))
-GREP_CONFIGURE_ARGS := --program-prefix=$(GNU_PREFIX)
-endif
-
 ifeq (,$(findstring darwin,$(MEMO_TARGET)))
 STRAPPROJECTS += grep
 else # ($(MEMO_TARGET),darwin-\*)
@@ -32,10 +28,10 @@ endif
 		$(DEFAULT_CONFIGURE_FLAGS) \
 		--disable-dependency-tracking \
 		--with-packager="$(DEB_MAINTAINER)" \
-		$(GREP_CONFIGURE_ARGS)
+		--program-prefix="$(GNU_PREFIX)"
 	+$(MAKE) -C $(BUILD_WORK)/grep
 	+$(MAKE) -C $(BUILD_WORK)/grep install \
-		DESTDIR=$(BUILD_STAGE)/grep
+		DESTDIR="$(BUILD_STAGE)/grep"
 	$(call AFTER_BUILD)
 endif
 

--- a/makefiles/grep.mk
+++ b/makefiles/grep.mk
@@ -7,7 +7,7 @@ STRAPPROJECTS += grep
 else # ($(MEMO_TARGET),darwin-\*)
 SUBPROJECTS   += grep
 endif # ($(MEMO_TARGET),darwin-\*)
-GREP_VERSION  := 3.8
+GREP_VERSION  := 3.9
 DEB_GREP_V    ?= $(GREP_VERSION)
 
 grep-setup: setup

--- a/makefiles/grep.mk
+++ b/makefiles/grep.mk
@@ -7,7 +7,7 @@ STRAPPROJECTS += grep
 else # ($(MEMO_TARGET),darwin-\*)
 SUBPROJECTS   += grep
 endif # ($(MEMO_TARGET),darwin-\*)
-GREP_VERSION  := 3.9
+GREP_VERSION  := 3.10
 DEB_GREP_V    ?= $(GREP_VERSION)
 
 grep-setup: setup

--- a/makefiles/grep.mk
+++ b/makefiles/grep.mk
@@ -11,8 +11,8 @@ STRAPPROJECTS += grep
 else # ($(MEMO_TARGET),darwin-\*)
 SUBPROJECTS   += grep
 endif # ($(MEMO_TARGET),darwin-\*)
-GREP_VERSION  := 3.7
-DEB_GREP_V    ?= $(GREP_VERSION)-1
+GREP_VERSION  := 3.8
+DEB_GREP_V    ?= $(GREP_VERSION)
 
 grep-setup: setup
 	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://ftpmirror.gnu.org/grep/grep-$(GREP_VERSION).tar.xz{$(comma).sig})

--- a/makefiles/grep.mk
+++ b/makefiles/grep.mk
@@ -26,7 +26,6 @@ grep: grep-setup
 endif
 	cd $(BUILD_WORK)/grep && ./configure -C \
 		$(DEFAULT_CONFIGURE_FLAGS) \
-		--disable-dependency-tracking \
 		--with-packager="$(DEB_MAINTAINER)" \
 		--program-prefix="$(GNU_PREFIX)"
 	+$(MAKE) -C $(BUILD_WORK)/grep


### PR DESCRIPTION
This PR updates grep to its latest released version, 3.10. Notable changes to the Makefile are documented under the commit message. Tested on iOS 12, iOS 14, and macOS 12.6.1, building on macOS.

### Checklist

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [x] This Pull Request doesn't contain any package additions; it's a small change (e.g README change, package update)
* [x] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [x] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
