### PR TITLE
rsync: Update to 3.2.7

### DIFF
--- a/makefiles/rsync.mk
+++ b/makefiles/rsync.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS   += rsync
-RSYNC_VERSION := 3.2.4
+RSYNC_VERSION := 3.2.7
 DEB_RSYNC_V   ?= $(RSYNC_VERSION)-1
 
 rsync-setup: setup


### PR DESCRIPTION
This PR updates rsync to 3.2.7.

### Checklist

* [X] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [X] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)
* [X] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [ ] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
