### PR TITLE
locsim: Fix building for rootless targets

### DIFF
--- a/makefiles/locsim.mk
+++ b/makefiles/locsim.mk
@@ -22,7 +22,6 @@ locsim: locsim-setup
 	$(CC) $(CFLAGS) $(LDFLAGS) $(BUILD_WORK)/locsim/{main,LSMGPXParserDelegate}.m \
 		-o $(BUILD_STAGE)/locsim/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/locsim \
 		-fobjc-arc -framework Foundation -framework CoreLocation
-	$(LN_S) $(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/locsim $(BUILD_STAGE)/locsim/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)$(MEMO_ALT_PREFIX)/bin/locsim
 	$(call AFTER_BUILD)
 endif
 

--- a/makefiles/locsim.mk
+++ b/makefiles/locsim.mk
@@ -7,7 +7,7 @@ ifeq (,$(findstring darwin,$(MEMO_TARGET)))
 SUBPROJECTS     += locsim
 LOCSIM_COMMIT   := 8bf4acb80bd10c121fb404341989692d4310f8f6
 LOCSIM_VERSION  := 1.1.8
-DEB_LOCSIM_V    ?= $(LOCSIM_VERSION)
+DEB_LOCSIM_V    ?= $(LOCSIM_VERSION)-1
 
 locsim-setup: setup
 	$(call GITHUB_ARCHIVE,udevsharold,locsim,$(LOCSIM_COMMIT),$(LOCSIM_COMMIT),locsim)


### PR DESCRIPTION
This PR fixes building `locsim` on rootless targets. Bumping up the version should require users to update the package. Changes were documented under the commit message.

### Checklist

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [x] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)
* [x] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [ ] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
