### PR TITLE
Fix libcursor makefile

### DIFF
--- a/makefiles/libxcursor.mk
+++ b/makefiles/libxcursor.mk
@@ -9,7 +9,7 @@ DEB_LIBXCURSOR_V   ?= $(LIBXCURSOR_VERSION)
 libxcursor-setup: setup
 	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://xorg.freedesktop.org/archive/individual/lib/libXcursor-$(LIBXCURSOR_VERSION).tar.bz2{$(comma).sig})
 	$(call PGP_VERIFY,libXcursor-$(LIBXCURSOR_VERSION).tar.bz2)
-	$(call EXTRACT_TAR,libXcursor-$(LIBXCURSOR_VERSION).tar.bz2,libXcursor-$(LIBXCURSOR_VERSION),libXcursor)
+	$(call EXTRACT_TAR,libXcursor-$(LIBXCURSOR_VERSION).tar.bz2,libXcursor-$(LIBXCURSOR_VERSION),libxcursor)
 
 ifneq ($(wildcard $(BUILD_WORK)/libxcursor/.build_complete),)
 libxcursor:


### PR DESCRIPTION
### All Submissions

* [x] Have you made sure there aren't any other open [Pull Requests](https://github.com/ProcursusTeam/Procursus/pulls) for the same update/change?
* [x] This Pull Request doesn't contain any package additions; it's a small change (e.g README change)

### Package Additions/Updates

* [ ] Have you confirmed this builds & works as intended on an iOS device (if applicable)?
* [ ] Have you confirmed this builds & works as intended on a tvOS device (if applicable)?
* [ ] Have you confirmed this builds & works as intended on a macOS device (if applicable)?

### Extra Info
I just fixed a typo that blocked the build of the package, I checked that the package built for iphoneos-arm64-rootless 1800