### PR TITLE
Makefile: Delete .la symlinks when packing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -831,7 +831,7 @@ AFTER_BUILD = \
 
 PACK = \
 	if [ -z "$(4)" ]; then \
-		find $(BUILD_DIST)/$(1) -name '*.la' -type f -delete; \
+		find $(BUILD_DIST)/$(1) -name '*.la' \( -type f -o -type l \) -delete; \
 	fi; \
 	rm -f $(BUILD_DIST)/$(1)/.build_complete; \
 	rm -rf $(BUILD_DIST)/$(1)/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/{info,doc}; \


### PR DESCRIPTION
Several packages, e.g `libpng16` have several `*.la` files, some which are symbolic links. When packing, their parent files are deleted. In reality, parent files should be deleted alongside symbolic links pointing to them.