### PR TITLE
dpkg: Update to 1.21.22

### DIFF
--- a/makefiles/dpkg.mk
+++ b/makefiles/dpkg.mk
@@ -22,7 +22,7 @@ dpkg:
 else
 dpkg: dpkg-setup gettext xz zstd libmd zlib-ng
 ifeq (,$(findstring darwin,$(MEMO_TARGET)))
-	sed -e '\|base-bsd-darwin|a base-bsd-darwin-arm64\t\t$(DEB_ARCH)' -i $(BUILD_WORK)/dpkg/data/tupletable
+	sed -i "\|base-bsd-darwin|a base-bsd-darwin-arm64\t\t$(DEB_ARCH)" $(BUILD_WORK)/dpkg/data/tupletable
 endif
 	cd $(BUILD_WORK)/dpkg && ./autogen
 	cd $(BUILD_WORK)/dpkg && ./configure -C \
@@ -37,7 +37,7 @@ endif
 		LDFLAGS="$(CFLAGS) $(LDFLAGS)" \
 		PERL_LIBDIR='$$(prefix)/share/perl5' \
 		PERL="$(shell command -v perl)" \
-		TAR=$(GNU_PREFIX)tar \
+		TAR="$(GNU_PREFIX)tar" \
 		LZMA_LIBS="$(BUILD_BASE)$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)$(MEMO_ALT_PREFIX)/lib/liblzma.dylib"
 	+$(MAKE) -C $(BUILD_WORK)/dpkg \
 		PERL="$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/perl"

--- a/makefiles/dpkg.mk
+++ b/makefiles/dpkg.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 STRAPPROJECTS  += dpkg
-DPKG_VERSION   := 1.21.21
+DPKG_VERSION   := 1.21.22
 DEB_DPKG_V     ?= $(DPKG_VERSION)
 
 dpkg-setup: setup


### PR DESCRIPTION
For whatever reason, dpkg maintainers decided to remove old versions of dpkg. Updating `dpkg` should prevent people from having issues regarding missing tarballs, and users will be obtaining the latest version.

### Checklist

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [ ] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)
* [x] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [x] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
