### PR TITLE
Makefile: Delete .la symlinks after building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -827,7 +827,7 @@ AFTER_BUILD = \
 	fi; \
 	[ -d $(BUILD_WORK)/$$pkg/ ] || mkdir $(BUILD_WORK)/$$pkg/; \
 	touch $(BUILD_WORK)/$$pkg/.build_complete; \
-	find $(BUILD_BASE) -name '*.la' -type f -delete
+	find $(BUILD_BASE) -name '*.la' \( -type f -o -type l \) -delete
 
 PACK = \
 	if [ -z "$(4)" ]; then \


### PR DESCRIPTION
When packages (particularly, libraries) are built, they're copied to `BUILD_BASE` so that they can be accessed by other packages when building. Seeing as libtool files are not necessary, `AFTER_BUILD` suffers from the issue addressed in #1404, which has been fixed here.