### PR TITLE
ninja: Update to 1.11.1

### DIFF
--- a/makefiles/ninja.mk
+++ b/makefiles/ninja.mk
@@ -9,18 +9,17 @@ DEB_NINJA_V   ?= $(NINJA_VERSION)
 ninja-setup: setup
 	$(call GITHUB_ARCHIVE,ninja-build,ninja,$(NINJA_VERSION),v$(NINJA_VERSION))
 	$(call EXTRACT_TAR,ninja-$(NINJA_VERSION).tar.gz,ninja-$(NINJA_VERSION),ninja)
-	mkdir -p $(BUILD_WORK)/ninja/build $(BUILD_STAGE)/ninja/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin
 
 ifneq ($(wildcard $(BUILD_WORK)/ninja/.build_complete),)
 ninja:
 	@echo "Using previously built ninja."
 else
 ninja: ninja-setup
-	cd $(BUILD_WORK)/ninja/build && cmake . \
-		$(DEFAULT_CMAKE_FLAGS) \
-		..
+	cd $(BUILD_WORK)/ninja && cmake -B build \
+		$(DEFAULT_CMAKE_FLAGS)
 	+$(MAKE) -C $(BUILD_WORK)/ninja/build
-	cp $(BUILD_WORK)/ninja/build/ninja $(BUILD_STAGE)/ninja/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/
+	+$(MAKE) -C $(BUILD_WORK)/ninja/build install \
+		DESTDIR="$(BUILD_STAGE)/ninja"
 	$(call AFTER_BUILD)
 endif
 

--- a/makefiles/ninja.mk
+++ b/makefiles/ninja.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS   += ninja
-NINJA_VERSION := 1.10.2
+NINJA_VERSION := 1.11.1
 DEB_NINJA_V   ?= $(NINJA_VERSION)
 
 ninja-setup: setup


### PR DESCRIPTION
This pull request updates ninja to its latest released version, 1.11.1. Rather than the Makefile handling a build directory, this change uses cmake's `-B` flag, introduced in 3.13+. Tested on iOS 12, 14, and macOS 12.6.1.

### Checklist

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [ ] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)
* [x] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [x] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
