### PR TITLE
[BerkeleyDB] fix bug in autotools

### DIFF
--- a/makefiles/berkeleydb.mk
+++ b/makefiles/berkeleydb.mk
@@ -17,7 +17,7 @@ berkeleydb:
 	@echo "Using previously built berkeleydb."
 else
 berkeleydb: berkeleydb-setup gettext openssl
-	cd $(BUILD_WORK)/berkeleydb/dist && ./s_config
+	cd $(BUILD_WORK)/berkeleydb/dist && ./s_config && sed -i 's/tlsvar = NULL/tlsvar = {}/g' configure
 	cd $(BUILD_WORK)/berkeleydb/build_unix && ../dist/configure \
 		$(DEFAULT_CONFIGURE_FLAGS) \
 		--includedir=$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include/db181 \


### PR DESCRIPTION
fix bug in autotools where Thread-Local Storage isn't detected because of undefined identifier 'NULL'

without this, autotools fails with:
conftest.cpp:31:72: error: use of undeclared identifier 'NULL' template<typename T>  __thread  T* TLSClass<T>::tlsvar = NULL;

### All Submissions

* [ ] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [ ] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)

### Package Additions/Updates

* [ ] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [ ] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
