### PR TITLE
Update img4lib

### DIFF
--- a/build_info/img4lib.control
+++ b/build_info/img4lib.control
@@ -2,7 +2,7 @@ Package: img4lib
 Version: @DEB_IMG4LIB_V@
 Architecture: @DEB_ARCH@
 Maintainer: @DEB_MAINTAINER@
-Depends: libssl3, liblzfse
+Depends: libssl3
 Section: Development
 Priority: optional
 Description: image4 vfs

--- a/build_patch/img4lib/makefile.patch
+++ b/build_patch/img4lib/makefile.patch
@@ -1,0 +1,44 @@
+diff --git a/Makefile b/Makefile
+index bab12a1..612dee4 100644
+--- a/Makefile
++++ b/Makefile
+@@ -5,32 +5,21 @@
+ # Darwin can use CommonCrypto instead of OpenSSL
+ #COMMONCRYPTO = 1
+ 
+-CC = gcc
+-CFLAGS = -Wall -W -pedantic
++CC ?= gcc
++CFLAGS ?= -Wall -W -pedantic
+ CFLAGS += -Wno-variadic-macros -Wno-multichar -Wno-four-char-constants -Wno-unused-parameter
+ CFLAGS += -O2 -I. -g -DiOS10
+ CFLAGS += -DDER_MULTIBYTE_TAGS=1 -DDER_TAG_SIZE=8
+ CFLAGS += -D__unused="__attribute__((unused))"
++CFLAGS += -DUSE_LIBCOMPRESSION
++LDLIBS = -lcompression
+ 
+-LD = gcc
+-LDFLAGS = -g
+-LDLIBS = -llzfse
++LD ?= gcc
++LDFLAGS ?= -g
+ 
+-AR = ar
++AR ?= ar
+ ARFLAGS = crus
+ 
+-ifneq (,$(wildcard lzfse/build/bin/liblzfse.a))
+-# liblzfse.a exists in-tree
+-CFLAGS += -Ilzfse/src
+-LDFLAGS += -Llzfse/build/bin
+-else
+-ifneq (,$(wildcard /usr/lib/libcompression.dylib))
+-# Darwin libcompression is available
+-CFLAGS += -DUSE_LIBCOMPRESSION
+-LDLIBS = -lcompression
+-endif
+-endif
+-
+ SOURCES = \
+ 	img4.c
+ 

--- a/makefiles/img4lib.mk
+++ b/makefiles/img4lib.mk
@@ -3,27 +3,21 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS     += img4lib
-IMG4LIB_COMMIT  := 1d8c1dd96a0e60e2070353771fff9adcfe3f3360
-IMG4LIB_VERSION := 1.0+git20210122.$(shell echo $(IMG4LIB_COMMIT) | cut -c -7)
-DEB_IMG4LIB_V   ?= $(IMG4LIB_VERSION)-1
+IMG4LIB_COMMIT  := 69772c72f3c08f021ec9fa4c386f2b3df60a38b7
+IMG4LIB_VERSION := 1.0+git20211128.$(shell echo $(IMG4LIB_COMMIT) | cut -c -7)
+DEB_IMG4LIB_V   ?= $(IMG4LIB_VERSION)
 
 img4lib-setup: setup
 	$(call GITHUB_ARCHIVE,xerub,img4lib,v$(IMG4LIB_COMMIT),$(IMG4LIB_COMMIT))
 	$(call EXTRACT_TAR,img4lib-v$(IMG4LIB_COMMIT).tar.gz,img4lib-$(IMG4LIB_COMMIT),img4lib)
-	sed -i 's/CFLAGS =/CFLAGS ?=/' $(BUILD_WORK)/img4lib/Makefile
-	sed -i 's/LDFLAGS =/LDFLAGS ?=/' $(BUILD_WORK)/img4lib/Makefile
-	sed -i '/CFLAGS += -DUSE_LIBCOMPRESSION/d' $(BUILD_WORK)/img4lib/Makefile
-	sed -i '/LDLIBS = -lcompression/d' $(BUILD_WORK)/img4lib/Makefile
-	sed -i 's/CC =/CC ?=/' $(BUILD_WORK)/img4lib/Makefile
-	sed -i 's/LD =/LD ?=/' $(BUILD_WORK)/img4lib/Makefile
-	sed -i 's/AR =/AR ?=/' $(BUILD_WORK)/img4lib/Makefile
+	$(call DO_PATCH,img4lib,img4lib,-p1)
 	mkdir -p $(BUILD_STAGE)/img4lib/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/{bin,include/{libvfs,libDER},lib}
 
 ifneq ($(wildcard $(BUILD_WORK)/img4lib/.build_complete),)
 img4lib:
 	@echo "Using previously built img4lib."
 else
-img4lib: img4lib-setup openssl lzfse
+img4lib: img4lib-setup openssl
 	+$(MAKE) -C $(BUILD_WORK)/img4lib \
 		LD=$(CC)
 	cp -a $(BUILD_WORK)/img4lib/img4 $(BUILD_STAGE)/img4lib/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin


### PR DESCRIPTION
This updates img4lib to the latest commit, and opts to use libcompression over lzfse, as it provides more functionality.

### All Submissions

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [ ] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)

### Package Additions/Updates

* [ ] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [x] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
