### PR TITLE
xtrans: Downgrade to 1.4.0

### DIFF
--- a/makefiles/xtrans.mk
+++ b/makefiles/xtrans.mk
@@ -3,13 +3,14 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS    += xtrans
-XTRANS_VERSION := 1.5.0
-DEB_XTRANS_V   ?= $(XTRANS_VERSION)
+XTRANS_VERSION := 1.4.0
+XTRANS_EPOCH   := 1.5.0
+DEB_XTRANS_V   ?= $(XTRANS_EPOCH)+really$(XTRANS_VERSION)
 
 xtrans-setup: setup
-	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://www.x.org/archive/individual/lib/xtrans-$(XTRANS_VERSION).tar.xz{$(comma).sig})
-	$(call PGP_VERIFY,xtrans-$(XTRANS_VERSION).tar.xz)
-	$(call EXTRACT_TAR,xtrans-$(XTRANS_VERSION).tar.xz,xtrans-$(XTRANS_VERSION),xtrans)
+	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://www.x.org/archive/individual/lib/xtrans-$(XTRANS_VERSION).tar.bz2{$(comma).sig})
+	$(call PGP_VERIFY,xtrans-$(XTRANS_VERSION).tar.bz2)
+	$(call EXTRACT_TAR,xtrans-$(XTRANS_VERSION).tar.bz2,xtrans-$(XTRANS_VERSION),xtrans)
 	sed -i 's|# include <stropts.h>|# include <sys/ioctl.h>|' $(BUILD_WORK)/xtrans/Xtranslcl.c
 
 ifneq ($(wildcard $(BUILD_WORK)/xtrans/.build_complete),)


### PR DESCRIPTION
### Description

Downgrade `xtrans` back to 1.4.0, as 1.5.0 breaks `libx11` with many macro errors in headers

### All Submissions

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?

### Package Additions/Updates

* [x] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [x] Have you confirmed this builds & works as intended on a macOS device (if applicable)?
