### PR TITLE
less: Update to 608

### DIFF
--- a/makefiles/less.mk
+++ b/makefiles/less.mk
@@ -7,7 +7,8 @@ LESS_VERSION := 608
 DEB_LESS_V   ?= $(LESS_VERSION)
 
 less-setup: setup
-	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),http://www.greenwoodsoftware.com/less/less-$(LESS_VERSION).tar.gz)
+	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://ftpmirror.gnu.org/gnu/less/less-$(LESS_VERSION).tar.gz{$(comma).sig})
+	$(call PGP_VERIFY,less-$(LESS_VERSION).tar.gz)
 	$(call EXTRACT_TAR,less-$(LESS_VERSION).tar.gz,less-$(LESS_VERSION),less)
 
 ifneq ($(wildcard $(BUILD_WORK)/less/.build_complete),)
@@ -36,9 +37,9 @@ endif
 
 	# less.mk Prep less
 	cp -a $(BUILD_STAGE)/less/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/* $(BUILD_DIST)/less/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)
-	$(LN_S) /$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/less $(BUILD_DIST)/less/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/more
+	$(LN_S) $(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/less $(BUILD_DIST)/less/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/more
 ifneq ($(MEMO_SUB_PREFIX),)
-	$(LN_S) /$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/less $(BUILD_DIST)/less/$(MEMO_PREFIX)/bin/more
+	$(LN_S) $(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/less $(BUILD_DIST)/less/$(MEMO_PREFIX)/bin/more
 endif
 
 	# less.mk Sign

--- a/makefiles/less.mk
+++ b/makefiles/less.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS  += less
-LESS_VERSION := 590
+LESS_VERSION := 608
 DEB_LESS_V   ?= $(LESS_VERSION)
 
 less-setup: setup


### PR DESCRIPTION
This PR updates less to its latest released version, 608. The Makefile now checks the downloaded tarball with a PGP signature using `PGP_VERIFY`. Tested on iOS 12, 14, and macOS 12.6.1.

### Checklist

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [ ] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)
* [x] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [x] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
