### PR TITLE
ed: Update to 1.19

### DIFF
--- a/makefiles/ed.mk
+++ b/makefiles/ed.mk
@@ -18,13 +18,13 @@ else
 ed: ed-setup
 	cd $(BUILD_WORK)/ed && ./configure \
 		$(DEFAULT_CONFIGURE_FLAGS) \
-		CC=$(CC) \
+		CC="$(CC)" \
 		CFLAGS="$(CCFLAGS)" \
 		CPPFLAGS="$(CPPFLAGS)" \
 		LDFLAGS="$(LDFLAGS)"
 	+$(MAKE) -C $(BUILD_WORK)/ed
-	+$(MAKE) -C $(BUILD_WORK)/ed install -j1 \
-		DESTDIR=$(BUILD_STAGE)/ed
+	+$(MAKE) -C $(BUILD_WORK)/ed install \
+		DESTDIR="$(BUILD_STAGE)/ed"
 	$(call AFTER_BUILD,copy)
 endif
 

--- a/makefiles/ed.mk
+++ b/makefiles/ed.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS += ed
-ED_VERSION  := 1.18
+ED_VERSION  := 1.19
 DEB_ED_V    ?= $(ED_VERSION)
 
 ed-setup: setup


### PR DESCRIPTION
This PR updates `ed` to its latest released version, 1.19. Tested on iOS 12, iOS 14, and macOS 12.6.1, building on macOS and iOS. 

### Checklist

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [x] This Pull Request doesn't contain any package additions; it's a small change (e.g README change, package update)
* [x] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [x] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
