### PR TITLE
chore(mirrors): remove Nebula mirror

### DIFF
--- a/mirrors.txt
+++ b/mirrors.txt
@@ -1,2 +1,1 @@
 https://apt.procurs.us
-https://procursus.itsnebula.net


### PR DESCRIPTION
This mirror has been wrongfully terminated from Oracle Cloud with no way to appeal it.

### All Submissions

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [x] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)

### Package Additions/Updates

* [ ] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [ ] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
