### PR TITLE
pcre2: Update to 10.42

### DIFF
--- a/build_info/libpcre2-dev.control
+++ b/build_info/libpcre2-dev.control
@@ -2,6 +2,7 @@ Package: libpcre2-dev
 Version: @DEB_PCRE2_V@
 Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
+Depends: libpcre2-8-0 (= @DEB_PCRE2_V@), libpcre2-16-0 (= @DEB_PCRE2_V@), libpcre2-32-0 (= @DEB_PCRE2_V@), libpcre2-posix3 (= @DEB_PCRE2_V@)
 Conflicts: pcre2 (<<1:0), libpcre2 (<< @DEB_PCRE2_V@)
 Section: Development
 Priority: standard

--- a/makefiles/pcre2.mk
+++ b/makefiles/pcre2.mk
@@ -3,8 +3,8 @@ $(error Use the main Makefile)
 endif
 
 STRAPPROJECTS += pcre2
-PCRE2_VERSION := 10.40
-DEB_PCRE2_V   ?= $(PCRE2_VERSION)-1
+PCRE2_VERSION := 10.42
+DEB_PCRE2_V   ?= $(PCRE2_VERSION)
 
 pcre2-setup: setup
 	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://github.com/PCRE2Project/pcre2/releases/download/pcre2-$(PCRE2_VERSION)/pcre2-$(PCRE2_VERSION).tar.bz2{$(comma).sig})
@@ -25,7 +25,7 @@ pcre2: pcre2-setup readline
 		--enable-pcre2grep-libbz2 \
 	+$(MAKE) -C $(BUILD_WORK)/pcre2
 	+$(MAKE) -C $(BUILD_WORK)/pcre2 install \
-		DESTDIR=$(BUILD_STAGE)/pcre2
+		DESTDIR="$(BUILD_STAGE)/pcre2"
 	$(call AFTER_BUILD,copy)
 endif
 


### PR DESCRIPTION
This PR updates `pcre2` to its latest release. `libpcre2-dev` needed to have its dependencies declared for dylibs, similar to Debian, so I decided to amend that as well.

### Checklist

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [ ] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)
* [x] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [x] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
