### PR TITLE
gh: Update to 2.27.0

### DIFF
--- a/makefiles/gh.mk
+++ b/makefiles/gh.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS += gh
-GH_VERSION  := 2.21.2
+GH_VERSION  := 2.27.0
 DEB_GH_V    ?= $(GH_VERSION)
 
 gh-setup: setup


### PR DESCRIPTION
This PR updates `gh` to its latest released version, 2.27.0. [Nothing more, nothing less.](https://github.com/cli/cli/releases/tag/v2.27.0)

### Checklist

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [ ] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)
* [x] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [x] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
