### PR TITLE
make: Update to 4.4.1

### DIFF
--- a/makefiles/make.mk
+++ b/makefiles/make.mk
@@ -6,10 +6,6 @@ SUBPROJECTS  += make
 MAKE_VERSION := 4.4.1
 DEB_MAKE_V   ?= $(MAKE_VERSION)
 
-ifneq (,$(findstring darwin,$(MEMO_TARGET)))
-MAKE_CONFIGURE_ARGS := --program-prefix=$(GNU_PREFIX)
-endif
-
 make-setup: setup
 	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://ftpmirror.gnu.org/make/make-$(MAKE_VERSION).tar.gz{$(comma).sig})
 	$(call PGP_VERIFY,make-$(MAKE_VERSION).tar.gz)
@@ -23,7 +19,7 @@ make: make-setup gettext
 	cd $(BUILD_WORK)/make && ./configure -C \
 		$(DEFAULT_CONFIGURE_FLAGS) \
 		--with-guile=no \
-		$(MAKE_CONFIGURE_ARGS)
+		--program-prefix="$(GNU_PREFIX)"
 	+$(MAKE) -C $(BUILD_WORK)/make
 	+$(MAKE) -C $(BUILD_WORK)/make install \
 		DESTDIR="$(BUILD_STAGE)/make"

--- a/makefiles/make.mk
+++ b/makefiles/make.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS  += make
-MAKE_VERSION := 4.4
+MAKE_VERSION := 4.4.1
 DEB_MAKE_V   ?= $(MAKE_VERSION)
 
 ifneq (,$(findstring darwin,$(MEMO_TARGET)))


### PR DESCRIPTION
This PR updates `make` to its latest version, 4.4.1. Tested on iOS 14 and macOS 12.6.1. Notes regarding changes are under the commit message.

### Checklist

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [ ] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)
* [x] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [x] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
